### PR TITLE
console: neutralize CSV formula injection in the events export (#965)

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1378,7 +1378,10 @@ function downloadBlob(filename, content, mime) {
 }
 function csvCell(v) {
   if (v === null || v === undefined) return "";
-  const s = typeof v === "object" ? JSON.stringify(v) : String(v);
+  let s = typeof v === "object" ? JSON.stringify(v) : String(v);
+  // Formula-injection guard (OWASP): a leading =, +, -, @, tab or CR would be
+  // interpreted as a formula by Excel/Sheets — prefix a quote to neutralize.
+  if (/^[=+\-@\t\r]/.test(s)) s = "'" + s;
   return /[",\r\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
 }
 function downloadEventsJSON(events) {

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -549,6 +549,31 @@ try {
   extv.staleAborted ? ok("ext-view: a server switch mid-import abandons the render (serverGen staleness)") : bad("ext-view: a server switch mid-import abandons the render (serverGen staleness)", "render ran after the switch");
 
 
+  // Scenario 11 — CSV formula-injection guard (#965). The events CSV export
+  // includes attacker-controlled values (pk_values/row_before/row_after from
+  // the monitored DB); a leading =, +, -, @, tab or CR must be neutralized
+  // with a leading quote or Excel/Sheets executes it on open. Calls the REAL
+  // embedded csvCell — deleting the guard line in app.js turns this red.
+  const csv = await page.evaluate(() => ({
+    formula: csvCell("=HYPERLINK(\"http://evil.example\",\"click\")"),
+    plus: csvCell("+1"),
+    minus: csvCell("-2"),
+    at: csvCell("@cmd"),
+    tab: csvCell("\tx"),
+    cr: csvCell("\rx"),
+    plain: csvCell("hello"),
+    number: csvCell(42),
+    quoted: csvCell('a,"b'),
+    objFormula: csvCell({ id: 1 }), // JSON starts with { — must NOT be prefixed
+  }));
+  csv.formula === '"\'=HYPERLINK(""http://evil.example"",""click"")"' ? ok("csv: leading = is quote-prefixed (and CSV-quoted)") : bad("csv: leading = is quote-prefixed (and CSV-quoted)", csv.formula);
+  csv.plus === "'+1" && csv.minus === "'-2" && csv.at === "'@cmd" ? ok("csv: leading +/-/@ are quote-prefixed") : bad("csv: leading +/-/@ are quote-prefixed", JSON.stringify([csv.plus, csv.minus, csv.at]));
+  csv.tab === "'\tx" ? ok("csv: leading tab is quote-prefixed") : bad("csv: leading tab is quote-prefixed", JSON.stringify(csv.tab));
+  csv.cr === '"\'\rx"' ? ok("csv: leading CR is quote-prefixed and still CSV-quoted") : bad("csv: leading CR is quote-prefixed and still CSV-quoted", JSON.stringify(csv.cr));
+  csv.plain === "hello" && csv.number === "42" ? ok("csv: benign values pass through untouched") : bad("csv: benign values pass through untouched", JSON.stringify([csv.plain, csv.number]));
+  csv.quoted === '"a,""b"' ? ok("csv: existing quoting logic unchanged") : bad("csv: existing quoting logic unchanged", JSON.stringify(csv.quoted));
+  csv.objFormula === '"{""id"":1}"' ? ok("csv: JSON object cells are not prefixed") : bad("csv: JSON object cells are not prefixed", JSON.stringify(csv.objFormula));
+
   // No uncaught JS errors over the whole run.
   jsErrors.length === 0 ? ok("no uncaught JS errors") : bad("no uncaught JS errors", JSON.stringify(jsErrors));
 } catch (err) {


### PR DESCRIPTION
Fixes #965

## Problem

`csvCell` in `internal/console/assets/app.js` only applied RFC-4180 quoting (`/[",\r\n]/`). A cell starting with `=`, `+`, `-`, `@`, tab, or CR reached the exported file verbatim. The events CSV export includes `pk_values`/`row_before`/`row_after` — data written by whoever writes to the monitored database — so a planted `=HYPERLINK(...)` executes when the export is opened in Excel or Google Sheets.

## Fix

OWASP CSV-injection mitigation: if the stringified cell starts with one of the trigger characters, prefix a single quote `'` **before** the existing quoting logic. One guard line; the quoting/escaping behavior for all other values is unchanged, and the JSON export (`downloadEventsJSON`) never goes through `csvCell`.

## Test

The console frontend's real harness is the headless-Chrome e2e (`test/console-e2e/console_e2e.mjs`); there is no node unit-test precedent for `assets/*.js`. Added Scenario 11, which calls the **embedded** `csvCell` in the loaded page (same bare-name `page.evaluate` pattern the suite already uses) and asserts:

- leading `=`/`+`/`-`/`@`/tab/CR are quote-prefixed (the `=HYPERLINK` case also keeps its CSV quoting),
- benign strings/numbers pass through untouched,
- existing quote/comma escaping is byte-identical,
- JSON-object cells (start with `{`) are not prefixed.

Mutation-checked: deleting the guard line makes the formula assertion fail. Full suite: 78/78 pass locally. `go build ./...` and `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
