### PR TITLE
docs: alert on what makes data recoverable, not on what was received

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -334,6 +334,31 @@ scrape_configs:
 groups:
   - name: bintrail
     rules:
+      # The recoverability alert. Every lag gauge below is moved only BY
+      # TRAFFIC and freezes at its last value under an idle source — so a dead
+      # stream reads identical to a healthy one. Dividing on the flush
+      # timestamp is immune to that: it stops advancing either way.
+      - alert: BintrailNothingBecomingRecoverable
+        expr: time() - bintrail_stream_last_flush_timestamp_seconds > 300
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Bintrail has not committed a batch to the index in 5 minutes"
+          description: "Changes since the last flush are NOT queryable and NOT recoverable."
+
+      # Read→queryable, both ends on one clock (skew-free, sub-second).
+      - alert: BintrailCommitLatencyHigh
+        expr: histogram_quantile(0.99, rate(bintrail_stream_index_commit_latency_seconds_bucket[5m])) > 30
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Bintrail p99 read→queryable latency is over 30s"
+          description: "The window in which a change exists but is not yet recoverable is widening."
+
+      # RECEIVE-time: says the daemon is behind the source, NOT that data is
+      # unrecoverable — it is set before batching.
       - alert: BintrailReplicationLagHigh
         expr: bintrail_stream_replication_lag_seconds > 60
         for: 5m

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -553,7 +553,7 @@ bintrail status --index-dsn "user:pass@tcp(127.0.0.1:3306)/binlog_index"
 | `failed to connect to index database: ...` | Wrong DSN, MySQL not running, or network issue | Verify the DSN is correct and test connectivity: `mysql -u user -p -h host -P 3306 binlog_index`. |
 | Index files stuck as `in_progress` | Previous `index` run crashed or was killed | Re-run `bintrail index` — `in_progress` files are retried automatically. |
 | `auto-discover binlog position: ...` on `bintrail stream` first run | The default auto-discovery (`SHOW BINARY LOG STATUS` / `SHOW MASTER STATUS`) failed — usually because `log_bin=OFF` on the source, or the user lacks `REPLICATION CLIENT` | Enable binary logging on the source (or override with an explicit `--start-file`/`--start-pos` or `--start-gtid`). On RDS, set `binlog_format=ROW` in the parameter group and ensure `backup-retention-period > 0`. |
-| Stream replication lag growing | High write rate on source, slow index DB, or large batches | Try increasing `--batch-size` (reduces round-trips), check index DB load, and monitor `bintrail_stream_replication_lag_seconds` via Prometheus. |
+| Stream replication lag growing | High write rate on source, slow index DB, or large batches | Try increasing `--batch-size` (reduces round-trips) and check index DB load. Monitor `bintrail_stream_index_commit_latency_seconds` — `replication_lag_seconds` is receive-time and can read "caught up" while events are not yet queryable. |
 | `unix socket; binlog replication requires TCP` | Source DSN uses a unix socket path | Switch `--source-dsn` to TCP format: `user:pass@tcp(host:3306)/`. The replication protocol does not work over unix sockets. |
 
 ---

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -31,9 +31,35 @@ The live pipeline — emitted on the hot path as events flow.
 | `bintrail_stream_batch_flushes_total` | counter | Batch INSERT operations executed |
 | `bintrail_stream_checkpoint_saves_total` | counter | Successful checkpoint saves |
 | `bintrail_stream_last_event_timestamp_seconds` | gauge | Timestamp of the last event processed |
-| `bintrail_stream_replication_lag_seconds` | gauge | Now minus the last processed event timestamp |
+| `bintrail_stream_replication_lag_seconds` | gauge | Now minus the last processed event timestamp. **Receive-time** — see the warning below |
+| `bintrail_stream_index_commit_latency_seconds` | histogram | Seconds from replication read to the event being **queryable** in the index |
+| `bintrail_stream_availability_lag_seconds` | gauge | Approximate seconds from source commit to queryable — the effective RPO |
+| `bintrail_stream_last_flush_timestamp_seconds` | gauge | Unix timestamp of the last batch successfully committed to the index |
 | `bintrail_stream_errors_total` | counter | Errors, by `type` |
 | `bintrail_stream_batch_size` | histogram | Events per INSERT batch |
+
+### Received is not recoverable
+
+`replication_lag_seconds` is set when an event comes **off the replication
+stream**, before batching. An event can therefore sit in an unflushed batch —
+up to a full batch or a checkpoint interval — while this gauge reads
+"caught up", even though the event is **not yet queryable and not yet
+recoverable**. It is unchanged and still useful for "is the source→daemon
+connection keeping up", but it is not a recovery-readiness signal.
+
+The three commit-side metrics close that window. They are published only after
+a batch is durably in the index:
+
+| Metric | Clock | Read it as |
+|---|---|---|
+| `index_commit_latency_seconds` | one process's monotonic clock — **skew-free, sub-second** | How long a change existed but was not yet recoverable. **This is the one to alert on.** Observed per event, so the histogram's tail is the real worst case, not a per-flush average. |
+| `availability_lag_seconds` | source clock **minus** local clock | The effective RPO. **Approximate**: it carries any clock skew between the source and this host, and the binlog header timestamp it starts from has one-**second** resolution. Negative values (a source clock running ahead) are clamped to 0. Reported as the batch **maximum** — the oldest change in a batch is what defines the recovery point. |
+| `last_flush_timestamp_seconds` | local | When this process last made anything queryable. Alert on `time() - <metric>`, never on its raw value. |
+
+A zero read time — a file-mode `bintrail index` backfill, or any event a
+non-replication producer built — is **skipped**, never recorded as a
+0-second latency. Re-indexing month-old binlogs must not publish
+"everything is perfectly fresh".
 
 ## Capture loss (`bintrail_statement_dml_dropped_total`)
 
@@ -118,8 +144,33 @@ bintrail_index_storage_bytes{location="mysql"}
 predict_linear(bintrail_index_storage_bytes{location="mysql"}[6h], 7 * 24 * 3600)
 ```
 
-**Stream stalled** — replication lag climbing, **or** no events indexed (either
-condition is a separate alert):
+**Capture is not making data recoverable** — the alert that actually protects
+recovery. Every lag *gauge* is moved only BY TRAFFIC, so under an idle source
+they all freeze at their last value and a dashboard reads "caught up" forever,
+including when the stream is dead. Dividing on the flush timestamp is immune to
+that, because the flush timestamp stops advancing whether the cause is a dead
+daemon or a quiet source:
+
+```promql
+time() - bintrail_stream_last_flush_timestamp_seconds > 300
+```
+
+**Alerting on a lag gauge alone is the mistake this metric exists to prevent.**
+`bintrail_stream_availability_lag_seconds > 300` looks equivalent and is not: a
+stream that dies leaves the gauge at whatever it last was, so a healthy-looking
+value can be hours stale.
+
+**Commit latency is degrading** — changes are taking longer to become
+recoverable, before it turns into an outage. Same-process clock, so this is
+exact:
+
+```promql
+histogram_quantile(0.99, rate(bintrail_stream_index_commit_latency_seconds_bucket[5m])) > 30
+```
+
+**Stream stalled** — the source→daemon connection is behind, **or** no events
+indexed (either condition is a separate alert). Note the first is receive-time:
+it says the daemon is behind the source, not that data is unrecoverable:
 
 ```promql
 bintrail_stream_replication_lag_seconds > 300
@@ -148,6 +199,27 @@ line / `stream.continuity.status` JSON field), and the alertable hook is its exi
 # in CI/cron — exits non-zero on gap_lost OR an unconfirmable state (fails closed)
 bintrail status --index-dsn "$IDX" --fail-on-gap
 ```
+
+The liveness half has the same shape. `status` reports a freshness verdict
+(`current` / `idle` / `stalled`, plus the never-a-false-ok states) in the Stream
+section and as `stream.freshness.status` in JSON, and `--fail-on-lag` is its
+alertable exit:
+
+```bash
+# non-zero on a stalled checkpoint, an unevaluable verdict (fails closed),
+# or a newest indexed event older than the threshold
+bintrail status --index-dsn "$IDX" --fail-on-lag 15m
+```
+
+Two things to know before you put that in cron. The **checkpoint** is the
+liveness signal, not the event time — the checkpoint ticker runs with or
+without traffic, so a stale checkpoint means the daemon, never the workload.
+And the age check is **traffic-sensitive**: offline, a source nobody wrote to
+and a capture running an hour behind are the *same observation* (fresh
+checkpoint, old newest-event), which is exactly why `idle` is its own verdict
+rather than being called healthy or unhealthy. Pick a threshold above your
+quiet windows, and use `index_commit_latency_seconds` on the daemon when you
+need to tell the two apart.
 
 See [the continuity signal](rotation-and-status.md#stream-continuity-no-data-lost).
 A Prometheus gauge for this state is not exposed in this release.
@@ -199,12 +271,24 @@ groups:
         labels: {severity: critical}
         annotations:
           summary: "bintrail stream/metrics endpoint is down — capture may have stopped"
+      - alert: BintrailNothingBecomingRecoverable
+        expr: time() - bintrail_stream_last_flush_timestamp_seconds > 300
+        for: 5m
+        labels: {severity: critical}
+        annotations:
+          summary: "bintrail has not committed a batch to the index in 5 minutes — changes since then are NOT recoverable"
+      - alert: BintrailCommitLatencyHigh
+        expr: histogram_quantile(0.99, rate(bintrail_stream_index_commit_latency_seconds_bucket[5m])) > 30
+        for: 10m
+        labels: {severity: warning}
+        annotations:
+          summary: "bintrail p99 read→queryable latency is over 30s — the recovery window is widening"
       - alert: BintrailReplicationLagHigh
         expr: bintrail_stream_replication_lag_seconds > 300
         for: 10m
         labels: {severity: warning}
         annotations:
-          summary: "bintrail capture is more than 5 minutes behind the source"
+          summary: "bintrail is more than 5 minutes behind the source (receive-time; see BintrailNothingBecomingRecoverable for recoverability)"
       - alert: BintrailStreamErrors
         expr: rate(bintrail_stream_errors_total[15m]) > 0
         for: 15m

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -294,7 +294,7 @@ The status command produces a multi-section report. The sections, in order:
 | Section | Shown when | Contents |
 |---|---|---|
 | **Servers** | `bintrail_servers` has rows | Registered source servers — `bintrail_id`, host/port, server UUID, status |
-| **Stream** | `stream_state` has a checkpoint, **or** reading it failed | Replication position/GTID, events indexed, last event/checkpoint, and the **continuity verdict** (below). On a read failure the block shows only an `unavailable` verdict |
+| **Stream** | `stream_state` has a checkpoint, **or** reading it failed | Replication position/GTID, events indexed, last event/checkpoint, and the **continuity** and **freshness** verdicts (below). On a read failure the block shows only an `unavailable` verdict |
 | **Indexed Files** | always | Every row in `index_state`, with the `bintrail_id` that indexed each file |
 | **Partitions** | always | Each partition's boundary and estimated row count |
 | **Archives** | `archive_state` has data | Archived-file / S3-upload counts |
@@ -318,6 +318,7 @@ about gap-**contiguity** of the captured range; it is **not** a liveness/lag che
   Last checkpoint: 2026-02-19 10:01:12
   Server ID:       100
   Continuity:      no gaps in the captured range (not a liveness check)
+  Freshness:       current — newest indexed event is 3s old
   Capture health:  OK — no events skipped
 ```
 
@@ -342,6 +343,47 @@ When data was permanently lost, a loud banner follows the section:
 
 This banner is also how an index-only `status` surfaces a lost or invalidated
 PostgreSQL replication slot (#532) after the capture process has exited.
+
+### Stream freshness ("is capture still keeping up?")
+
+Continuity's sibling, and deliberately a different question. Continuity is about
+gap-contiguity of what was captured; freshness is the **liveness** half. Both are
+needed: a perfectly contiguous index can be three days stale, and a perfectly
+fresh one can have a hole in the middle.
+
+| Text | JSON `stream.freshness.status` | Meaning |
+|---|---|---|
+| `current — newest indexed event is Ns old` | `current` | Checkpointing **and** indexing recent events |
+| `idle — checkpointing, newest indexed event is …` | `idle` | Checkpointing, but nothing recent indexed. **Not a fault, and not a clean bill of health** — see below |
+| `⚠ STALLED — no checkpoint for …` | `stalled` | The checkpoint itself is stale. The alertable state |
+| `not evaluated (a stream row with no checkpoint …)` | `unknown` | Nothing to judge; never a false `current` |
+| *(no Stream block)* | `unavailable` / `none` | `stream_state` unreadable, or a file-mode index that ran no capture and makes no claim |
+
+The **checkpoint** is the liveness signal, not the event time: the checkpoint
+ticker runs with or **without** traffic, so a stale checkpoint means the daemon
+is dead or wedged — never that the workload went quiet.
+
+**What `idle` does and does not tell you.** From the index alone, a source
+nobody wrote to and a capture running an hour behind are the *same
+observation*: fresh checkpoint, old newest-event. Nothing in `stream_state`
+separates them, so `status` reports the ambiguity instead of guessing. The
+daemon *can* tell — that is exactly what
+`bintrail_stream_index_commit_latency_seconds` measures (see
+[observability.md](observability.md)).
+
+**`--fail-on-lag <duration>` (for CI / cron).** The freshness equivalent of
+`--fail-on-gap`, and a separate flag because the two failures are independent —
+alert on one without the other. It exits non-zero on `stalled`, on any verdict
+that is not a claim (**fails closed**), or when the newest indexed event is
+older than the duration:
+
+```bash
+bintrail status --index-dsn "$IDX" --fail-on-lag 15m || alert "dbtrail capture is behind"
+```
+
+The age check is **traffic-sensitive by construction** (see `idle` above): on a
+source with genuinely quiet periods it fires with nothing wrong. Pick a
+threshold above your quiet windows. Unset, it never changes the exit code.
 
 **`--fail-on-gap` (for CI / cron).** By default a gap **never** changes the exit
 code — `status` is a report. Pass `--fail-on-gap` to exit non-zero when continuity
@@ -521,7 +563,8 @@ bintrail status
         information_schema.PARTITIONS, archive_state, schema_changes
         (and baseline Parquet with --baseline-dir)
         prints multi-section report incl. the stream-continuity verdict
-        (--format json for machine-readable; --fail-on-gap to alert on loss)
+        (--format json for machine-readable; --fail-on-gap to alert on loss,
+        --fail-on-lag to alert on capture falling behind or stalling)
 
 bintrail query [--archive-s3 s3://...]
     └── partition pruning: only reads relevant partitions

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -334,7 +334,10 @@ When `--metrics-addr :9090` is set, a Prometheus HTTP endpoint starts at `/metri
 | `bintrail_stream_batch_flushes_total` | Counter | Number of batch INSERT operations |
 | `bintrail_stream_checkpoint_saves_total` | Counter | Successful checkpoint writes |
 | `bintrail_stream_last_event_timestamp_seconds` | Gauge | Unix timestamp of the last received event |
-| `bintrail_stream_replication_lag_seconds` | Gauge | `now() - last_event_timestamp` in seconds |
+| `bintrail_stream_replication_lag_seconds` | Gauge | `now() - last_event_timestamp` in seconds — **receive-time**, set before batching |
+| `bintrail_stream_index_commit_latency_seconds` | Histogram | Seconds from replication read to the event being **queryable** (per event) |
+| `bintrail_stream_availability_lag_seconds` | Gauge | Approximate seconds from source commit to queryable — the effective RPO |
+| `bintrail_stream_last_flush_timestamp_seconds` | Gauge | Unix timestamp of the last batch committed to the index |
 | `bintrail_stream_errors_total{source,type}` | Counter | Errors by type: `batch_flush`, `checkpoint`, `gtid_update` |
 | `bintrail_stream_batch_size` | Histogram | Distribution of events per batch flush |
 
@@ -346,7 +349,33 @@ in one process stay distinguishable (the top-level
 monitored entry's ID, and the **daemon** serves one `/metrics` endpoint covering
 all supervised streams (per-stream endpoints would fight over the bind).
 
-`replication_lag_seconds` is the most useful metric for monitoring — it tells you how far behind the stream is relative to real time. If it grows steadily, the index database can't keep up with the write rate. With multiple sources, alert per label: `bintrail_stream_replication_lag_seconds{source="<entry-id>"}`.
+`replication_lag_seconds` tells you how far behind the stream is relative to
+real time. If it grows steadily, the index database can't keep up with the
+write rate. With multiple sources, alert per label:
+`bintrail_stream_replication_lag_seconds{source="<entry-id>"}`.
+
+**It is not a recoverability signal.** It is set when an event comes *off* the
+stream, before batching, so an event can sit in an unflushed batch — up to a
+full batch or a checkpoint interval — while this gauge reads "caught up",
+though the event is not yet queryable and not yet recoverable. Its semantics
+are unchanged on purpose, so existing dashboards keep meaning what they meant.
+
+For recovery readiness use the commit-side metrics, published only after a
+batch is durably in the index:
+
+- `index_commit_latency_seconds` — read→queryable, per event. Both ends are
+  this process's own clock, so it is skew-free and sub-second: **the one to
+  alert on.**
+- `availability_lag_seconds` — source commit→queryable, the effective RPO.
+  Approximate: it crosses the source's clock and ours, the source timestamp has
+  one-second resolution, and negatives are clamped to 0. Reported as the batch
+  maximum, since the oldest change defines the recovery point.
+- `last_flush_timestamp_seconds` — alert on `time() - <metric>`. Every gauge
+  above freezes under idle traffic, so a dead stream looks identical to a
+  healthy one; dividing on the flush timestamp is what distinguishes them.
+
+See [observability.md](observability.md) for the alert rules, and
+`bintrail status --fail-on-lag` for the offline (metrics-free) equivalent.
 
 The metrics HTTP server shuts down gracefully (5-second timeout) on command exit.
 


### PR DESCRIPTION
closes #1228

Final PR of #1223.

## The problem in the docs

The metrics docs told operators to alert on `replication_lag_seconds` — `streaming.md` called it *"the most useful metric for monitoring"*. That gauge is set when an event comes **off** the stream, before batching, so it can read "caught up" while events sit in an unflushed batch: not queryable, not recoverable. Two shipped PromQL alert examples were built on it.

## What changed

**A clocks table** — which clock each metric uses, its resolution, its negative-clamp and idle behaviour, and which one is safe to alert on:

- `index_commit_latency_seconds` is the answer: both ends are one process's monotonic clock, so it is skew-free and sub-second.
- `availability_lag_seconds` is documented as **approximate** — it crosses the source's clock and ours, and starts from a one-**second** binlog header timestamp.
- A zero read time (file-mode backfill) is skipped, never recorded as 0s.

**The idle-traffic trap, stated where the alerts are.** Every lag gauge is moved only *by traffic*: under an idle source they freeze at their last value, so a dead stream reads identical to a healthy one. `time() - last_flush_timestamp_seconds` is immune — the flush timestamp stops advancing either way. Two new alert rules encode this (`BintrailNothingBecomingRecoverable`, `BintrailCommitLatencyHigh`).

**`replication_lag` keeps its rules and its section**, relabelled receive-time with a pointer to the recoverability alert. Its semantics did not change and neither should anyone's dashboards.

**The offline half**: the freshness verdict and `--fail-on-lag` in `rotation-and-status.md`, including why `idle` exists — from the index alone a quiet source and a capture an hour behind are the same observation — and that the age check is traffic-sensitive by construction.

## Scope note

The issue named `streaming.md` + `deployment.md`. `observability.md` turned out to be the primary metrics doc and held both misleading alert examples, and `rotation-and-status.md`'s Stream sample output had gone **stale** when #1226 added the `Freshness:` line. Correcting those is completing the stated scope ("clarify `replication_lag` vs the new metrics"), not widening it — leaving them would have left the repo contradicting itself.

## Test plan

- [x] Docs-only diff; `go build ./...` and `go test ./... -count=1` clean
- [x] **Every sample and verdict string verified against the built binary**, not transcribed from source

Rather than trusting the prose, I seeded `stream_state` and ran the real `bintrail status`:

```
--- CURRENT ---
  Freshness:       current — newest indexed event is 3s old
--- IDLE ---
  Freshness:       idle — checkpointing, newest indexed event is 2h0m0s old
                   (no traffic and capture falling behind look identical from the index;
--- STALLED ---
  Freshness:       ⚠ STALLED — no checkpoint for 3h0m0s (the ticker runs even with no traffic,
--- JSON ---
{"status":"stalled","checkpoint_age_seconds":10800,"newest_event_age_seconds":7200}
```

`--fail-on-lag 15m` exits **1** on the stall with the documented message; unset it exits **0**. The `current — newest indexed event is 3s old` line in the doc sample is that output verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
