### PR TITLE
ci: pin actions to commit SHAs and scope write permissions per job

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Keep the SHA-pinned actions in .github/workflows/ receiving update PRs.
+# Actions are pinned to full commit SHAs (immutable — a hijacked tag can't
+# swap the code we run); Dependabot understands the `sha # vX.Y.Z` comment
+# convention and bumps both together.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# Default for every job: read-only. The `changes` job overrides with the
+# pull-requests read it needs for dorny/paths-filter.
+permissions:
+  contents: read
+
 jobs:
   # Detects which parts of the tree changed so the expensive jobs below can
   # skip themselves on PRs that can't possibly affect them (e.g. a console
@@ -38,8 +43,8 @@ jobs:
       go: ${{ steps.filter.outputs.go }}
       console: ${{ steps.filter.outputs.console }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3.0.4
         id: filter
         with:
           filters: |
@@ -62,9 +67,9 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
@@ -126,10 +131,10 @@ jobs:
       # on a skipped run, leaving those required checks permanently pending.
       # Step-level `if:` lets the matrix still expand into both contexts;
       # each just completes instantly with every step skipped.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         if: github.event_name == 'push' || needs.changes.outputs.go == 'true'
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         if: github.event_name == 'push' || needs.changes.outputs.go == 'true'
         with:
           go-version-file: go.mod
@@ -235,9 +240,9 @@ jobs:
       BINTRAIL_REQUIRE_MARIADB: "1"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
@@ -333,10 +338,10 @@ jobs:
     steps:
       # Step-level (not job-level) `if:` — see the note on the `integration`
       # job above; this job's matrix has the same requirement.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         if: github.event_name == 'push' || needs.changes.outputs.go == 'true'
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         if: github.event_name == 'push' || needs.changes.outputs.go == 'true'
         with:
           go-version-file: go.mod
@@ -424,13 +429,13 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.go == 'true' || needs.changes.outputs.console == 'true'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
 
@@ -472,7 +477,7 @@ jobs:
 
       - name: Upload failure screenshot
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: console-e2e-failure
           path: |

--- a/.github/workflows/demo-image.yml
+++ b/.github/workflows/demo-image.yml
@@ -26,10 +26,10 @@ on:
         required: true
         type: string
 
+# Default for every job: read-only. packages:write lives on the two jobs
+# that push to ghcr.io; id-token:write only on `merge`, which cosign-signs.
 permissions:
   contents: read
-  packages: write
-  id-token: write # cosign keyless signing via GitHub OIDC
 
 env:
   IMAGE: ghcr.io/dbtrail/bintrail-demo
@@ -42,6 +42,9 @@ jobs:
   # multi-arch manifest list. (Docker's documented multi-runner pattern.)
   build:
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write # push per-arch images by digest to ghcr.io
     strategy:
       fail-fast: false
       matrix:
@@ -56,28 +59,28 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
         run: echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           # On dispatch, build the tag's tree (checkout fails loudly if
           # the input names a tag that doesn't exist). On tag push this
           # is the pushed ref anyway.
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.IMAGE }}
 
       - id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: demo/image/Dockerfile
@@ -104,7 +107,7 @@ jobs:
           mkdir -p "${{ runner.temp }}/digests"
           touch "${{ runner.temp }}/digests/${DIGEST#sha256:}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -114,25 +117,28 @@ jobs:
   merge:
     runs-on: ubuntu-22.04
     needs: build
+    permissions:
+      packages: write # push the merged manifest list to ghcr.io
+      id-token: write # cosign keyless signing via GitHub OIDC
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: sigstore/cosign-installer@v3
+      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.IMAGE }}
           tags: |

--- a/.github/workflows/managed-pg-smoke.yml
+++ b/.github/workflows/managed-pg-smoke.yml
@@ -52,9 +52,9 @@ jobs:
       NAME: bintrail-pg-smoke-${{ github.run_id }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/oss-firewall.yml
+++ b/.github/workflows/oss-firewall.yml
@@ -11,11 +11,14 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Forbid private-module references
         run: |
           fail=0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,10 +5,10 @@ on:
     tags:
       - "v*"
 
+# Default for every job: read-only. The write grants (contents/packages/
+# id-token) live on the `release` job only — the sole job that publishes.
 permissions:
-  contents: write   # create the GitHub release + upload assets
-  packages: write   # push images to ghcr.io
-  id-token: write   # cosign keyless signing via OIDC
+  contents: read
 
 jobs:
   # --- Integration matrix, run against the TAGGED ref itself -----------------
@@ -43,9 +43,7 @@ jobs:
   # names, matrix versions), port the change here too.
   integration-mysql:
     runs-on: ubuntu-22.04
-    # Job-level permissions override the workflow-level grant (contents:write,
-    # packages:write, id-token:write — needed only by the `release` job's
-    # publish steps). These test jobs only need read access to the tagged ref.
+    # These test jobs only need read access to the tagged ref.
     permissions:
       contents: read
 
@@ -65,9 +63,9 @@ jobs:
       BINTRAIL_REQUIRE_MYSQL: "1"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
@@ -130,9 +128,9 @@ jobs:
       BINTRAIL_REQUIRE_MARIADB: "1"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
@@ -207,9 +205,9 @@ jobs:
       BINTRAIL_REQUIRE_POSTGRES: "1"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
@@ -274,14 +272,18 @@ jobs:
   release:
     needs: [integration-mysql, integration-mariadb-source, integration-postgres-source]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write   # create the GitHub release + upload assets
+      packages: write   # push images to ghcr.io
+      id-token: write   # cosign keyless signing via OIDC
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
 
@@ -293,13 +295,13 @@ jobs:
       # QEMU lets the amd64 runner execute the arm64 image's RUN layer
       # (apt-get + useradd) when GoReleaser builds linux/arm64.
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -307,16 +309,16 @@ jobs:
 
       # Required by the .goreleaser.yaml signs/docker_signs/sboms blocks.
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Run tests
         run: go test ./...
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: "~> v2"
           args: release --clean


### PR DESCRIPTION
Hardens the GitHub Actions supply chain per #973.

**Problem**: `release.yaml` granted `contents`/`packages`/`id-token: write` at workflow scope, and every action in every workflow was pinned to a mutable tag (`@v3`, `@v6`, `@v0`, …). A hijacked action tag running in a job with `id-token: write` could mint a Sigstore certificate identifying as this repo's release workflow and sign arbitrary artifacts.

**Changes**:
- **SHA-pin every `uses:`** in all five workflows (`release.yaml`, `ci.yml`, `demo-image.yml`, `managed-pg-smoke.yml`, `oss-firewall.yml`) to the full 40-char commit SHA of the tag currently in use, with the resolved version as a trailing comment. No action's major line changes; notably `sigstore/cosign-installer` stays on v3 (pinned at v3.9.1).
- **Least-privilege permissions**: every workflow now defaults to `permissions: contents: read`. Write grants move to the only jobs that publish:
  - `release.yaml` → `release` job: `contents: write` + `packages: write` + `id-token: write` (GoReleaser release + GHCR push + cosign). The integration test jobs keep their explicit `contents: read`.
  - `demo-image.yml` → `build` job: `packages: write` (digest push); `merge` job: `packages: write` + `id-token: write` (manifest push + cosign signing). `build` no longer gets `id-token` at all.
  - `ci.yml` / `oss-firewall.yml`: read-only default added (the `changes` job keeps its `pull-requests: read` for `dorny/paths-filter`); `managed-pg-smoke.yml` already had `contents: read`.
- **Dependabot**: new `.github/dependabot.yml` with a weekly `github-actions` entry so pinned SHAs keep receiving update PRs (Dependabot bumps the SHA and the version comment together).

**No behavior change**: the diff is exclusively `uses:` pins, permissions blocks, and comments. `actionlint` reports only pre-existing shellcheck infos in untouched `run:` scripts.

Fixes #973

🤖 Generated with [Claude Code](https://claude.com/claude-code)
