### PR TITLE
console: server timeouts, JSON body caps, CSP, and probe logging (#848)

### DIFF
--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -284,7 +284,7 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 	}
 	var body recoverRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
-		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeBodyDecodeError(w, err)
 		return
 	}
 	p := filterParams{
@@ -800,6 +800,20 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		slog.Error("console: JSON encode failed", "error", err)
 	}
+}
+
+// writeBodyDecodeError maps a request-body decode failure onto a response:
+// 413 when the apiGuard size cap tripped (MaxBytesReader makes json.Decode
+// return *http.MaxBytesError), 400 for malformed JSON. The 413 message is
+// static — the overflow error must not surface internals.
+func writeBodyDecodeError(w http.ResponseWriter, err error) {
+	var tooLarge *http.MaxBytesError
+	if errors.As(err, &tooLarge) {
+		writeJSONError(w, http.StatusRequestEntityTooLarge,
+			fmt.Sprintf("request body too large (limit %d bytes)", tooLarge.Limit))
+		return
+	}
+	writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
 }
 
 func writeJSONError(w http.ResponseWriter, status int, msg string) {

--- a/internal/console/auth.go
+++ b/internal/console/auth.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/dbtrail/dbtrail/ext"
 )
@@ -121,16 +122,60 @@ func (s *Server) tokenMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// securityHeaders sets three static response headers on everything:
+// maxAPIBody caps authenticated JSON request bodies (#848). 1 MiB is far
+// above any legitimate console request (the largest are recover filters and
+// server CRUD payloads, well under a kilobyte) while keeping a leaked
+// automation token from buffering a multi-GB JSON string in the watch
+// daemon's heap — which shares the process with the capture stream. The
+// pre-auth login/setup bodies have their own tighter cap (maxLoginBody).
+const maxAPIBody = 1 << 20
+
+// apiGuard runs after authentication on every /api handler. It does two
+// things (#848):
+//
+//   - caps the request body at maxAPIBody, so json.Decode fails with
+//     *http.MaxBytesError on overflow (writeBodyDecodeError maps it to 413);
+//   - clears the connection read deadline armed by the server-wide
+//     ReadTimeout. That timeout exists to bound unauthenticated slow-drip
+//     connections; several authenticated handlers (recover, verify explain,
+//     reconstruct over S3 archives) legitimately run past it, and net/http's
+//     background read hitting the deadline cancels the request context
+//     mid-flight. Best-effort: recorders and non-deadline writers just skip
+//     it.
+func apiGuard(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxAPIBody)
+		_ = http.NewResponseController(w).SetReadDeadline(time.Time{})
+		next.ServeHTTP(w, r)
+	})
+}
+
+// securityHeaders sets four static response headers on everything:
 // Referrer-Policy keeps the ?token= bootstrap URL out of Referer headers,
-// nosniff hardens the embedded assets, and DENY blocks framing the login
-// overlay (clickjacking).
+// nosniff hardens the embedded assets, DENY blocks framing the login
+// overlay (clickjacking), and the CSP freezes the frontend's no-inline-script
+// invariant structurally (#848) — app.js builds the DOM with el()/textContent
+// and never innerHTML, so even a stored-XSS payload smuggled through source
+// data (row images, schema/table names, source error messages) has no
+// executable sink, and script-src 'self' guarantees that stays true.
+//
+// The CSP value matches what the embedded frontend actually needs:
+// script-src 'self' (index.html has exactly one <script src="app.js">, no
+// inline scripts; extension views load as same-origin module imports);
+// style-src needs 'unsafe-inline' (index.html carries a <style> block and
+// inline style attributes, including on the DOMParser-built SVG icons);
+// img-src needs data: (style.css embeds data:image/svg+xml select arrows);
+// frame-ancestors 'none' restates X-Frame-Options DENY for CSP-first
+// browsers.
 func securityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h := w.Header()
 		h.Set("Referrer-Policy", "no-referrer")
 		h.Set("X-Content-Type-Options", "nosniff")
 		h.Set("X-Frame-Options", "DENY")
+		h.Set("Content-Security-Policy",
+			"default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "+
+				"img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/console/auth.go
+++ b/internal/console/auth.go
@@ -161,7 +161,15 @@ func apiGuard(next http.Handler) http.Handler {
 //
 // The CSP value matches what the embedded frontend actually needs:
 // script-src 'self' (index.html has exactly one <script src="app.js">, no
-// inline scripts; extension views load as same-origin module imports);
+// inline scripts; real extension views are same-origin module imports —
+// ext.ConsoleViewProvider.Script names a URL under the provider's /ext/<ID>/
+// StaticHandler subtree) plus blob:, because dynamically minted module URLs
+// are part of the ext-view import surface (the console-e2e ext-view contract
+// stubs Script() with a blob: ES module, and an embedding build may do the
+// same to hand the SPA a module it assembled client-side). blob: is an
+// acceptable relaxation, not a hole: a blob URL can only be minted by
+// same-origin script that is ALREADY executing, so it cannot serve as an
+// initial injection vector the way 'unsafe-inline' or a remote origin could;
 // style-src needs 'unsafe-inline' (index.html carries a <style> block and
 // inline style attributes, including on the DOMParser-built SVG icons);
 // img-src needs data: (style.css embeds data:image/svg+xml select arrows);
@@ -174,7 +182,7 @@ func securityHeaders(next http.Handler) http.Handler {
 		h.Set("X-Content-Type-Options", "nosniff")
 		h.Set("X-Frame-Options", "DENY")
 		h.Set("Content-Security-Policy",
-			"default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "+
+			"default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; "+
 				"img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'")
 		next.ServeHTTP(w, r)
 	})

--- a/internal/console/hardening_test.go
+++ b/internal/console/hardening_test.go
@@ -43,17 +43,14 @@ func TestSecurityHeadersCSP(t *testing.T) {
 		req := httptest.NewRequest("GET", "http://127.0.0.1:8090"+path, nil)
 		srv.Handler().ServeHTTP(rec, req)
 		csp := rec.Header().Get("Content-Security-Policy")
-		for _, directive := range []string{
-			"default-src 'self'",
-			"script-src 'self'",
-			"style-src 'self' 'unsafe-inline'", // index.html has a <style> block + inline style attrs
-			"img-src 'self' data:",             // style.css embeds data: SVG arrows
-			"connect-src 'self'",
-			"frame-ancestors 'none'",
-		} {
-			if !strings.Contains(csp, directive) {
-				t.Errorf("%s: CSP %q missing directive %q", path, csp, directive)
-			}
+		// Pin the exact value: every directive is load-bearing (see the
+		// securityHeaders comment), and blob: in script-src is what keeps the
+		// ext-view module-import surface (console-e2e scenario 10) alive.
+		const want = "default-src 'self'; script-src 'self' blob:; " +
+			"style-src 'self' 'unsafe-inline'; img-src 'self' data:; " +
+			"connect-src 'self'; frame-ancestors 'none'"
+		if csp != want {
+			t.Errorf("%s: CSP = %q, want %q", path, csp, want)
 		}
 		// script-src must NOT allow inline script — that is the invariant the
 		// header exists to freeze.

--- a/internal/console/hardening_test.go
+++ b/internal/console/hardening_test.go
@@ -1,0 +1,100 @@
+package console
+
+// Console hardening backstops (#848): server timeout posture, the
+// authenticated-API JSON body cap, the CSP header, and the probe log line.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestHTTPServerTimeouts pins the Serve timeout posture: header/read/idle
+// timeouts set, WriteTimeout deliberately absent (it would sever /mcp SSE
+// streams and long recover/verify responses mid-write — see httpServer).
+func TestHTTPServerTimeouts(t *testing.T) {
+	srv := newTestServer(t)
+	hs := srv.httpServer()
+	if hs.ReadHeaderTimeout != 10*time.Second {
+		t.Errorf("ReadHeaderTimeout = %v, want 10s", hs.ReadHeaderTimeout)
+	}
+	if hs.ReadTimeout != 30*time.Second {
+		t.Errorf("ReadTimeout = %v, want 30s (slowloris backstop)", hs.ReadTimeout)
+	}
+	if hs.IdleTimeout != 2*time.Minute {
+		t.Errorf("IdleTimeout = %v, want 2m", hs.IdleTimeout)
+	}
+	if hs.WriteTimeout != 0 {
+		t.Errorf("WriteTimeout = %v, must stay unset (SSE /mcp + long responses)", hs.WriteTimeout)
+	}
+	if hs.Handler == nil {
+		t.Error("httpServer must carry the console mux")
+	}
+}
+
+// TestSecurityHeadersCSP asserts the CSP (and the pre-existing headers) are
+// emitted through the real handler chain, on both an asset and an API route.
+func TestSecurityHeadersCSP(t *testing.T) {
+	srv := newTestServer(t)
+	for _, path := range []string{"/", "/api/healthz"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "http://127.0.0.1:8090"+path, nil)
+		srv.Handler().ServeHTTP(rec, req)
+		csp := rec.Header().Get("Content-Security-Policy")
+		for _, directive := range []string{
+			"default-src 'self'",
+			"script-src 'self'",
+			"style-src 'self' 'unsafe-inline'", // index.html has a <style> block + inline style attrs
+			"img-src 'self' data:",             // style.css embeds data: SVG arrows
+			"connect-src 'self'",
+			"frame-ancestors 'none'",
+		} {
+			if !strings.Contains(csp, directive) {
+				t.Errorf("%s: CSP %q missing directive %q", path, csp, directive)
+			}
+		}
+		// script-src must NOT allow inline script — that is the invariant the
+		// header exists to freeze.
+		if strings.Contains(csp, "script-src 'self' 'unsafe-inline'") {
+			t.Errorf("%s: CSP allows inline script: %q", path, csp)
+		}
+		// The pre-existing headers must survive the addition.
+		if rec.Header().Get("X-Frame-Options") != "DENY" ||
+			rec.Header().Get("X-Content-Type-Options") != "nosniff" ||
+			rec.Header().Get("Referrer-Policy") != "no-referrer" {
+			t.Errorf("%s: pre-existing security headers regressed: %v", path, rec.Header())
+		}
+	}
+}
+
+// TestAPIBodyCapRejectsOversizedJSON sends a syntactically VALID oversized
+// JSON body through the real mux to a representative decode endpoint.
+// Mutation rule: without the MaxBytesReader in apiGuard this body decodes
+// fine (the unknown "pad" field is ignored) and the request proceeds — only
+// the cap can produce the asserted 413.
+func TestAPIBodyCapRejectsOversizedJSON(t *testing.T) {
+	srv := newRegistryServer(t)
+	body := `{"name":"big","host":"127.0.0.1","port":"3306","user":"u","dbname":"d","pad":"` +
+		strings.Repeat("a", maxAPIBody) + `"}`
+	rec, respBody := doServersReq(t, srv, "POST", "/api/servers", body)
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized body: code = %d, want 413", rec.Code)
+	}
+	if !strings.Contains(string(respBody), "request body too large") {
+		t.Errorf("413 body = %s, want the static too-large message", respBody)
+	}
+	// The overflow response must not echo decoder internals or the payload.
+	if strings.Contains(string(respBody), "pad") {
+		t.Errorf("413 body echoed request content: %s", respBody)
+	}
+
+	// A normal-sized request on the same endpoint still works — the cap must
+	// not change behavior for legitimate clients.
+	rec, respBody = doServersReq(t, srv, "POST", "/api/servers",
+		`{"name":"ok","host":"127.0.0.1","port":"3306","user":"u","dbname":"d"}`)
+	if rec.Code != 201 {
+		t.Fatalf("normal body after cap: code = %d, body = %s, want 201", rec.Code, respBody)
+	}
+}

--- a/internal/console/mcp.go
+++ b/internal/console/mcp.go
@@ -132,6 +132,12 @@ func (s *Server) mcpHandler() http.Handler {
 				"unknown server: use /mcp for the default server, or /mcp/{id-or-name} for a server from the console registry")
 			return
 		}
+		// This request has authenticated. Clear the connection read deadline
+		// armed by the server-wide ReadTimeout (#848): a streamable-HTTP SSE
+		// GET hangs open by design, and net/http's background read hitting
+		// that deadline would cancel the stream's context 30s in. Pre-auth
+		// traffic (rejected above by RequireBearerToken) keeps the deadline.
+		_ = http.NewResponseController(w).SetReadDeadline(time.Time{})
 		streamable.ServeHTTP(w, r)
 	}))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -360,9 +366,9 @@ func (s *Server) newMCPServer(id string, pol *ext.AccessPolicy) *mcp.Server {
 		// call from the bundle's FindBaseline exactly like the handler's
 		// cascadeProviderFor(b), baseline parameters rejected like
 		// reconstruct's.
-		RecoverCascade: true,
-		QueryMaxLimit:       func() int { return eventsMaxLimit },
-		RecoverMaxLimit:     recoverMaxLimit,
+		RecoverCascade:  true,
+		QueryMaxLimit:   func() int { return eventsMaxLimit },
+		RecoverMaxLimit: recoverMaxLimit,
 		// #849: the console's /mcp recover tool renders the same reversal
 		// script as /api/recover, in the same shared daemon process — it must
 		// not be left at the Generator's CLI-sized 2 GiB default just because

--- a/internal/console/recover_cascade.go
+++ b/internal/console/recover_cascade.go
@@ -110,7 +110,7 @@ func (s *Server) handleRecoverCascade(w http.ResponseWriter, r *http.Request) {
 
 	var body recoverCascadeRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
-		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeBodyDecodeError(w, err)
 		return
 	}
 

--- a/internal/console/rotation_api.go
+++ b/internal/console/rotation_api.go
@@ -78,7 +78,7 @@ func (s *Server) handleRotationUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	var req rotationRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeBodyDecodeError(w, err)
 		return
 	}
 	retain := strings.TrimSpace(req.Retain)

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -552,7 +552,7 @@ func (s *Server) buildHandler() http.Handler {
 	// authorization (authzMiddleware). authz is inert for policy-less sessions —
 	// the static token, the password login, and every OSS session — so this only
 	// enforces when an EE build attaches a policy via the session-issuer seam.
-	root.Handle("/api/", s.tokenMiddleware(s.authzMiddleware(api)))
+	root.Handle("/api/", s.tokenMiddleware(s.authzMiddleware(apiGuard(api))))
 	// MCP endpoint (#1039): the read-only tools over Streamable HTTP,
 	// token-authenticated (static or UI-managed — #1052), routed per server
 	// by URL path. Carries its own auth check (tokens only, no sessions —
@@ -608,17 +608,39 @@ func (s *Server) Listen() (net.Listener, error) {
 	return net.Listen("tcp", s.listen)
 }
 
+// httpServer builds the http.Server Serve runs. Split out so tests can assert
+// the timeout posture without binding a socket.
+//
+// ReadTimeout bounds a slow-dripped request from an unauthenticated client
+// (slowloris): MaxBytesReader caps body SIZE, not time, so without it a
+// 1-byte-per-minute POST to /api/auth/login would pin a goroutine and an fd
+// forever (#848). Authenticated surfaces that legitimately outlive it — the
+// /api handlers (recover/verify/reconstruct can run long against S3 archives)
+// and /mcp (hanging streamable-HTTP SSE GETs) — clear the connection read
+// deadline once the credential has been verified (see apiGuard and
+// mcpHandler); pre-auth traffic keeps the full deadline.
+//
+// WriteTimeout is deliberately absent: it is a whole-response deadline, and
+// it would sever exactly those long responses and /mcp SSE streams mid-write.
+// IdleTimeout only reaps keep-alive connections BETWEEN requests, so it is
+// safe everywhere.
+func (s *Server) httpServer() *http.Server {
+	return &http.Server{
+		Handler:           s.mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		IdleTimeout:       2 * time.Minute,
+		TLSConfig:         s.tlsConf,
+	}
+}
+
 // Serve serves on ln and blocks until ctx is cancelled, then shuts the server
 // down gracefully (5s drain). It takes ownership of ln (Shutdown closes it).
 // Lazily-opened registry connections are closed on the way out; the boot
 // entry's db belongs to the cmd layer and its deferred Close.
 func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 	defer s.cm.CloseAll()
-	srv := &http.Server{
-		Handler:           s.mux,
-		ReadHeaderTimeout: 10 * time.Second,
-		TLSConfig:         s.tlsConf,
-	}
+	srv := s.httpServer()
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/internal/console/servers_api.go
+++ b/internal/console/servers_api.go
@@ -194,7 +194,7 @@ func (s *Server) handleServersGet(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleServersCreate(w http.ResponseWriter, r *http.Request) {
 	var req serverRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeBodyDecodeError(w, err)
 		return
 	}
 	flavor, err := NormalizeFlavor(req.Flavor)
@@ -276,7 +276,7 @@ func (s *Server) handleServersUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	var req serverRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeBodyDecodeError(w, err)
 		return
 	}
 	dsn, err := buildDSN(req, old.DSN)
@@ -346,7 +346,7 @@ func (s *Server) handleServersUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if dsn != old.DSN {
-		s.cm.evict(id)                    // connection points at the old DSN; close and reopen lazily
+		s.cm.evict(id)                   // connection points at the old DSN; close and reopen lazily
 		s.sessionProfiles.invalidate(id) // its cached profile rules were resolved against the old index (#1075)
 	} else {
 		s.cm.rebuildDerived(entry) // keep the db, recompute baseline/no-archive gates
@@ -567,7 +567,7 @@ func (s *Server) handleServersTest(w http.ResponseWriter, r *http.Request) {
 	// An empty body means "test the stored DSN as-is"; anything else must parse.
 	var req serverRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
-		writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		writeBodyDecodeError(w, err)
 		return
 	}
 
@@ -594,11 +594,34 @@ func isUnknownDatabase(err error) bool {
 	return errors.As(err, &me) && me.Number == 1049
 }
 
-// probeServer runs the write-free reachability probe against one DSN. When
-// monitored is true, an Unknown-database error means the per-source index has
-// not been provisioned yet (Start creates it) rather than an unreachable
-// server, so it is reported as a pending state instead of a hard failure.
+// probeServer runs the write-free reachability probe and logs one structured
+// line per attempt (#848): destination host:port and outcome only, never
+// credentials or the DSN (the error string is already scrubbed by
+// scrubDSNError). The probe connects to an arbitrary host:port taken from the
+// request body, so leaving no trace would make the console a silent
+// internal-network mapping oracle for a leaked automation token. slog, not
+// the ext audit seam: the audit contract (ext/audit.go) covers reads of
+// historical row data, and a connectivity probe returns none.
 func probeServer(r *http.Request, dsn string, monitored bool) testResponse {
+	resp := runProbe(r, dsn, monitored)
+	addr := "<invalid-dsn>"
+	if cfg, err := mysql.ParseDSN(dsn); err == nil {
+		addr = cfg.Addr
+	}
+	slog.Info("console: connection test probe",
+		"addr", addr,
+		"ok", resp.OK,
+		"provision_pending", resp.ProvisionPending,
+		"latency_ms", resp.LatencyMS,
+		"error", resp.Error)
+	return resp
+}
+
+// runProbe is the probe itself. When monitored is true, an Unknown-database
+// error means the per-source index has not been provisioned yet (Start
+// creates it) rather than an unreachable server, so it is reported as a
+// pending state instead of a hard failure.
+func runProbe(r *http.Request, dsn string, monitored bool) testResponse {
 	short, dbName, err := shortTimeoutDSN(dsn)
 	if err != nil {
 		return testResponse{Error: scrubDSNError(err, dsn)}

--- a/internal/console/telemetry_api.go
+++ b/internal/console/telemetry_api.go
@@ -137,7 +137,7 @@ func (s *Server) handleTelemetrySet(w http.ResponseWriter, r *http.Request) {
 		Enabled bool `json:"enabled"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
-		writeJSONError(w, http.StatusBadRequest, "invalid JSON body")
+		writeBodyDecodeError(w, err)
 		return
 	}
 	// A higher-precedence control (DO_NOT_TRACK, --telemetry, or

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -211,7 +211,7 @@ func (s *Server) handleVerifyTrigger(w http.ResponseWriter, r *http.Request) {
 		// EOF = no/empty body = defaults. Any other decode error means the
 		// caller's actual request (e.g. an explicit live-source mode) must
 		// not be silently substituted with the baseline-anchored default.
-		writeJSONError(w, http.StatusBadRequest, "malformed request body: "+err.Error())
+		writeBodyDecodeError(w, err)
 		return
 	}
 	mode := VerifyModeBaselineAnchored

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -451,10 +451,12 @@ try {
   // nav item appears, the route "ext-<id>" mounts the module and calls its
   // render(mount, {apiBase, api}), and a server switch both drops the nav item
   // and abandons an in-flight render (serverGen staleness). Script() is stubbed
-  // with a blob-URL ES module — a same-document dynamic import, which works only
-  // because the console sets no Content-Security-Policy (the invariant documented
-  // on ext.ConsoleViewProvider.Script; a script-src CSP without 'self'/blob:
-  // would break this and every real extension view).
+  // with a blob-URL ES module — a same-document dynamic import, which works
+  // because the console's Content-Security-Policy allows script-src 'self'
+  // blob: (securityHeaders, #848); real extension views are same-origin
+  // ('self', ext.ConsoleViewProvider.Script), and blob: keeps this stub and
+  // client-side-minted module URLs importable. Dropping blob: from script-src
+  // breaks this scenario — that is the contract this test pins.
   const extv = await page.evaluate(async () => {
     const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
     const modURL = (marker) => URL.createObjectURL(new Blob(


### PR DESCRIPTION
Fixes #848

Four backstops from the console hardening cluster; none changes behavior for legitimate clients.

## 1. HTTP server timeouts (`internal/console/server.go`)

The single `http.Server` construction site (`Serve`, now via a testable `httpServer()` helper) gains:

- `ReadTimeout: 30s` — the slowloris backstop: `MaxBytesReader` caps body **size**, not time, so a 1-byte-per-minute unauthenticated `POST /api/auth/login` would otherwise pin a goroutine+fd forever.
- `IdleTimeout: 2m` — reaps keep-alive connections between requests.
- **`WriteTimeout` deliberately unset**: `/mcp` is `mcp.NewStreamableHTTPHandler` — hanging SSE GETs are its design — and recover/verify/reconstruct responses can legitimately run long against S3 archives. A whole-response deadline would sever both.

Go's `ReadTimeout` is a whole-connection read deadline: net/http's background read hitting it **cancels the request context** of any still-running handler. So authenticated surfaces that legitimately outlive 30s clear the connection read deadline post-auth (`http.NewResponseController(w).SetReadDeadline(time.Time{})`): `apiGuard` for `/api` (after `tokenMiddleware`), and the `/mcp` handler after `RequireBearerToken`. Pre-auth traffic keeps the full deadline, which is where the slowloris risk lives. The flashback port is MySQL-protocol, untouched.

## 2. JSON body caps

`apiGuard` (new middleware between `authzMiddleware` and the api mux) wraps every authenticated `/api` request body in `http.MaxBytesReader(w, r.Body, 1<<20)` — structural, so future handlers are covered too. Endpoints with a `json.Decode` this reaches:

- `POST /api/recover`, `POST /api/recover-cascade`
- `POST /api/servers`, `PUT /api/servers/{id}`, `POST /api/servers[/{id}]/test`
- `POST /api/servers/{id}/verify` (verify trigger)
- `PUT /api/rotation`, `POST /api/telemetry`
- (plus the mcp-token and extension-view data routes on the same mux)

Pre-auth `POST /api/auth/setup|login` and `/api/auth/password` already had a tighter 4 KiB cap (`requireJSONBody`, `maxLoginBody`) with 413 mapping — unchanged. All eight uncapped decode sites now route errors through a shared `writeBodyDecodeError`: `*http.MaxBytesError` → **static 413** ("request body too large (limit N bytes)", no internals), anything else → 400 exactly as before.

## 3. CSP (`securityHeaders`, `internal/console/auth.go`)

```
Content-Security-Policy: default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'
```

How the frontend was verified to survive it (exhaustive static inspection of the embedded assets — `index.html`, `app.js`, `style.css`, the only assets besides two PNGs):

- **script-src 'self' blob:**: exactly one `<script>` tag in `index.html` (`src="app.js"`), zero inline scripts, zero inline event handlers (`onclick=` etc. grepped exhaustively — none). `app.js` has no `eval`/`new Function`; its one dynamic `import(view.script)` loads extension-view modules — real providers serve them same-origin from the unauthenticated `/ext/<id>/` StaticHandler (`'self'`), and `blob:` covers the ext-view import surface the console-e2e contract pins (scenario 10 stubs `Script()` with a blob-URL ES module; Chrome refuses blob: dynamic imports under bare `'self'`). blob: is not an injection vector: a blob URL can only be minted by same-origin script that is already executing. The decorative SVG strings go through `DOMParser` (`image/svg+xml`), which never executes script.
- **style-src 'self' 'unsafe-inline'** is required: `index.html` carries a `<style>` block and inline `style="…"` attributes (including on the DOMParser-built SVG icons). JS `el.style.prop = …` (CSSOM) is not CSP-restricted.
- **img-src 'self' data:** is required: `style.css` embeds two `data:image/svg+xml` select arrows.
- No external fonts/CDN/`@import`; all `fetch()` calls are same-origin `/api` (`connect-src 'self'`); the events JSON/CSV export uses an `<a download>` on a Blob URL — a download, not a resource load, unaffected by CSP.
- `frame-ancestors 'none'` restates the existing `X-Frame-Options: DENY` for CSP-first browsers.

Verified live: `make console-e2e` against the local Docker MySQL — 71/71 pass in headless Chrome under the final header (this suite is what caught the blob: gap in the first push).

## 4. Probe logging (`servers_api.go`)

`probeServer` now emits one structured slog line per `POST /api/servers[/{id}]/test` attempt: `addr` (host:port from the parsed DSN), `ok`, `provision_pending`, `latency_ms`, and the **already-scrubbed** error (same `scrubDSNError` posture — never credentials or the DSN). slog, not the `ext` audit seam: `ext/audit.go` scopes auditing to reads of historical row data, and a connectivity probe returns none — confirmed against the "Deliberately NOT audited" list before choosing slog.

## Tests

`internal/console/hardening_test.go`:
- `TestHTTPServerTimeouts` — pins ReadHeader/Read/Idle values and asserts `WriteTimeout` stays 0.
- `TestSecurityHeadersCSP` — through the real handler chain on `/` and `/api/healthz`; also asserts script-src does NOT carry `'unsafe-inline'` and the pre-existing headers survive.
- `TestAPIBodyCapRejectsOversizedJSON` — a syntactically **valid** >1 MiB JSON body to `POST /api/servers` through the real mux must 413 with the static message (removing the `MaxBytesReader` makes the body decode fine and the test go red), and a normal-sized create on the same endpoint still returns 201.

`go build ./...`, `go vet ./...`, `go vet -tags integration` on the touched packages, and `go test ./internal/console/... ./consoleapp/... -count=1 -race` all pass. No exported signatures changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
