### PR TITLE
baseline: refresh a snapshot from the index, without mydumper or the source

### DIFF
--- a/cliapp/baseline_refresh.go
+++ b/cliapp/baseline_refresh.go
@@ -1,0 +1,304 @@
+package cliapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/cli"
+	"github.com/dbtrail/dbtrail/internal/cliutil"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+)
+
+var baselineRefreshCmd = &cobra.Command{
+	Use:   "refresh",
+	Short: "Produce a new baseline snapshot from the previous one plus indexed deltas",
+	Long: `Fold the changes the index already holds onto the newest baseline snapshot and
+publish the result as a NEW snapshot — no mydumper run, no connection to the
+source database.
+
+The information needed to move a baseline forward is already in bintrail's own
+storage: the previous snapshot has the rows, and the index has every change
+since. Refreshing keeps time-travel fast (a short delta window instead of
+months of replay) and keeps the archive hours a reconstruction depends on from
+growing without bound.
+
+Tables default to every table in the newest discoverable snapshot; --tables
+narrows that, which is the tool for isolating a table that refuses.
+
+WHAT IT REFUSES, AND WHY IT REFUSES RATHER THAN WARNS
+
+A baseline is picked up automatically by every later reconstruct, so a wrong
+one is not a bad output — it is a wrong answer to every future question.
+
+  capture gap   The window spans events the index permanently lost (or an
+                index too old to rule that out). --allow-gaps proceeds, and
+                the emitted snapshot then carries a permanent marker in its
+                metadata saying so — inherited by every snapshot derived from
+                it, because the missing events stay missing.
+  schema change The table's columns moved since the baseline. The snapshot
+                would carry the old CREATE TABLE forward and project rows onto
+                the old shape. Only a real re-dump fixes this.
+  destructive   A TRUNCATE / DROP / RENAME in the window emits no row events,
+      DDL       so the fold would resurrect rows that no longer exist.
+
+Publication is all-or-nothing: if any table refuses, NOTHING is published and
+the exit status is non-zero. A half-refreshed snapshot would be a set of tables
+from two different points in time under one anchor.
+
+Every full-table reconstruct limit applies (primary key required, a PK-changing
+UPDATE in the window refuses, PostgreSQL sources are out of scope).
+
+Examples:
+  # Refresh every table of the newest snapshot, in place
+  bintrail baseline refresh --index-dsn "..." --baseline-dir /data/baselines
+
+  # One table, to a point in the past
+  bintrail baseline refresh --index-dsn "..." --baseline-dir /data/baselines \
+    --tables mydb.orders --at "2026-05-01 12:00:00"
+
+  # Source snapshots on S3: read from there, write locally, then upload
+  bintrail baseline refresh --index-dsn "..." \
+    --baseline-s3 s3://bucket/baselines/ --output /data/baselines
+  bintrail upload --source /data/baselines --destination s3://bucket/baselines/`,
+	RunE: runBaselineRefresh,
+}
+
+var (
+	brIndexDSN    string
+	brBaselineDir string
+	brBaselineS3  string
+	brOutput      string
+	brTables      string
+	brAt          string
+	brAllowGaps   bool
+	brParallelism int
+	brFetchBatch  int
+	brWarnEvents  int64
+)
+
+func init() {
+	f := baselineRefreshCmd.Flags()
+	f.StringVar(&brIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
+	f.StringVar(&brBaselineDir, "baseline-dir", "", "Local directory of baseline snapshots to refresh from (and, unless --output is set, to write into)")
+	f.StringVar(&brBaselineS3, "baseline-s3", "", "S3 URL prefix of baseline snapshots to refresh from (requires --output for the local destination)")
+	f.StringVar(&brOutput, "output", "", "Directory to write the new snapshot into (default: --baseline-dir)")
+	f.StringVar(&brTables, "tables", "", "Comma-separated schema.table list (default: every table in the newest snapshot)")
+	f.StringVar(&brAt, "at", "", "Point-in-time to refresh to (default: now)")
+	f.BoolVar(&brAllowGaps, "allow-gaps", false, "Publish even when the window spans a known permanent capture gap; the snapshot is permanently marked as knowingly incomplete")
+	f.IntVar(&brParallelism, "parallelism", 0, "Max tables refreshed concurrently (0 = one per CPU)")
+	f.IntVar(&brFetchBatch, "fetch-batch-size", 0, "Event page size for the delta fold (0 = default)")
+	f.Int64Var(&brWarnEvents, "warn-event-threshold", 5_000_000, "Warn when a table's delta window exceeds this many events (0 disables)")
+	cli.AddDuckDBTuningFlags(baselineRefreshCmd)
+	bindCommandEnv(baselineRefreshCmd)
+
+	baselineCmd.AddCommand(baselineRefreshCmd)
+}
+
+// refreshOutcome is one table's verdict in the run summary.
+type refreshOutcome struct {
+	Table   string
+	Verdict string // "refreshed", "refused-gap", "refused-ddl", "refused"
+	Detail  string
+}
+
+func runBaselineRefresh(cmd *cobra.Command, _ []string) error {
+	if brIndexDSN == "" {
+		return fmt.Errorf("--index-dsn is required")
+	}
+	if brBaselineDir == "" && brBaselineS3 == "" {
+		return fmt.Errorf("one of --baseline-dir or --baseline-s3 is required")
+	}
+	if brBaselineDir != "" && brBaselineS3 != "" {
+		return fmt.Errorf("--baseline-dir and --baseline-s3 are mutually exclusive")
+	}
+	source := brBaselineDir
+	if source == "" {
+		source = brBaselineS3
+	}
+	output := brOutput
+	if output == "" {
+		output = brBaselineDir
+	}
+	if output == "" {
+		// Reading from S3 with nowhere local to write. Refuse rather than pick a
+		// directory for the operator: a snapshot written somewhere they did not
+		// name is a snapshot they will not find, and this command's whole value
+		// is that the result is discoverable.
+		return fmt.Errorf("--output is required with --baseline-s3: the new snapshot is written locally "+
+			"(publish it with `bintrail upload --source <output> --destination %s`)", brBaselineS3)
+	}
+	if brWarnEvents < 0 {
+		return fmt.Errorf("--warn-event-threshold must be >= 0 (0 disables)")
+	}
+
+	at := time.Now().UTC()
+	if brAt != "" {
+		parsed, err := cliutil.ParseTime(brAt)
+		if err != nil {
+			return fmt.Errorf("--at: %w", err)
+		}
+		if parsed != nil {
+			at = *parsed
+		}
+	}
+
+	tables, err := resolveRefreshTables(cmd.Context(), source)
+	if err != nil {
+		return err
+	}
+	if len(tables) == 0 {
+		return fmt.Errorf("no tables to refresh: no baseline snapshot was discovered under %s "+
+			"(take one with `bintrail dump` + `bintrail baseline` first)", source)
+	}
+
+	tuning, err := cli.DuckDBTuningFromFlags(cmd)
+	if err != nil {
+		return err
+	}
+
+	reports, failures, runErr := reconstruct.ReconstructTablesDetailed(cmd.Context(), reconstruct.FullTableConfig{
+		IndexDSN:           brIndexDSN,
+		BaselineSrc:        source,
+		Tables:             tables,
+		At:                 at,
+		OutputDir:          output,
+		OutputFormat:       reconstruct.OutputFormatParquet,
+		AllowGaps:          brAllowGaps,
+		Parallelism:        brParallelism,
+		FetchBatchSize:     brFetchBatch,
+		WarnEventThreshold: brWarnEvents,
+		ArchiveFetcher:     cli.TunedArchiveFetcher(tuning),
+		DuckDBTuning:       tuning,
+	})
+
+	outcomes := buildRefreshOutcomes(tables, reports, failures)
+	writeRefreshSummary(cmd.OutOrStdout(), outcomes, output, at, runErr == nil)
+
+	if runErr != nil {
+		// The per-table detail is already in the summary above; keep the returned
+		// error to the consequence, which is the part an operator acts on.
+		return fmt.Errorf("baseline refresh published nothing: %d of %d table(s) refused",
+			len(failures), len(tables))
+	}
+	return nil
+}
+
+// resolveRefreshTables returns the schema.table list to refresh: --tables when
+// given, otherwise every table in the NEWEST discoverable snapshot.
+//
+// Defaulting to the newest snapshot's tables (rather than, say, every table the
+// index has ever seen) keeps the refreshed snapshot a strict successor of the
+// one it was folded from. A table absent from the source snapshot has nothing to
+// fold onto, and inventing an entry for it would publish a snapshot claiming
+// coverage it does not have.
+func resolveRefreshTables(ctx context.Context, source string) ([]string, error) {
+	if brTables != "" {
+		var out []string
+		for _, entry := range strings.Split(brTables, ",") {
+			entry = strings.TrimSpace(entry)
+			if entry == "" {
+				continue
+			}
+			if !strings.Contains(entry, ".") {
+				return nil, fmt.Errorf("--tables entry %q must be schema.table", entry)
+			}
+			out = append(out, entry)
+		}
+		if len(out) == 0 {
+			return nil, fmt.Errorf("--tables: no entries after trimming")
+		}
+		return out, nil
+	}
+
+	files, err := reconstruct.ListBaselines(ctx, source)
+	if err != nil {
+		return nil, fmt.Errorf("list baseline snapshots under %s: %w", source, err)
+	}
+	if len(files) == 0 {
+		return nil, nil
+	}
+	newest := files[0].SnapshotTime // ListBaselines returns newest first
+	seen := map[string]bool{}
+	var out []string
+	for _, f := range files {
+		if !f.SnapshotTime.Equal(newest) {
+			continue
+		}
+		entry := f.Schema + "." + f.Table
+		if seen[entry] {
+			continue
+		}
+		seen[entry] = true
+		out = append(out, entry)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// buildRefreshOutcomes pairs every requested table with its verdict.
+//
+// The classification reads the sentinels reconstruct exports rather than the
+// message text: "the events are gone" and "the table changed shape" have
+// completely different remedies, and a summary that blurs them sends the
+// operator down the wrong one.
+func buildRefreshOutcomes(tables []string, reports []*reconstruct.TableReport, failures []reconstruct.TableFailure) []refreshOutcome {
+	failed := make(map[string]error, len(failures))
+	for _, f := range failures {
+		failed[f.Schema+"."+f.Table] = f.Err
+	}
+	done := make(map[string]bool, len(reports))
+	for _, r := range reports {
+		done[r.Schema+"."+r.Table] = true
+	}
+
+	out := make([]refreshOutcome, 0, len(tables))
+	for _, t := range tables {
+		switch err, bad := failed[t]; {
+		case bad && errors.Is(err, reconstruct.ErrCaptureGap):
+			out = append(out, refreshOutcome{t, "refused-gap", err.Error()})
+		case bad && (errors.Is(err, reconstruct.ErrSchemaChanged) || errors.Is(err, reconstruct.ErrDestructiveDDL)):
+			out = append(out, refreshOutcome{t, "refused-ddl", err.Error()})
+		case bad:
+			out = append(out, refreshOutcome{t, "refused", err.Error()})
+		case done[t]:
+			out = append(out, refreshOutcome{t, "refreshed", ""})
+		default:
+			// Requested, neither reported nor failed: the run was cancelled
+			// before this table started. Not "fine" — say so.
+			out = append(out, refreshOutcome{t, "skipped", "the run ended before this table was reached"})
+		}
+	}
+	return out
+}
+
+func writeRefreshSummary(w io.Writer, outcomes []refreshOutcome, output string, at time.Time, published bool) {
+	fmt.Fprintf(w, "baseline refresh to %s\n\n", at.UTC().Format(time.RFC3339))
+	width := 0
+	for _, o := range outcomes {
+		if len(o.Table) > width {
+			width = len(o.Table)
+		}
+	}
+	for _, o := range outcomes {
+		fmt.Fprintf(w, "  %-*s  %s\n", width, o.Table, o.Verdict)
+		if o.Detail != "" {
+			fmt.Fprintf(w, "  %-*s  └─ %s\n", width, "", o.Detail)
+		}
+	}
+	fmt.Fprintln(w)
+	if published {
+		fmt.Fprintf(w, "published %s/%s\n", strings.TrimRight(output, string(os.PathSeparator)),
+			strings.ReplaceAll(at.UTC().Format(time.RFC3339), ":", "-"))
+		return
+	}
+	fmt.Fprintln(w, "NOTHING was published: a snapshot mixing refreshed and stale tables under one anchor")
+	fmt.Fprintln(w, "would be worse than no refresh. Fix or exclude the tables above (--tables) and retry.")
+}

--- a/cliapp/baseline_refresh_test.go
+++ b/cliapp/baseline_refresh_test.go
@@ -1,0 +1,224 @@
+package cliapp
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+)
+
+// TestBuildRefreshOutcomes pins the classification.
+//
+// It reads reconstruct's exported sentinels rather than message text, and this
+// test is what keeps that true: "the events are permanently gone" and "the table
+// changed shape" have opposite remedies (accept the loss with --allow-gaps vs.
+// take a real dump), so a summary that blurs them sends the operator down the
+// wrong one.
+func TestBuildRefreshOutcomes(t *testing.T) {
+	tables := []string{"shop.orders", "shop.items", "shop.users", "shop.audit", "shop.late"}
+	reports := []*reconstruct.TableReport{{Schema: "shop", Table: "orders"}}
+	failures := []reconstruct.TableFailure{
+		{Schema: "shop", Table: "items", Err: fmt.Errorf("window: %w", reconstruct.ErrCaptureGap)},
+		{Schema: "shop", Table: "users", Err: fmt.Errorf("shape: %w", reconstruct.ErrSchemaChanged)},
+		{Schema: "shop", Table: "audit", Err: fmt.Errorf("boom: %w", errors.New("disk full"))},
+	}
+
+	got := buildRefreshOutcomes(tables, reports, failures)
+	want := map[string]string{
+		"shop.orders": "refreshed",
+		"shop.items":  "refused-gap",
+		"shop.users":  "refused-ddl",
+		"shop.audit":  "refused",
+		// Requested but neither reported nor failed: the run ended first. This
+		// must not read as success.
+		"shop.late": "skipped",
+	}
+	if len(got) != len(tables) {
+		t.Fatalf("got %d outcomes for %d tables", len(got), len(tables))
+	}
+	for _, o := range got {
+		if want[o.Table] != o.Verdict {
+			t.Errorf("%s = %q, want %q", o.Table, o.Verdict, want[o.Table])
+		}
+	}
+}
+
+// TestBuildRefreshOutcomes_destructiveDDLIsDDL: a TRUNCATE/DROP/RENAME in the
+// window is the same remedy as a schema change (re-dump), so it must not fall
+// into the generic bucket.
+func TestBuildRefreshOutcomes_destructiveDDLIsDDL(t *testing.T) {
+	got := buildRefreshOutcomes(
+		[]string{"shop.orders"}, nil,
+		[]reconstruct.TableFailure{{Schema: "shop", Table: "orders",
+			Err: fmt.Errorf("truncate: %w", reconstruct.ErrDestructiveDDL)}},
+	)
+	if got[0].Verdict != "refused-ddl" {
+		t.Fatalf("verdict = %q, want refused-ddl", got[0].Verdict)
+	}
+}
+
+// TestWriteRefreshSummary_refusalSaysNothingWasPublished: the all-or-nothing
+// rule is only useful if the operator is told it applied. A summary listing one
+// refusal among four successes reads as "three tables were refreshed" unless it
+// says otherwise.
+func TestWriteRefreshSummary_refusalSaysNothingWasPublished(t *testing.T) {
+	var buf bytes.Buffer
+	writeRefreshSummary(&buf, []refreshOutcome{
+		{"shop.orders", "refreshed", ""},
+		{"shop.items", "refused-gap", "events permanently lost"},
+	}, "/data/baselines", time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC), false)
+
+	out := buf.String()
+	if !strings.Contains(out, "NOTHING was published") {
+		t.Errorf("summary does not say the run published nothing:\n%s", out)
+	}
+	if !strings.Contains(out, "events permanently lost") {
+		t.Errorf("summary drops the refusal detail:\n%s", out)
+	}
+	if strings.Contains(out, "published /data/baselines") {
+		t.Errorf("summary claims a publication that did not happen:\n%s", out)
+	}
+}
+
+// TestWriteRefreshSummary_successNamesTheSnapshot: on success the operator needs
+// the path the snapshot actually landed at, in the directory form discovery uses.
+func TestWriteRefreshSummary_successNamesTheSnapshot(t *testing.T) {
+	var buf bytes.Buffer
+	writeRefreshSummary(&buf, []refreshOutcome{{"shop.orders", "refreshed", ""}},
+		"/data/baselines", time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC), true)
+	if !strings.Contains(buf.String(), "/data/baselines/2026-05-01T12-00-00Z") {
+		t.Errorf("summary does not name the published snapshot:\n%s", buf.String())
+	}
+}
+
+// TestRunBaselineRefresh_flagValidation covers the refusals that happen before
+// any connection, including the one that would otherwise write a snapshot the
+// operator can never find.
+func TestRunBaselineRefresh_flagValidation(t *testing.T) {
+	reset := func() {
+		brIndexDSN, brBaselineDir, brBaselineS3, brOutput, brTables, brAt = "", "", "", "", "", ""
+		brAllowGaps = false
+		brWarnEvents = 5_000_000
+	}
+	for _, tc := range []struct {
+		name    string
+		set     func()
+		wantErr string
+	}{
+		{"no index dsn", func() {}, "--index-dsn is required"},
+		{"no baseline source", func() { brIndexDSN = "d" }, "one of --baseline-dir or --baseline-s3"},
+		{"both sources", func() { brIndexDSN = "d"; brBaselineDir = "/b"; brBaselineS3 = "s3://b/" }, "mutually exclusive"},
+		{
+			// Reading from S3 with no local destination: writing somewhere we
+			// picked would produce a snapshot nobody finds.
+			name:    "s3 source without output",
+			set:     func() { brIndexDSN = "d"; brBaselineS3 = "s3://b/" },
+			wantErr: "--output is required with --baseline-s3",
+		},
+		{"negative warn threshold", func() { brIndexDSN = "d"; brBaselineDir = "/b"; brWarnEvents = -1 }, "must be >= 0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reset()
+			tc.set()
+			err := runBaselineRefresh(baselineRefreshCmd, nil)
+			if err == nil {
+				t.Fatalf("expected an error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err, tc.wantErr)
+			}
+		})
+	}
+	reset()
+}
+
+// TestResolveRefreshTables_explicitList covers --tables parsing; the discovery
+// path needs a snapshot on disk and is covered by the integration test.
+func TestResolveRefreshTables_explicitList(t *testing.T) {
+	defer func() { brTables = "" }()
+
+	brTables = " shop.orders , shop.items ,, "
+	got, err := resolveRefreshTables(t.Context(), "/unused")
+	if err != nil {
+		t.Fatalf("resolveRefreshTables: %v", err)
+	}
+	if len(got) != 2 || got[0] != "shop.orders" || got[1] != "shop.items" {
+		t.Fatalf("got %v, want [shop.orders shop.items]", got)
+	}
+
+	brTables = "orders"
+	if _, err := resolveRefreshTables(t.Context(), "/unused"); err == nil ||
+		!strings.Contains(err.Error(), "must be schema.table") {
+		t.Fatalf("error = %v, want a schema.table refusal", err)
+	}
+}
+
+// TestBaselineRefreshCmd_registered: a subcommand defined but never attached is
+// invisible, and nothing else in the build notices.
+func TestBaselineRefreshCmd_registered(t *testing.T) {
+	for _, c := range baselineCmd.Commands() {
+		if c.Name() == "refresh" {
+			return
+		}
+	}
+	t.Fatal("`baseline refresh` is not registered under `baseline`")
+}
+
+// TestResolveRefreshTables_discoversNewestSnapshot: with no --tables, the run
+// refreshes exactly the tables the source snapshot has.
+//
+// Defaulting to the newest snapshot (rather than every table the index has ever
+// seen) keeps the result a strict successor of what it was folded from: a table
+// absent from the source has nothing to fold onto, and inventing an entry would
+// publish a snapshot claiming coverage it does not have.
+func TestResolveRefreshTables_discoversNewestSnapshot(t *testing.T) {
+	defer func() { brTables = "" }()
+	brTables = ""
+
+	root := t.TempDir()
+	// An older snapshot with a table the newest one no longer has.
+	writeSnapshotFixture(t, root, "2026-04-01T00-00-00Z", map[string][]string{"shop": {"orders", "retired"}})
+	writeSnapshotFixture(t, root, "2026-05-01T00-00-00Z", map[string][]string{"shop": {"orders", "items"}})
+
+	got, err := resolveRefreshTables(t.Context(), root)
+	if err != nil {
+		t.Fatalf("resolveRefreshTables: %v", err)
+	}
+	want := []string{"shop.items", "shop.orders"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+// writeSnapshotFixture lays out a complete snapshot directory. The Parquet files
+// are placeholders: ListBaselines discovers by layout and marker, and this test
+// is about which tables get selected, not about their contents.
+func writeSnapshotFixture(t *testing.T, root, ts string, tables map[string][]string) {
+	t.Helper()
+	dir := filepath.Join(root, ts)
+	for schema, names := range tables {
+		if err := os.MkdirAll(filepath.Join(dir, schema), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		for _, name := range names {
+			if err := os.WriteFile(filepath.Join(dir, schema, name+".parquet"), []byte("placeholder"), 0o644); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+		}
+	}
+	if err := baseline.WriteSuccessMarker(dir); err != nil {
+		t.Fatalf("WriteSuccessMarker: %v", err)
+	}
+}

--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -319,22 +319,54 @@ The S3 copy is **not** pruned — only the redundant local copy. To prune on a l
 
 ## Step 3 (optional): a newer baseline without a new dump
 
-`bintrail reconstruct --output-format parquet` writes its result **as a baseline snapshot** instead of a SQL dump. Since the index already holds every change since the last snapshot, a fresher snapshot can be folded out of storage you already have — no mydumper run, no connection to the source:
+`bintrail baseline refresh` folds the changes the index already holds onto the newest snapshot and publishes the result as a new one — no mydumper run, no connection to the source:
 
 ```sh
-bintrail reconstruct \
-  --index-dsn     "user:pass@tcp(index-db:3306)/bintrail_index" \
-  --baseline-dir  /data/baselines \
-  --tables        mydb.orders,mydb.users \
-  --output-format parquet \
-  --output-dir    /data/baselines
+bintrail baseline refresh \
+  --index-dsn    "user:pass@tcp(index-db:3306)/bintrail_index" \
+  --baseline-dir /data/baselines
 ```
 
-`--output-dir` is the **baselines root** here, not the destination file: the snapshot lands in `/data/baselines/<timestamp>/<db>/<table>.parquet` with the same `_SUCCESS` / `_MANIFEST` files a converted dump gets, and the next `reconstruct`, `verify` or shim query discovers it as the newest baseline with no configuration change.
+Tables default to every table in the newest snapshot; `--tables` narrows that, and `--at` targets a point in the past. The snapshot lands in `/data/baselines/<timestamp>/<db>/<table>.parquet` with the same `_SUCCESS` / `_MANIFEST` files a converted dump gets, and the next `reconstruct`, `verify` or shim query discovers it as the newest baseline with no configuration change.
+
+When the source snapshots live on S3, read from there and write locally, then publish:
+
+```sh
+bintrail baseline refresh --index-dsn "..." \
+  --baseline-s3 s3://bucket/baselines/ --output /data/baselines
+bintrail upload --source /data/baselines --destination s3://bucket/baselines/
+```
+
+The same thing is available a level down as `bintrail reconstruct --output-format parquet --output-dir <baselines root>`, which is what `refresh` runs — use it when you want to name every table and instant yourself.
+
+**Publication is all-or-nothing.** If any table refuses, nothing is published and the exit status is non-zero, with a per-table verdict:
+
+```
+baseline refresh to 2026-05-01T12:00:00Z
+
+  mydb.orders  refreshed
+  mydb.users   refused-gap
+               └─ reconstruct: stamped capture gap at 2026-04-20T06:00:00Z falls inside …
+
+NOTHING was published: a snapshot mixing refreshed and stale tables under one anchor
+would be worse than no refresh. Fix or exclude the tables above (--tables) and retry.
+```
+
+A snapshot holding some tables from one point in time and others from another, under a single anchor, is worse than no refresh at all — so a partial run publishes nothing, and `--tables` is the tool for isolating a problem table.
 
 Why this matters beyond convenience: reconstructing from a **fresh** snapshot reads a short delta window instead of replaying months of events, so time-travel gets faster and the archive hours the replay depends on stop growing without bound.
 
-**What it inherits.** The emitted snapshot is subject to every full-table reconstruct limit — the table needs a primary key, a PK-changing `UPDATE` in the window refuses the run, and a `TRUNCATE`/`DROP`/`RENAME` between the source snapshot and `--at` refuses it too. A table with no baseline at all is refused rather than degraded: a snapshot folded from deltas alone would silently omit every row the window never touched. Refuse cases point at `bintrail dump` — a real re-dump is the only correct answer for all of them.
+**What it refuses, and why refusing beats warning.** A baseline is picked up automatically by every later reconstruct, so a wrong one is not a bad output — it is a wrong answer to every future question.
+
+| Refusal | What happened | What fixes it |
+|---|---|---|
+| `refused-gap` | The window spans events the index permanently lost, or the index is too old to rule that out | `--allow-gaps` to accept the loss knowingly, or a fresh dump |
+| `refused-ddl` | The table's columns moved since the baseline, or a `TRUNCATE`/`DROP`/`RENAME` landed in the window | `bintrail dump` + `bintrail baseline` — no flag helps |
+| `refused` | Anything else (no baseline for the table, no primary key, a PK-changing `UPDATE` in the window) | Named in the message |
+
+A table with no baseline is refused rather than degraded to the binlog-only fallback: a snapshot folded from deltas alone would silently omit every row the window never touched.
+
+**A knowingly-gapped snapshot stays marked forever.** `--allow-gaps` exists because sometimes the incomplete result is genuinely what you want — but the snapshot then carries a `bintrail.capture_gap` line in its Parquet metadata naming what was lost, and **every snapshot later refreshed from it inherits that line**. The missing events stay missing down the chain, so the record does too; one refresh can never launder a knowingly-incomplete baseline into a clean-looking one.
 
 **What it deliberately omits.** A dumped snapshot carries a content digest fingerprinting the rows against the live source, which `bintrail verify` compares. A reconstructed snapshot never read the source, so it carries **no** digest — that table is not verifiable against a source through this snapshot until the next real dump. It also carries no GTID set (the index stores GTIDs per event, not as an accumulated executed-set). Both absences are visible in the file's metadata, alongside a `bintrail.snapshot_producer = reconstruct` marker so a reconstructed snapshot stays distinguishable from a dumped one forever.
 

--- a/internal/baseline/metadata.go
+++ b/internal/baseline/metadata.go
@@ -71,6 +71,22 @@ const (
 	// baseline whose GUC-sensitive text may not join post-pin deltas — readers
 	// warn and recommend re-baselining. Absent on MySQL/MariaDB baselines.
 	MetaKeyRenderGUCs = "bintrail.render_gucs"
+	// MetaKeyCaptureGap marks a snapshot that was published over a KNOWN
+	// permanent capture gap — a `baseline refresh` / `reconstruct
+	// --output-format parquet` run whose window contained a stamped
+	// stream_state.gap_lost_at (or an index that could not answer the question)
+	// and which proceeded anyway under --allow-gaps (#1170).
+	//
+	// Its value is one human-readable line per gap the snapshot was folded
+	// across, oldest first. It is INHERITED: a snapshot derived from a gapped
+	// one carries its ancestor's lines plus any of its own, because the missing
+	// events are missing from every descendant too. That inheritance is the
+	// whole point — an operator must never have to reconstruct the provenance
+	// chain by hand to learn that a baseline is knowingly incomplete.
+	//
+	// Absent on every snapshot taken from a real dump, and on any reconstructed
+	// snapshot whose window was verifiably gap-free.
+	MetaKeyCaptureGap = "bintrail.capture_gap"
 )
 
 // RenderGUCsPinned is the canonical value the capture side stamps under
@@ -94,6 +110,11 @@ type DumpMetadata struct {
 	RowCount       int64  // rows ingested into this table's baseline; valid only when ContentDigest != ""
 	LSN            uint64 // PostgreSQL WAL LSN delta-replay floor, inclusive (MetaKeyLSN, see its doc comment / #771); 0 = absent (MySQL baseline, or pre-#593 PG baseline)
 	RenderGUCs     string // pinned rendering-GUC stamp (MetaKeyRenderGUCs, #593 slice D); "" = pre-pin PG baseline or MySQL baseline
+	// CaptureGap is MetaKeyCaptureGap: non-empty means this snapshot is KNOWINGLY
+	// incomplete — it was folded across a permanent capture gap under
+	// --allow-gaps, or inherited that state from the snapshot it was derived
+	// from. Empty is the normal case; see MetaKeyCaptureGap.
+	CaptureGap string
 }
 
 // StartedAtMarkerFile is a bintrail-authored sidecar written into the mydumper
@@ -268,6 +289,9 @@ func ReadParquetMetadata(path string) (DumpMetadata, error) {
 	if v, ok := pf.Lookup(MetaKeyRenderGUCs); ok {
 		m.RenderGUCs = v
 	}
+	if v, ok := pf.Lookup(MetaKeyCaptureGap); ok {
+		m.CaptureGap = v
+	}
 	if v, ok := pf.Lookup(MetaKeyRowCount); ok {
 		n, parseErr := strconv.ParseInt(v, 10, 64)
 		if parseErr != nil {
@@ -351,6 +375,8 @@ func ReadParquetMetadataAny(ctx context.Context, path string) (DumpMetadata, err
 			m.ContentDigest = val
 		case MetaKeyRenderGUCs:
 			m.RenderGUCs = val
+		case MetaKeyCaptureGap:
+			m.CaptureGap = val
 		case MetaKeyRowCount:
 			if n, parseErr := strconv.ParseInt(val, 10, 64); parseErr == nil {
 				m.RowCount = n

--- a/internal/reconstruct/capture_gap_marker_1170_integration_test.go
+++ b/internal/reconstruct/capture_gap_marker_1170_integration_test.go
@@ -1,0 +1,130 @@
+//go:build integration
+
+package reconstruct_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestRefresh_gapMarkerIsStampedAndInherited is the durable half of #1170's
+// fail-closed rule.
+//
+// Refusing a gapped refresh is only half the contract: --allow-gaps exists
+// because an operator sometimes genuinely wants the incomplete result. What must
+// never happen is that the resulting baseline becomes indistinguishable from a
+// clean one — least of all after being refreshed again, which is exactly when
+// the human memory of the override is gone.
+//
+// So this asserts both halves against a real gapped stream_state: the first
+// refresh refuses without --allow-gaps and stamps a marker with it, and the
+// SECOND refresh — a clean window, no gap of its own — still carries the
+// ancestor's marker forward.
+func TestRefresh_gapMarkerIsStampedAndInherited(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	db, dbName := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 48, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	dsn := testutil.BaseDSN() + "/" + dbName
+	const schema = "shop"
+
+	base := time.Now().UTC().Truncate(time.Hour)
+	cut1 := base.Add(30 * time.Second)
+	cut2 := base.Add(60 * time.Second)
+
+	seedOrdersSnapshot(t, db, schema, base)
+	testutil.InsertEvent(t, db, "binlog.000001", 100, 200,
+		base.Add(10*time.Second).Format("2006-01-02 15:04:05"), nil,
+		schema, "orders", 2, "1", nil, nil, []byte(`{"id":1,"status":"A"}`))
+	testutil.InsertEvent(t, db, "binlog.000001", 200, 300,
+		base.Add(40*time.Second).Format("2006-01-02 15:04:05"), nil,
+		schema, "orders", 2, "2", nil, nil, []byte(`{"id":2,"status":"B"}`))
+
+	// A permanent capture loss stamped INSIDE the first refresh's window.
+	testutil.MustExec(t, db, `INSERT INTO stream_state
+		(id, mode, binlog_file, binlog_position, gtid_set, events_indexed, last_checkpoint, server_id, gap_lost_at, gap_lost_detail)
+		VALUES (1, 'position', 'binlog.000001', 300, '', 2, NOW(), 1, ?, ?)`,
+		base.Add(5*time.Second).Format("2006-01-02 15:04:05"),
+		"source binlogs purged before the stream caught up")
+
+	root := t.TempDir()
+	seedSourceBaseline(t, root, base, schema)
+
+	cfg := func(at time.Time, allowGaps bool) reconstruct.FullTableConfig {
+		return reconstruct.FullTableConfig{
+			IndexDSN:     dsn,
+			BaselineSrc:  root,
+			Tables:       []string{schema + ".orders"},
+			At:           at,
+			OutputDir:    root,
+			OutputFormat: reconstruct.OutputFormatParquet,
+			AllowGaps:    allowGaps,
+		}
+	}
+
+	// Strict: refuse, and refuse in a way the summary can classify.
+	_, failures, err := reconstruct.ReconstructTablesDetailed(ctx, cfg(cut1, false))
+	if err == nil {
+		t.Fatal("a refresh over a stamped capture gap was published under the default (strict) policy")
+	}
+	if len(failures) != 1 || !errorsIsCaptureGap(failures[0].Err) {
+		t.Fatalf("failure is not classified as a capture gap: %+v", failures)
+	}
+
+	// Overridden: publish, and mark it forever.
+	if _, err := reconstruct.ReconstructTables(ctx, cfg(cut1, true)); err != nil {
+		t.Fatalf("refresh with AllowGaps: %v", err)
+	}
+	mid, _, _, err := reconstruct.FindBaseline(ctx, root, schema, "orders", cut2)
+	if err != nil {
+		t.Fatalf("FindBaseline: %v", err)
+	}
+	midMeta, err := baseline.ReadParquetMetadata(mid)
+	if err != nil {
+		t.Fatalf("ReadParquetMetadata: %v", err)
+	}
+	if midMeta.CaptureGap == "" {
+		t.Fatal("the published snapshot carries no capture-gap marker: nothing distinguishes a knowingly " +
+			"incomplete baseline from a clean one once the terminal is closed")
+	}
+	if !strings.Contains(midMeta.CaptureGap, "purged") {
+		t.Errorf("marker does not carry the recorded detail: %q", midMeta.CaptureGap)
+	}
+
+	// Second refresh: its OWN window is clean (the gap is before it), so the
+	// only thing that can keep the fact alive is inheritance.
+	if _, err := reconstruct.ReconstructTables(ctx, cfg(cut2, false)); err != nil {
+		t.Fatalf("second refresh over a clean window: %v", err)
+	}
+	final, _, _, err := reconstruct.FindBaseline(ctx, root, schema, "orders", cut2.Add(time.Second))
+	if err != nil {
+		t.Fatalf("FindBaseline after the second refresh: %v", err)
+	}
+	finalMeta, err := baseline.ReadParquetMetadata(final)
+	if err != nil {
+		t.Fatalf("ReadParquetMetadata: %v", err)
+	}
+	if finalMeta.CaptureGap == "" {
+		t.Fatal("the refreshed snapshot dropped its ancestor's capture-gap marker — one refresh would " +
+			"launder a knowingly-incomplete baseline into a clean-looking one")
+	}
+}
+
+// errorsIsCaptureGap classifies via the exported sentinel, not the message —
+// the same way `baseline refresh` does, so this test fails if that tagging is
+// ever dropped.
+func errorsIsCaptureGap(err error) bool { return errors.Is(err, reconstruct.ErrCaptureGap) }

--- a/internal/reconstruct/capture_gap_marker_1170_test.go
+++ b/internal/reconstruct/capture_gap_marker_1170_test.go
@@ -1,0 +1,177 @@
+package reconstruct
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// TestCaptureGapLines covers the marker a knowingly-gapped snapshot carries.
+//
+// The inheritance case is the one that matters: a refresh chain folds forward,
+// so the events a gapped ancestor never captured are absent from every
+// descendant. Dropping the ancestor's line at the first refresh would launder a
+// knowingly-incomplete baseline into a clean-looking one — silently, and
+// permanently.
+func TestCaptureGapLines(t *testing.T) {
+	at := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	own := &CaptureGap{
+		At:     time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC),
+		Detail: "binlogs purged before the stream caught up",
+		Since:  time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		Until:  at,
+	}
+
+	t.Run("clean window stamps nothing", func(t *testing.T) {
+		if got := captureGapLines(mergeInput{SnapshotAt: at}); got != "" {
+			t.Fatalf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("own gap", func(t *testing.T) {
+		got := captureGapLines(mergeInput{SnapshotAt: at, CaptureGap: own})
+		if !strings.HasPrefix(got, "2026-05-01T12:00:00Z: ") {
+			t.Errorf("line is not stamped with the snapshot instant: %q", got)
+		}
+		if !strings.Contains(got, "2026-04-20T06:00:00Z") {
+			t.Errorf("line does not name when capture was lost: %q", got)
+		}
+	})
+
+	t.Run("inherited only", func(t *testing.T) {
+		in := mergeInput{SnapshotAt: at}
+		in.SourceBaseline.Metadata = baseline.DumpMetadata{CaptureGap: "2026-04-01T00:00:00Z: older loss"}
+		got := captureGapLines(in)
+		if got != "2026-04-01T00:00:00Z: older loss" {
+			t.Fatalf("an inherited gap was dropped: %q", got)
+		}
+	})
+
+	t.Run("inherited plus own, oldest first", func(t *testing.T) {
+		in := mergeInput{SnapshotAt: at, CaptureGap: own}
+		in.SourceBaseline.Metadata = baseline.DumpMetadata{CaptureGap: "2026-04-01T00:00:00Z: older loss"}
+		lines := strings.Split(captureGapLines(in), "\n")
+		if len(lines) != 2 {
+			t.Fatalf("got %d line(s), want 2: %q", len(lines), lines)
+		}
+		if !strings.HasPrefix(lines[0], "2026-04-01T00:00:00Z") || !strings.HasPrefix(lines[1], "2026-05-01T12:00:00Z") {
+			t.Fatalf("lines are not oldest-first: %q", lines)
+		}
+	})
+}
+
+// TestParquetSnapshot_stampsCaptureGap drives the marker through the real writer
+// and reads it back the way a consumer would.
+func TestParquetSnapshot_stampsCaptureGap(t *testing.T) {
+	rows, nulls := zooRows()
+	src := writeZooBaseline(t, rows, nulls)
+	at := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	snapDir := t.TempDir()
+	rep := &TableReport{Schema: "mydb", Table: "orders"}
+	srcMeta, err := baseline.ReadParquetMetadata(src)
+	if err != nil {
+		t.Fatalf("read source metadata: %v", err)
+	}
+	in := mergeInput{
+		LocalBaselinePath: src,
+		CreateTableSQL:    zooCreateTableSQL,
+		Schema:            "mydb",
+		Table:             "orders",
+		PKCols:            pkColsIntID(),
+		Changes:           map[string]*query.ResultRow{},
+		SnapshotDir:       snapDir,
+		SnapshotAt:        at,
+		CaptureGap: &CaptureGap{
+			At: time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC), Detail: "purged",
+			Since: at.Add(-24 * time.Hour), Until: at,
+		},
+		SourceBaseline: baselineMeta{Path: src, Time: at.Add(-time.Hour), Metadata: srcMeta},
+	}
+	if err := mergeBaselineIntoParquet(t.Context(), in, rep); err != nil {
+		t.Fatalf("mergeBaselineIntoParquet: %v", err)
+	}
+
+	meta, err := baseline.ReadParquetMetadata(filepath.Join(snapDir, "mydb", "orders.parquet"))
+	if err != nil {
+		t.Fatalf("ReadParquetMetadata: %v", err)
+	}
+	if meta.CaptureGap == "" {
+		t.Fatal("a snapshot published over a known capture gap carries no marker — the only durable record " +
+			"that it is knowingly incomplete would be a log line the operator has since closed")
+	}
+	if !strings.Contains(meta.CaptureGap, "2026-04-20T06:00:00Z") {
+		t.Errorf("marker does not name the loss: %q", meta.CaptureGap)
+	}
+}
+
+// TestCheckBaselineSchemaCurrent covers the ALTER that no write followed — the
+// drift the #602/#843 event-image guards structurally cannot see, because they
+// need a delta event to carry (or stop carrying) the column.
+func TestCheckBaselineSchemaCurrent(t *testing.T) {
+	const createSQL = "CREATE TABLE `orders` (\n" +
+		"  `id` int NOT NULL,\n" +
+		"  `status` varchar(32) DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`id`)\n" +
+		");\n"
+	col := func(name string, generated bool) metadata.ColumnMeta {
+		return metadata.ColumnMeta{Name: name, IsGenerated: generated}
+	}
+
+	for _, tc := range []struct {
+		name    string
+		current []metadata.ColumnMeta
+		wantErr string
+	}{
+		{"unchanged", []metadata.ColumnMeta{col("id", false), col("status", false)}, ""},
+		{
+			"case differences are not drift",
+			[]metadata.ColumnMeta{col("ID", false), col("Status", false)},
+			"",
+		},
+		{
+			// mydumper never dumps a generated column's value, so ParseSchema
+			// drops it; the snapshot must not report it as an addition.
+			"generated column added",
+			[]metadata.ColumnMeta{col("id", false), col("status", false), col("total", true)},
+			"",
+		},
+		{
+			"column added since the baseline",
+			[]metadata.ColumnMeta{col("id", false), col("status", false), col("note", false)},
+			"added since: note",
+		},
+		{
+			"column dropped since the baseline",
+			[]metadata.ColumnMeta{col("id", false)},
+			"gone since: status",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tm := &metadata.TableMeta{Schema: "mydb", Table: "orders", Columns: tc.current}
+			err := checkBaselineSchemaCurrent(createSQL, tm, "mydb", "orders")
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("unexpected refusal: %v", err)
+			case tc.wantErr == "":
+			case err == nil:
+				t.Fatalf("expected a refusal containing %q", tc.wantErr)
+			case !strings.Contains(err.Error(), tc.wantErr):
+				t.Fatalf("error %q does not contain %q", err, tc.wantErr)
+			}
+			// Classification is what `baseline refresh` reports on; a refusal
+			// that is not tagged reads as a generic failure in the summary.
+			if err != nil && !isSchemaChanged(err) {
+				t.Errorf("refusal is not tagged ErrSchemaChanged: %v", err)
+			}
+		})
+	}
+}
+
+func isSchemaChanged(err error) bool { return errors.Is(err, ErrSchemaChanged) }

--- a/internal/reconstruct/capturegap.go
+++ b/internal/reconstruct/capturegap.go
@@ -111,9 +111,25 @@ func CaptureGapStatus(ctx context.Context, db *sql.DB, since, until time.Time) (
 // --allow-gaps it logs a slog.Warn and returns nil so the caller proceeds with
 // a known-incomplete result.
 func CheckCaptureGap(ctx context.Context, db *sql.DB, schema, table string, since, until time.Time, allowGaps bool) error {
+	_, err := CheckCaptureGapStatus(ctx, db, schema, table, since, until, allowGaps)
+	return err
+}
+
+// CheckCaptureGapStatus is CheckCaptureGap plus the finding it acted on: the
+// same strict/allow policy, but the caller also learns WHAT was overridden when
+// allowGaps let the run proceed.
+//
+// It exists because "proceeded over a known gap" has to outlive the log line
+// that reported it. A snapshot published under --allow-gaps is knowingly
+// incomplete forever, and the only place that can say so forever is the
+// artifact itself (baseline.MetaKeyCaptureGap, #1170) — a warning in a
+// terminal the operator has since closed is not a record.
+//
+// A nil finding with a nil error means the window was evaluated and is clean.
+func CheckCaptureGapStatus(ctx context.Context, db *sql.DB, schema, table string, since, until time.Time, allowGaps bool) (*CaptureGap, error) {
 	gap, err := CaptureGapStatus(ctx, db, since, until)
 	if err != nil || gap == nil {
-		return err
+		return nil, err
 	}
 	if allowGaps {
 		slog.Warn("reconstruct: "+gap.Reason()+"; output may be incomplete, proceeding due to --allow-gaps",
@@ -121,8 +137,8 @@ func CheckCaptureGap(ctx context.Context, db *sql.DB, schema, table string, sinc
 			"gap_lost_at", gap.At.UTC().Format(time.RFC3339), "detail", gap.Detail,
 			"gap_evaluable", !gap.Unevaluable,
 			"window_since", since.UTC().Format(time.RFC3339), "window_until", until.UTC().Format(time.RFC3339))
-		return nil
+		return gap, nil
 	}
-	return fmt.Errorf("reconstruct: %s for %s.%s; pass --allow-gaps to proceed with a known-incomplete reconstruction",
-		gap.Reason(), schema, table)
+	return nil, fmt.Errorf("reconstruct: %s for %s.%s; pass --allow-gaps to proceed with a known-incomplete reconstruction: %w",
+		gap.Reason(), schema, table, ErrCaptureGap)
 }

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -290,11 +290,58 @@ func maybeWarnEventVolume(schema, table string, n int64, threshold int64, parall
 			"via --warn-event-threshold / BINTRAIL_RECONSTRUCT_WARN_EVENTS (0 disables)")
 }
 
+// Refusal classes a caller can act on without parsing error text. Every
+// full-table refusal that a REFRESH loop needs to report distinctly wraps one of
+// these; anything else is an ordinary failure.
+//
+// They exist for `bintrail baseline refresh`, which must tell an operator WHY a
+// table could not be refreshed — "the events are gone" and "the table changed
+// shape" have completely different remedies — without the summary code
+// string-matching messages that are free to be reworded.
+var (
+	// ErrCaptureGap: the fold window spans a permanent capture loss (or an
+	// index that cannot rule one out). Remedy: --allow-gaps to accept a
+	// knowingly-incomplete result, or a fresh dump.
+	ErrCaptureGap = errors.New("capture gap in the reconstruction window")
+	// ErrSchemaChanged: the table's shape moved between the baseline and the
+	// target — an ALTER, a destructive DDL, or delta events disagreeing with
+	// the baseline's columns. Remedy: a real re-dump; no flag helps.
+	ErrSchemaChanged = errors.New("schema changed since the baseline")
+)
+
+// TableFailure is one table's refusal, kept separate from the joined error so a
+// caller can classify and report per table.
+type TableFailure struct {
+	Schema string
+	Table  string
+	Err    error
+}
+
+// ReconstructTablesDetailed is ReconstructTables plus the per-table failures.
+//
+// ReconstructTables joins every failure into one error, which is right for a
+// command that either produces a dump or doesn't. A refresh has to render a
+// per-table verdict — refreshed / refused-gap / refused-ddl — so it needs the
+// failures apart, classifiable against the sentinels above. The run semantics
+// are identical, including all-or-nothing publication: any failure leaves the
+// snapshot directory marked _INCOMPLETE and therefore undiscoverable.
+func ReconstructTablesDetailed(ctx context.Context, cfg FullTableConfig) ([]*TableReport, []TableFailure, error) {
+	var failures []TableFailure
+	reports, err := reconstructTables(ctx, cfg, &failures)
+	return reports, failures, err
+}
+
 // ReconstructTables runs ReconstructTable concurrently for every entry in
 // cfg.Tables, sharing a single *sql.DB + *query.Engine + *metadata.Resolver.
 // Returns the list of reports in arbitrary order plus a joined error
 // containing every per-table failure (via errors.Join).
 func ReconstructTables(ctx context.Context, cfg FullTableConfig) ([]*TableReport, error) {
+	return reconstructTables(ctx, cfg, nil)
+}
+
+// reconstructTables is the implementation both entry points share. failures, when
+// non-nil, collects each per-table error alongside the joined one.
+func reconstructTables(ctx context.Context, cfg FullTableConfig, failures *[]TableFailure) ([]*TableReport, error) {
 	if cfg.IndexDSN == "" {
 		return nil, errors.New("FullTableConfig: IndexDSN is required")
 	}
@@ -344,12 +391,20 @@ func ReconstructTables(ctx context.Context, cfg FullTableConfig) ([]*TableReport
 		// refreshes inside the same second) would interleave table files from
 		// different folds under a single anchor, and the second run's _SUCCESS
 		// would publish the mixture as one coherent snapshot.
-		if entries, err := os.ReadDir(cfg.snapshotDir); err == nil && len(entries) > 0 {
-			return nil, fmt.Errorf("snapshot directory %s already exists and is not empty; "+
+		//
+		// The exception is a directory holding NOTHING BUT the _INCOMPLETE
+		// marker: that is a previous run of this exact target that published
+		// nothing, so there is no data to interleave. Refusing it would make the
+		// most ordinary recovery impossible — fix the problem the run reported,
+		// retry the same --at, and be told the directory is in the way.
+		leftover, err := snapshotDirLeftovers(cfg.snapshotDir)
+		if err != nil {
+			return nil, err
+		}
+		if len(leftover) > 0 {
+			return nil, fmt.Errorf("snapshot directory %s already holds %s; "+
 				"a baseline snapshot is written once — remove it, or target a different instant with --at",
-				cfg.snapshotDir)
-		} else if err != nil && !os.IsNotExist(err) {
-			return nil, fmt.Errorf("inspect snapshot directory %s: %w", cfg.snapshotDir, err)
+				cfg.snapshotDir, strings.Join(leftover, ", "))
 		}
 		if err := os.MkdirAll(cfg.snapshotDir, 0o755); err != nil {
 			return nil, fmt.Errorf("create snapshot directory %s: %w", cfg.snapshotDir, err)
@@ -475,6 +530,9 @@ func ReconstructTables(ctx context.Context, cfg FullTableConfig) ([]*TableReport
 				slog.Error("full-table reconstruct failed",
 					"schema", schema, "table", table, "error", err)
 				errs = append(errs, fmt.Errorf("%s.%s: %w", schema, table, err))
+				if failures != nil {
+					*failures = append(*failures, TableFailure{Schema: schema, Table: table, Err: err})
+				}
 				return
 			}
 			reports = append(reports, rep)
@@ -555,6 +613,28 @@ func ReconstructTables(ctx context.Context, cfg FullTableConfig) ([]*TableReport
 		return reports, err
 	}
 	return reports, nil
+}
+
+// snapshotDirLeftovers lists what an existing snapshot directory holds that a
+// new run must not write alongside. An absent directory, or one holding only the
+// _INCOMPLETE marker a previous failed run left, yields nothing — see the caller
+// for why that exception is load-bearing.
+func snapshotDirLeftovers(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("inspect snapshot directory %s: %w", dir, err)
+	}
+	var out []string
+	for _, e := range entries {
+		if e.Name() == baseline.IncompleteMarker {
+			continue
+		}
+		out = append(out, e.Name())
+	}
+	return out, nil
 }
 
 // markRunIncomplete stamps outputDir _INCOMPLETE for a NEW reconstruct run
@@ -761,6 +841,29 @@ func ReconstructTable(
 		}
 	}
 
+	// ── 3a-bis. Parquet mode only: refuse when the baseline's schema is no ──
+	// longer the current one. The #602/#843 guards below catch drift only when
+	// a delta event carries (or stops carrying) the column, so an ALTER that no
+	// write followed is invisible to them — and the emitted snapshot would then
+	// declare an obsolete CREATE TABLE over rows nobody can place. Only Parquet
+	// mode: a mydumper dump is read by a human or myloader against a table they
+	// chose, while a baseline is picked up automatically by every later
+	// reconstruct.
+	if cfg.OutputFormat == OutputFormatParquet {
+		if err := checkBaselineSchemaCurrent(bmeta.CreateTableSQL, tm, schema, table); err != nil {
+			return nil, err
+		}
+		// A gapped ancestor taints every descendant: the events it lost are
+		// still lost. Warn on READ as well as stamping on write, so an operator
+		// reconstructing from such a chain is told once per run rather than
+		// having to inspect a Parquet footer.
+		if bmeta.CaptureGap != "" {
+			slog.Warn("the baseline this reconstruction is anchored on was itself published over a KNOWN capture gap; "+
+				"its missing events are missing here too",
+				"schema", schema, "table", table, "baseline", baselinePath, "capture_gap", bmeta.CaptureGap)
+		}
+	}
+
 	// ── 3b. Refuse if a TRUNCATE/DROP/RENAME hit this table in the window ──
 	// TRUNCATE/DROP emit no row events (#764): without this check the merge
 	// below would replay the baseline straight through and silently
@@ -774,7 +877,12 @@ func ReconstructTable(
 	// binlogs purged before the stream caught up); unlike the archive-coverage
 	// gap the fetch below already guards against, no amount of archive
 	// resolution can fill this — it must be checked directly.
-	if err := CheckCaptureGap(ctx, db, schema, table, snapshotTime, cfg.At, cfg.AllowGaps); err != nil {
+	// The finding is kept, not just acted on: under --allow-gaps the run
+	// proceeds over a known permanent loss, and a Parquet snapshot published
+	// that way must carry the fact in its own metadata (#1170). A log line
+	// cannot: the artifact outlives the terminal.
+	capGap, err := CheckCaptureGapStatus(ctx, db, schema, table, snapshotTime, cfg.At, cfg.AllowGaps)
+	if err != nil {
 		return nil, err
 	}
 
@@ -888,6 +996,7 @@ func ReconstructTable(
 		in.SnapshotDir = cfg.snapshotDir
 		in.SnapshotAt = cfg.At
 		in.Cut = cfg.cut
+		in.CaptureGap = capGap
 		in.SourceBaseline = baselineMeta{
 			Path:     baselinePath,
 			Time:     snapshotTime,
@@ -935,8 +1044,8 @@ func prepareMerge(ctx context.Context, in mergeInput) ([]string, error) {
 		return nil, fmt.Errorf(
 			"full-table reconstruct: %s.%s has column(s) %s present in delta events but absent from the baseline schema "+
 				"(added after the baseline snapshot); their values cannot be emitted without dropping data silently — "+
-				"re-run `bintrail baseline` to capture a snapshot that includes the new column(s)",
-			in.Schema, in.Table, strings.Join(extra, ", "))
+				"re-run `bintrail baseline` to capture a snapshot that includes the new column(s): %w",
+			in.Schema, in.Table, strings.Join(extra, ", "), ErrSchemaChanged)
 	}
 
 	// Fail loud on a baseline column DROPPED after the baseline (#843), the
@@ -955,8 +1064,8 @@ func prepareMerge(ctx context.Context, in mergeInput) ([]string, error) {
 			"full-table reconstruct: %s.%s has baseline column(s) %s absent from delta-event row images "+
 				"(dropped from the source table after the baseline snapshot); emitting would mix schema epochs — "+
 				"rows touched after the drop would carry NULL while never-touched rows keep the pre-drop value — "+
-				"re-run `bintrail baseline` to capture a snapshot of the current schema",
-			in.Schema, in.Table, strings.Join(missing, ", "))
+				"re-run `bintrail baseline` to capture a snapshot of the current schema: %w",
+			in.Schema, in.Table, strings.Join(missing, ", "), ErrSchemaChanged)
 	}
 	return colNames, nil
 }
@@ -990,6 +1099,10 @@ type mergeInput struct {
 	SnapshotAt     time.Time
 	Cut            *query.BinlogPos
 	SourceBaseline baselineMeta
+	// CaptureGap is the permanent-loss finding this run OVERRODE under
+	// AllowGaps, or nil when the window was verifiably clean. Non-nil means the
+	// emitted snapshot is knowingly incomplete and must say so in its metadata.
+	CaptureGap *CaptureGap
 
 	// DuckDBTuning sets the resource budget for the DuckDB sessions this
 	// function opens (readBaselineColumns, mergeBaselineImages) (#842). Zero

--- a/internal/reconstruct/parquet_snapshot_1169_test.go
+++ b/internal/reconstruct/parquet_snapshot_1169_test.go
@@ -634,7 +634,38 @@ func TestReconstructTables_refusesNonEmptySnapshotDir(t *testing.T) {
 		OutputDir:    root,
 		OutputFormat: OutputFormatParquet,
 	})
-	if err == nil || !strings.Contains(err.Error(), "already exists and is not empty") {
+	if err == nil || !strings.Contains(err.Error(), "already holds") {
 		t.Fatalf("error = %v, want a refusal to write into an occupied snapshot directory", err)
+	}
+}
+
+// TestReconstructTables_retriesIntoAMarkerOnlySnapshotDir is the other side of
+// that guard. A run that refused published nothing but still left its
+// _INCOMPLETE marker; refusing THAT would make the most ordinary recovery
+// impossible — fix what the run reported, retry the same --at, be told the
+// directory is in the way.
+func TestReconstructTables_retriesIntoAMarkerOnlySnapshotDir(t *testing.T) {
+	root := t.TempDir()
+	at := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	prior := filepath.Join(root, snapshotDirName(at))
+	if err := os.MkdirAll(prior, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := baseline.WriteIncompleteMarker(prior); err != nil {
+		t.Fatalf("WriteIncompleteMarker: %v", err)
+	}
+
+	_, err := ReconstructTables(context.Background(), FullTableConfig{
+		IndexDSN:     "user:pass@tcp(127.0.0.1:1)/idx",
+		BaselineSrc:  t.TempDir(),
+		Tables:       []string{"mydb.orders"},
+		At:           at,
+		OutputDir:    root,
+		OutputFormat: OutputFormatParquet,
+	})
+	// It must get PAST the directory guard; the connection to a dead port is
+	// where this run is expected to stop.
+	if err != nil && strings.Contains(err.Error(), "already holds") {
+		t.Fatalf("a marker-only directory from a failed run blocked the retry: %v", err)
 	}
 }

--- a/internal/reconstruct/parquet_writer.go
+++ b/internal/reconstruct/parquet_writer.go
@@ -9,11 +9,13 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/metadata"
 )
 
 // ParquetWriterCompression / ParquetWriterRowGroupSize are the codec and row
@@ -223,6 +225,9 @@ func mergeBaselineIntoParquet(ctx context.Context, in mergeInput, rep *TableRepo
 		MetaKeyDerivedFrom:             in.SourceBaseline.Time.UTC().Format(time.RFC3339),
 		MetaKeyDerivedFromPath:         in.SourceBaseline.Path,
 	}
+	if line := captureGapLines(in); line != "" {
+		md[baseline.MetaKeyCaptureGap] = line
+	}
 	switch {
 	case in.Cut != nil:
 		md[baseline.MetaKeyBinlogFile] = in.Cut.File
@@ -279,6 +284,88 @@ func mergeBaselineIntoParquet(ctx context.Context, in mergeInput, rep *TableRepo
 	rep.Files = []string{filepath.Join(in.Schema, in.Table+".parquet")}
 	rep.RowsWritten = w.Rows()
 	return nil
+}
+
+// captureGapLines builds the snapshot's MetaKeyCaptureGap value: what it
+// inherited from the snapshot it was derived from, plus what this run itself
+// overrode.
+//
+// Inheritance is the load-bearing half. A refresh chain folds forward, so the
+// events a gapped ancestor never captured are absent from every descendant —
+// dropping the ancestor's line at the first refresh would silently launder a
+// knowingly-incomplete baseline into a clean-looking one, which is exactly the
+// state #1170 exists to make impossible.
+func captureGapLines(in mergeInput) string {
+	lines := strings.TrimSpace(in.SourceBaseline.Metadata.CaptureGap)
+	if in.CaptureGap == nil {
+		return lines
+	}
+	own := in.SnapshotAt.UTC().Format(time.RFC3339) + ": " + in.CaptureGap.Reason()
+	if lines == "" {
+		return own
+	}
+	return lines + "\n" + own
+}
+
+// checkBaselineSchemaCurrent refuses when the CREATE TABLE embedded in the
+// source baseline no longer describes the table's current columns.
+//
+// The comparison is against the schema SNAPSHOT (the resolver), not the live
+// table — that is the newest statement of the schema this index has, and it is
+// what every other reconstruct decision is already made against. Generated
+// columns are excluded on both sides: mydumper never dumps their values, so
+// ParseSchema drops them, and the snapshot marks them explicitly.
+//
+// Why refuse rather than warn: the emitted snapshot carries the OLD CREATE
+// TABLE forward as its own schema. Publish it and every later reconstruct
+// anchored on it declares a table shape the source stopped having, with rows
+// projected onto the old column set — a dump that loads and is wrong. A real
+// re-dump is the only correct answer, so the message says so instead of
+// offering a flag.
+func checkBaselineSchemaCurrent(createSQL string, tm *metadata.TableMeta, schema, table string) error {
+	if strings.TrimSpace(createSQL) == "" || tm == nil {
+		// A missing CREATE TABLE is already refused upstream with its own
+		// message; a nil TableMeta cannot happen on this path (the resolver
+		// errored earlier). Neither is this check's story to tell.
+		return nil
+	}
+	cols, err := baseline.ParseSchemaText(createSQL)
+	if err != nil {
+		return fmt.Errorf("parse the baseline's embedded CREATE TABLE for %s.%s: %w", schema, table, err)
+	}
+	inBaseline := make(map[string]bool, len(cols))
+	for _, c := range cols {
+		inBaseline[strings.ToLower(c.Name)] = true
+	}
+	current := make(map[string]bool, len(tm.Columns))
+	for _, c := range tm.Columns {
+		if c.IsGenerated {
+			continue
+		}
+		current[strings.ToLower(c.Name)] = true
+	}
+	var added, dropped []string
+	for name := range current {
+		if !inBaseline[name] {
+			added = append(added, name)
+		}
+	}
+	for name := range inBaseline {
+		if !current[name] {
+			dropped = append(dropped, name)
+		}
+	}
+	if len(added) == 0 && len(dropped) == 0 {
+		return nil
+	}
+	sort.Strings(added)
+	sort.Strings(dropped)
+	return fmt.Errorf(
+		"%s.%s changed shape since its baseline was taken (added since: %s; gone since: %s) — "+
+			"a snapshot emitted from it would carry the OLD CREATE TABLE forward and project every row onto the old columns, "+
+			"so every reconstruct anchored on it would be wrong. Take a real snapshot instead: `bintrail dump` + `bintrail baseline`. "+
+			"(If the schema snapshot is what is stale, run `bintrail snapshot` first and retry.): %w",
+		schema, table, strings.Join(orNone(added), ", "), strings.Join(orNone(dropped), ", "), ErrSchemaChanged)
 }
 
 // checkSchemaMatchesBaseline refuses when the CREATE TABLE embedded in the


### PR DESCRIPTION
closes #1170

## Summary

`bintrail baseline refresh` folds the deltas the index already holds onto the newest snapshot and publishes the result as a new one — no mydumper run, no connection to the source. Tables default to every table in the newest discoverable snapshot, so the ordinary invocation is just the index plus the baseline directory:

```sh
bintrail baseline refresh --index-dsn "..." --baseline-dir /data/baselines
```

It runs #1169's Parquet emit path. What this PR adds is the refresh contract around it.

## The fail-closed rules, and the durable part

A baseline is picked up automatically by every later reconstruct, so a wrong one is not a bad output — it is a wrong answer to every future question.

- **Capture gap** — strict by default, unchanged. `--allow-gaps` still proceeds, but the emitted snapshot now carries a `bintrail.capture_gap` line in its Parquet metadata naming what was lost, and **every snapshot later refreshed from it inherits that line**. The missing events stay missing down the chain, so the record does too: one refresh can never launder a knowingly-incomplete baseline into a clean-looking one. A warning in a terminal the operator has since closed is not a record.
- **Schema change** — the baseline's embedded `CREATE TABLE` is compared against the current schema snapshot. The #602/#843 guards only see drift a delta event *carries*, so an `ALTER` that no write followed was invisible to them, and the emitted snapshot would declare an obsolete shape while projecting rows onto it. Refuses, pointing at `bintrail dump`; no flag helps.
- **Partial runs publish nothing** — already enforced by the markers. What is new is *saying so*: the summary gives a per-table verdict and states explicitly that nothing was published, because a list of four successes and one refusal otherwise reads as "four tables were refreshed".

```
baseline refresh to 2026-05-01T12:00:00Z

  mydb.orders  refreshed
  mydb.users   refused-gap
               └─ reconstruct: stamped capture gap at 2026-04-20T06:00:00Z falls inside …

NOTHING was published: a snapshot mixing refreshed and stale tables under one anchor
would be worse than no refresh. Fix or exclude the tables above (--tables) and retry.
```

Verdicts classify against exported sentinels (`ErrCaptureGap`, `ErrSchemaChanged`, `ErrDestructiveDDL`), never message text — "the events are permanently gone" and "the table changed shape" have opposite remedies, and blurring them sends the operator down the wrong one. `ReconstructTablesDetailed` returns the per-table failures the joined error flattens.

## Also fixed (a #1169 footgun this work surfaced)

A run that refused left its `_INCOMPLETE` marker behind, and #1169's write-once guard counted that marker as occupancy — so fixing the reported problem and retrying the same `--at` was refused, permanently. A directory holding **nothing but** that marker published no data and is now reusable; anything else still refuses. Found by the integration test, which performs exactly that recovery.

## Notes

- With `--baseline-s3` the new snapshot is written locally (`--output` required) and published with `bintrail upload`; `baseline.Writer` writes files, not objects. The command refuses rather than picking a directory the operator did not name.
- Defaulting to the newest snapshot's tables (not every table the index has seen) keeps the result a strict successor: a table absent from the source has nothing to fold onto, and inventing an entry would claim coverage it does not have.

## Test plan

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `go vet -tags integration ./...`
- [x] Integration tests **ran** against Docker MySQL: `TestRefresh_gapMarkerIsStampedAndInherited` seeds a real gapped `stream_state`, asserts the strict refusal is classified as a capture gap, asserts the `--allow-gaps` run stamps the marker, then runs a SECOND refresh over a clean window and asserts the ancestor's marker survives.
- [x] Unit coverage: marker composition (own / inherited / both, oldest-first), stamping through the real writer, the schema-currency check including the case-difference and generated-column non-cases, verdict classification for all five outcomes, the summary's "nothing was published" wording, flag validation, table discovery from a snapshot fixture, and the marker-only retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
