### PR TITLE
console: offer the DuckDB schema for your own lake, without becoming the engine

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -334,6 +334,18 @@ across the rotation dialog and the per-server edit form):
   start from. The empty states explain how to produce a first baseline
   (`bintrail dump` → `bintrail baseline`). When the **Create baseline** button
   is enabled (see below) it sits in this panel's header.
+- **Query in DuckDB** — a one-click download of `views.sql`: a ready-made
+  DuckDB schema over the selected server's own Parquet — an `events` view
+  across every archive source registered in `archive_state`, plus one
+  `state_<schema>_<table>` view per table in the newest baseline snapshot. It
+  is the same file `bintrail views` writes. **The console does not run it.**
+  You get a text file; your own DuckDB executes it, in your process, on your
+  machine — which is why unrestricted SQL over your lake needs no sandbox, no
+  timeout and no result cap here. No credentials appear in the file (S3 uses
+  your AWS credential chain), so it is safe to share or commit. The card is
+  hidden for a server with archives disabled, for one with nothing archived and
+  no baseline yet, and while an access-control profile is active — the file
+  maps straight onto the unredacted Parquet a profile exists to withhold.
 - **Usage telemetry** — the current state of dbtrail's metadata-only usage
   telemetry and a one-click opt-out. Turning it off stops this `watch` daemon's
   beacons immediately (no restart) and records the machine-wide choice, exactly
@@ -860,7 +872,7 @@ start-to-finish walkthrough (bundle install included), see
 
 ## API
 
-All endpoints return JSON. `/api/*` (except `healthz`) require
+All endpoints return JSON except `GET /api/views.sql`, which serves a SQL file. `/api/*` (except `healthz`) require
 `Authorization: Bearer <token>`.
 
 | Method & path | Purpose |
@@ -891,6 +903,7 @@ All endpoints return JSON. `/api/*` (except `healthz`) require
 | `GET /api/rotation` | Effective global rotation policy: `{retain, interval, add_future, source, enabled}` — `source` is `"override"` (console-saved) or `"default"` (daemon `--rotate-*`). |
 | `PUT /api/rotation` | Supervisor only (403 on the standalone console): save a global rotation override `{retain, interval, add_future}` (validated; `off` rejected). Applies live on the next cycle. |
 | `GET /api/baselines` | Read-only listing of the **selected server's** baseline snapshots, grouped per snapshot: `{configured, source, kind, reconstruct, snapshots: [{time, age_hours, tables, binlog_file, binlog_pos, gtid_set}]}` (coordinates local-only, capped at 50 snapshots). `502` when the configured source is unreadable. |
+| `GET /api/views.sql` | **Not JSON** — a `text/plain` DuckDB schema over the selected server's Parquet (the same output as `bintrail views`), served as a `views.sql` attachment. Nothing is executed here; the file runs in your own DuckDB. 404 when archives are disabled or nothing is archived yet, 403 while an access-control profile is active. |
 | `GET /api/storage` | Process-global storage context: `{aws: {access_key_env, profile, region_env, shared_config, container_creds, web_identity}}` — presence booleans and non-secret names only, never credential values. |
 
 Every data endpoint (`status`, `schemas`, `events`, `recover`,

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -175,6 +175,25 @@ async function api(path, opts = {}) {
   return data;
 }
 
+// apiText is api() for a text/plain endpoint. Same auth, same server header,
+// same central 401 handling — only the parsing differs, because views.sql is a
+// SQL file and api()'s JSON.parse would reject it as malformed.
+async function apiText(path) {
+  const headers = { Authorization: "Bearer " + TOKEN };
+  if (currentServer) headers["X-Bintrail-Server"] = currentServer;
+  const res = await fetch(path, { headers });
+  const text = await res.text();
+  if (!res.ok) {
+    if (res.status === 401) handleUnauthorized();
+    // An error body here is the API's JSON {error}; fall back to the raw text
+    // so a proxy's HTML error page still says something useful.
+    let msg = text || "HTTP " + res.status;
+    try { const j = JSON.parse(text); if (j && j.error) msg = j.error; } catch (_) { /* raw text it is */ }
+    throw apiError(res.status, msg);
+  }
+  return text;
+}
+
 function apiError(status, message) {
   const err = new Error(message);
   err.status = status;
@@ -1967,6 +1986,7 @@ function buildStorage(serversRes, rotation, storage, baselines, telemetry) {
   cards.append(rotationCard(rotation));
   cards.append(credentialsCard(storage));
   cards.append(telemetryCard(telemetry));
+  if (capsCache.views) cards.append(duckdbCard());
   cards.append(baselineSummaryCard(baselines, cur));
   v.append(cards);
 
@@ -2030,6 +2050,34 @@ function credentialsCard(storage) {
 // toggle. Turning it off here stops THIS running daemon's beacons immediately
 // (the daemon wired its live client) and persists the choice for every bintrail
 // process on the machine.
+// duckdbCard offers the generated DuckDB schema for this server's Parquet
+// layout. The console does not run the SQL and gains no query engine: the file
+// is executed by the operator's own DuckDB, on their machine, which is why
+// "unrestricted SQL over your lake" needs no sandbox, timeout or result cap here.
+function duckdbCard() {
+  const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Query in DuckDB" }));
+  card.append(el("p", { class: "form-hint", text:
+    "Download a ready-made schema over your archived Parquet: an events view across every archive source, " +
+    "plus one view per table in the newest baseline snapshot. Run it in your own DuckDB — nothing is executed here." }));
+  card.append(el("p", { class: "form-hint", text:
+    "No credentials are in the file: S3 access uses your AWS credential chain, so it is safe to share." }));
+  const btn = el("button", { class: "btn btn-sm", type: "button", text: "Open in DuckDB…" });
+  btn.onclick = async () => {
+    btn.disabled = true;
+    try {
+      const sql = await apiText("/api/views.sql");
+      downloadBlob("views.sql", sql, "text/plain");
+      toast("views.sql downloaded — run it with: duckdb lake.db < views.sql");
+    } catch (err) {
+      toast("could not generate views: " + ((err && err.message) || err));
+    } finally {
+      btn.disabled = false;
+    }
+  };
+  card.append(el("div", { class: "stg-cardfoot" }, btn));
+  return card;
+}
+
 function telemetryCard(t) {
   const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Usage telemetry" }));
   if (!t || t.error) {

--- a/internal/console/authz.go
+++ b/internal/console/authz.go
@@ -89,6 +89,10 @@ var apiRoutePerms = []routePerm{
 	{"PUT", "/api/rotation", ext.PermServersWrite},
 	{"GET", "/api/baselines", ext.PermSettingsRead},
 	{"GET", "/api/storage", ext.PermSettingsRead},
+	// views.sql is a Settings/Storage artifact: it names paths and column
+	// names, never row data, so it reads like the storage panel it is offered
+	// from rather than like an events read.
+	{"GET", "/api/views.sql", ext.PermSettingsRead},
 	{"GET", "/api/telemetry", ext.PermSettingsRead},
 	{"POST", "/api/telemetry", ext.PermSettingsRead},
 	{"GET", "/api/mcp-token", ext.PermSettingsRead},

--- a/internal/console/authz_test.go
+++ b/internal/console/authz_test.go
@@ -27,6 +27,7 @@ var registeredAPIPatterns = []struct{ method, pattern string }{
 	{"GET", "/api/capabilities"},
 	{"GET", "/api/reconstruct"},
 	{"GET", "/api/baselines"},
+	{"GET", "/api/views.sql"},
 	{"GET", "/api/storage"},
 	{"GET", "/api/telemetry"},
 	{"POST", "/api/telemetry"},

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -62,6 +62,11 @@ type capabilitiesResponse struct {
 	// baseline dir set but `bintrail snapshot` never run), where the handler
 	// degrades to Phase-1; advertising true there would over-promise.
 	RecoverCascadeBaseline bool `json:"recover_cascade_baseline"`
+	// Views: GET /api/views.sql can produce a DuckDB schema for the SELECTED
+	// server's Parquet layout. Per-server and gated exactly as the handler is
+	// (archives enabled, no active data profile, and something to describe), so
+	// the UI never offers a button that only 404s.
+	Views bool `json:"views"`
 	// BaselineTrigger: this process can create baseline snapshots in-process from
 	// the console (the watch daemon opted in with BINTRAIL_CONSOLE_BASELINE_TRIGGER=1).
 	// Process-global, like Monitor — the endpoint does the per-server validation
@@ -175,6 +180,7 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		// capabilities must go false for a profiled session too (#1075).
 		restricted := sessionRestricted(r)
 		resp.Reconstruct = b.baselineConfigured && !restricted
+		resp.Views = s.viewsAvailable(r, b)
 		// Match the recover-cascade handler's Phase-2 gate exactly so the advertised
 		// capability can't over-promise (handler builds the provider only when both
 		// a baseline source and a resolver are present).

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -193,7 +193,7 @@ type Server struct {
 	// version is the running build's version string (Config.Version).
 	version string
 	cm      *connManager
-	mux              http.Handler
+	mux     http.Handler
 	// Password login: authPath is the credential file (re-read per login so a
 	// live `user set-password` applies without restart); passwordCfg is its
 	// boot-time existence, which drives the bind gate and the printed banner.
@@ -453,6 +453,7 @@ func (s *Server) buildHandler() http.Handler {
 	// listing, and the process's ambient AWS credential signals (presence
 	// booleans and non-secret names — never values).
 	api.HandleFunc("GET /api/baselines", s.handleBaselines)
+	api.HandleFunc("GET /api/views.sql", s.handleViewsSQL)
 	api.HandleFunc("GET /api/storage", s.handleStorageInfo)
 	// Usage-telemetry opt-out: read the machine-wide state, and toggle it (a
 	// local config write, not a data write). Available on any console; the UI

--- a/internal/console/views_api.go
+++ b/internal/console/views_api.go
@@ -1,0 +1,143 @@
+package console
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+	"github.com/dbtrail/dbtrail/internal/views"
+)
+
+// handleViewsSQL serves GET /api/views.sql: the same DuckDB view definitions
+// `bintrail views` generates, with the paths resolved from the selected
+// server's bundle.
+//
+// The point of the surface is what it is NOT. The console executes no SQL and
+// gains no query engine here — it hands the operator a text file their own
+// DuckDB runs, in their own process, on their own machine, against their own
+// Parquet. That is why the "unrestricted SQL over the lake" the UI advertises
+// costs nothing to secure: there is no sandbox to escape, no timeout to tune
+// and no result cap to argue about, because none of it runs in the daemon.
+//
+// Deliberately NOT audited. ext.Record's contract covers surfaces that serve
+// historical ROW DATA; this emits view definitions — paths and column names,
+// with no row ever read — the same metadata-only class as `status`. Recording
+// it would report a data access that did not happen.
+func (s *Server) handleViewsSQL(w http.ResponseWriter, r *http.Request) {
+	b := s.resolveOr(w, r)
+	if b == nil {
+		return
+	}
+
+	// An active data profile refuses this file, exactly as it refuses the
+	// baseline listing (#1075). The reasoning is the same and it is not about
+	// the bytes: RBAC redaction happens in the console's own read path, and this
+	// file is a map straight past it — a ready-made schema over the unredacted
+	// Parquet the profile exists to withhold. Whether the session ALSO has
+	// filesystem or S3 access is not the console's judgement to make; handing
+	// over the map is.
+	if sessionRestricted(r) {
+		recordProfileGateDeny(r, "views")
+		writeJSONError(w, http.StatusForbidden,
+			"the DuckDB view file is unavailable while an access-control profile is active — "+
+				"it maps directly onto the unredacted Parquet files")
+		return
+	}
+	if b.noArchive {
+		writeJSONError(w, http.StatusNotFound,
+			"archive access is disabled for this server, so there is no Parquet layout to describe")
+		return
+	}
+
+	in := views.Input{
+		GeneratedAt: time.Now().UTC(),
+		Version:     s.version,
+	}
+	in.ArchiveSources = consoleArchiveSources(r.Context(), b.db)
+	if b.baselineSrc != "" {
+		in.BaselineSource = b.baselineSrc
+		files, err := reconstruct.ListBaselines(r.Context(), b.baselineSrc)
+		if err != nil {
+			// Configured but unreadable is an upstream fault worth naming, and
+			// the same 502 the baseline listing returns for it. Degrading to
+			// "archives only" would silently hand over a file missing every
+			// state view the operator came for.
+			writeJSONError(w, http.StatusBadGateway, "list baselines: "+err.Error())
+			return
+		}
+		if len(files) > 0 {
+			newest := files[0].SnapshotTime // ListBaselines returns newest first
+			in.BaselineSnapshot = newest
+			for _, f := range files {
+				if !f.SnapshotTime.Equal(newest) {
+					continue
+				}
+				in.Baselines = append(in.Baselines, views.BaselineTable{
+					Schema: f.Schema, Table: f.Table, Path: f.Path,
+				})
+			}
+		}
+	}
+
+	if len(in.ArchiveSources) == 0 && len(in.Baselines) == 0 {
+		// Nothing to describe. A file of comments explaining that would be a
+		// worse answer than the UI simply not offering the button, which is
+		// what the matching capability arranges.
+		writeJSONError(w, http.StatusNotFound,
+			"this server has no archived partitions and no baseline snapshot yet — nothing to generate views over")
+		return
+	}
+
+	sqlText := views.Generate(in)
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="views.sql"`)
+	// The file names paths, not data, and it is regenerated from live state on
+	// every request — a cached copy would quietly describe a layout that has
+	// since rotated.
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte(sqlText)); err != nil {
+		slog.Debug("console: client went away while receiving views.sql", "error", err)
+	}
+}
+
+// consoleArchiveSources reads the selected server's archive registry,
+// best-effort.
+//
+// A registry read failure degrades to "no archive sources" rather than failing
+// the request: the baseline half of the file is still useful on its own, and the
+// generated header states which archive sources were resolved — so an empty list
+// shows up in the artifact itself rather than only in a log. Returns nil for a
+// server whose connection is not open.
+func consoleArchiveSources(ctx context.Context, db *sql.DB) []string {
+	if db == nil {
+		return nil
+	}
+	sources, err := query.ResolveArchiveSources(ctx, db)
+	if err != nil {
+		slog.Warn("console: could not resolve archive sources for views.sql; the file will describe baselines only",
+			"error", err)
+		return nil
+	}
+	return sources
+}
+
+// viewsAvailable reports whether the selected server has a Parquet layout worth
+// generating views over — the capability the UI gates the download button on.
+//
+// It runs the SAME checks the handler does, in the same order, so the advertised
+// capability cannot over-promise: a button that only 404s is a lie, and this
+// codebase already refuses that trade for reconstruct and verify.
+func (s *Server) viewsAvailable(r *http.Request, b *bundle) bool {
+	if b == nil || b.noArchive || sessionRestricted(r) {
+		return false
+	}
+	if b.baselineSrc != "" {
+		return true
+	}
+	return len(consoleArchiveSources(r.Context(), b.db)) > 0
+}

--- a/internal/console/views_api_test.go
+++ b/internal/console/views_api_test.go
@@ -1,0 +1,125 @@
+package console
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newViewsServer builds a Server whose boot bundle points at a baseline source
+// and no index DB — the archive half degrades to empty, which is exactly the
+// baseline-only shape this endpoint must still serve.
+func newViewsServer(t *testing.T, src string, noArchive bool) *Server {
+	t.Helper()
+	s := &Server{token: "t", version: "v0.50.0", cm: newConnManager(nil, false)}
+	s.cm.boot = &bundle{baselineSrc: src, baselineConfigured: src != "", noArchive: noArchive}
+	s.mux = s.buildHandler()
+	return s
+}
+
+func TestViewsAPI_servesADownloadableSQLFile(t *testing.T) {
+	dir := t.TempDir()
+	writeBaselineFixture(t, dir, "2026-06-10T12-00-00Z", "shop", "orders.parquet")
+	writeBaselineFixture(t, dir, "2026-06-10T12-00-00Z", "shop", "users.parquet")
+	// An OLDER snapshot: its tables must not appear. Two snapshots' rows are two
+	// points in time, and a schema spanning them would describe a state that
+	// never existed.
+	writeBaselineFixture(t, dir, "2026-06-01T00-00-00Z", "shop", "retired.parquet")
+
+	srv := newViewsServer(t, dir, false)
+	rec, body := doServersReq(t, srv, "GET", "/api/views.sql", "")
+	if rec.Code != 200 {
+		t.Fatalf("code = %d, body = %s", rec.Code, body)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("Content-Type = %q, want text/plain", ct)
+	}
+	if cd := rec.Header().Get("Content-Disposition"); !strings.Contains(cd, `filename="views.sql"`) {
+		t.Errorf("Content-Disposition = %q, want a views.sql attachment", cd)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		// A cached copy would describe a layout that has since rotated.
+		t.Errorf("Cache-Control = %q, want no-store", cc)
+	}
+
+	sql := string(body)
+	for _, want := range []string{`CREATE OR REPLACE VIEW "state_shop_orders"`, `CREATE OR REPLACE VIEW "state_shop_users"`} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("generated SQL is missing %s:\n%s", want, sql)
+		}
+	}
+	if strings.Contains(sql, "state_shop_retired") {
+		t.Error("a superseded snapshot's table leaked into the schema")
+	}
+}
+
+// TestViewsAPI_neverLeaksCredentials is the property that makes the file safe to
+// download and paste into a shared notebook.
+func TestViewsAPI_neverLeaksCredentials(t *testing.T) {
+	dir := t.TempDir()
+	writeBaselineFixture(t, dir, "2026-06-10T12-00-00Z", "shop", "orders.parquet")
+	srv := newViewsServer(t, dir, false)
+	srv.token = "super-secret-token"
+
+	_, body := doServersReq(t, srv, "GET", "/api/views.sql", "")
+	for _, forbidden := range []string{"super-secret-token", "Bearer ", "KEY_ID '", "password"} {
+		for _, line := range strings.Split(string(body), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "--") {
+				continue // the commented-out explicit-key alternative
+			}
+			if strings.Contains(line, forbidden) {
+				t.Errorf("executable line leaks %q: %s", forbidden, line)
+			}
+		}
+	}
+}
+
+// TestViewsAPI_disabledWithoutArchives: no-archive servers have no Parquet
+// layout to describe, and the capability hides the button for the same reason.
+func TestViewsAPI_disabledWithoutArchives(t *testing.T) {
+	srv := newViewsServer(t, t.TempDir(), true)
+	rec, body := doServersReq(t, srv, "GET", "/api/views.sql", "")
+	if rec.Code != 404 {
+		t.Fatalf("code = %d, body = %s; want 404 for a no-archive server", rec.Code, body)
+	}
+}
+
+// TestViewsAPI_nothingToDescribe: a fresh install with neither archives nor a
+// baseline gets a 404, not a file of comments explaining there is nothing in it.
+func TestViewsAPI_nothingToDescribe(t *testing.T) {
+	srv := newViewsServer(t, "", false)
+	rec, body := doServersReq(t, srv, "GET", "/api/views.sql", "")
+	if rec.Code != 404 {
+		t.Fatalf("code = %d, body = %s; want 404 when there is no layout yet", rec.Code, body)
+	}
+	if !strings.Contains(string(body), "nothing to generate views over") {
+		t.Errorf("404 body is not actionable: %s", body)
+	}
+}
+
+// TestViewsAvailable mirrors the handler's gate, which is the point: the
+// capability decides whether the UI shows a button, and a button that only 404s
+// is a lie.
+func TestViewsAvailable(t *testing.T) {
+	dir := t.TempDir()
+	writeBaselineFixture(t, dir, "2026-06-10T12-00-00Z", "shop", "orders.parquet")
+
+	for _, tc := range []struct {
+		name string
+		b    *bundle
+		want bool
+	}{
+		{"baseline source configured", &bundle{baselineSrc: dir}, true},
+		{"archives disabled", &bundle{baselineSrc: dir, noArchive: true}, false},
+		{"nothing configured", &bundle{}, false},
+		{"no bundle", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{cm: newConnManager(nil, false)}
+			r := httptest.NewRequest("GET", "http://127.0.0.1:8090/api/views.sql", nil)
+			if got := s.viewsAvailable(r, tc.b); got != tc.want {
+				t.Fatalf("viewsAvailable = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
closes #1176

## Summary

A **Query in DuckDB** card in Settings → Storage downloads `views.sql` — the same schema `bintrail views` generates (#1172), with the paths resolved from the selected server's bundle. `GET /api/views.sql` serves it as a `text/plain` attachment.

The point is what this is **not**. The console executes no SQL and gains no query engine: the operator's own DuckDB runs the file, in their process, on their machine. That is why "unrestricted SQL over your lake" costs nothing to secure here — there is no sandbox to escape, no timeout to tune and no result cap to argue about, because none of it runs in the daemon. #1177 (a server-side SQL panel) stays parked; this covers the need without the risk.

## Gating

Exactly what the handler does, so the button can never be one that only 404s (the same stance `reconstruct` and `verify` already take on their capabilities):

- archives disabled for the server → hidden / 404
- nothing archived **and** no baseline yet → hidden / 404
- an active data profile → hidden / 403

That last one is not about the bytes. RBAC redaction happens in the console's own read path, and this file is a ready-made map straight past it, onto the unredacted Parquet the profile exists to withhold. Whether the session *also* has filesystem or S3 access is not the console's judgement to make; handing over the map is.

## Security

No credentials are renderable into the file — S3 uses the credential chain, and the explicit-key form appears only in a comment. Pinned by a test that scans every non-comment line with the console token deliberately set to a string it looks for.

Serving view **definitions** is metadata-only and deliberately outside the audit surface, consistent with `ext/audit.go`'s scope: no row is ever read.

## Test plan

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `go vet -tags integration ./...`
- [x] Handler tests: serves a `views.sql` attachment with `no-store`; includes only the newest snapshot's tables (a superseded snapshot's table must not leak into the schema); leaks no credentials on any executable line; 404 for a no-archive server; 404 with an actionable body when there is no layout yet; capability matches the handler's gate case by case.
- [x] The route is added to the authz route table (a permission entry with no registered route fails `TestRouteTableHasNoDeadEntries`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
