### PR TITLE
dump/baseline: authenticate encrypted dumps with an HMAC-SHA256 sidecar

### DIFF
--- a/cliapp/baseline.go
+++ b/cliapp/baseline.go
@@ -58,7 +58,7 @@ func init() {
 	baselineCmd.Flags().StringVar(&bslBaselineRetain, "baseline-retain", "", "Prune local snapshots older than this (Nd/Nh) once a durable S3 copy exists (requires --upload; never deletes the only copy or the newest snapshot per table)")
 	baselineCmd.Flags().StringVar(&bslFormat, "format", "text", "Output format: text or json")
 	baselineCmd.Flags().BoolVar(&bslRetry, "retry", false, "Skip tables whose output Parquet file already exists and S3 objects that were already uploaded")
-	baselineCmd.Flags().BoolVar(&bslEncrypt, "encrypt", false, "Decrypt encrypted dump files before processing (requires openssl on $PATH)")
+	baselineCmd.Flags().BoolVar(&bslEncrypt, "encrypt", false, "Decrypt encrypted dump files before processing, verifying each file's .enc.hmac integrity sidecar first (requires openssl on $PATH)")
 	baselineCmd.Flags().StringVar(&bslEncryptKey, "encrypt-key", "", "Path to encryption key file (default: ~/.config/bintrail/dump.key)")
 	_ = baselineCmd.MarkFlagRequired("input")
 	_ = baselineCmd.MarkFlagRequired("output")
@@ -222,10 +222,24 @@ func resolveBaselineRetain(retainRaw, upload string) (retain time.Duration, doPr
 // decryptDumpFiles walks inputDir and decrypts every .enc file using openssl,
 // writing the decrypted output alongside with the .enc extension stripped.
 // Returns a cleanup function that removes the decrypted files.
+//
+// Before decrypting each file it verifies the HMAC-SHA256 sidecar written by
+// `bintrail dump --encrypt` (#960): CBC gives no authentication, so a tampered
+// or bit-rotted .enc would otherwise decrypt into garbled SQL that flows
+// silently into the baseline. A sidecar mismatch is a hard error and the file
+// is never handed to openssl; a MISSING sidecar (legacy pre-sidecar dump) only
+// warns, so existing dumps keep working. The `.enc.hmac` sidecars themselves
+// do not end in ".enc" and are skipped by the walk.
 func decryptDumpFiles(inputDir, keyPath string) (func(), error) {
 	absKey, err := filepath.Abs(keyPath)
 	if err != nil {
 		return nil, fmt.Errorf("resolve key path: %w", err)
+	}
+
+	// Raw key bytes double as the HMAC key. Read in-process — never on argv.
+	hmacKey, err := readHMACKey(absKey)
+	if err != nil {
+		return nil, err
 	}
 
 	entries, err := os.ReadDir(inputDir)
@@ -246,6 +260,16 @@ func decryptDumpFiles(inputDir, keyPath string) (func(), error) {
 		}
 		encPath := filepath.Join(inputDir, e.Name())
 		outPath := strings.TrimSuffix(encPath, ".enc")
+
+		hadSidecar, verr := verifyEncFileHMAC(encPath, hmacKey)
+		if verr != nil {
+			cleanup()
+			return nil, verr
+		}
+		if !hadSidecar {
+			slog.Warn("no .hmac sidecar for encrypted dump file — legacy unauthenticated dump, integrity cannot be verified",
+				"file", e.Name())
+		}
 
 		cmd := exec.Command("openssl", "enc", "-d", "-aes-256-cbc", "-pbkdf2",
 			"-pass", "file:"+absKey, "-in", encPath, "-out", outPath)

--- a/cliapp/dump.go
+++ b/cliapp/dump.go
@@ -60,7 +60,7 @@ func init() {
 	dumpCmd.Flags().StringVar(&dmpMydumperImage, "mydumper-image", "mydumper/mydumper:latest", "Docker image for mydumper (used when no local binary is found)")
 	dumpCmd.Flags().IntVar(&dmpThreads, "threads", 4, "Number of mydumper dump threads")
 	dumpCmd.Flags().StringVar(&dmpFormat, "format", "text", "Output format: text or json")
-	dumpCmd.Flags().BoolVar(&dmpEncrypt, "encrypt", false, "Encrypt dump files at rest using AES-256-CBC (requires openssl on $PATH)")
+	dumpCmd.Flags().BoolVar(&dmpEncrypt, "encrypt", false, "Encrypt dump files at rest using AES-256-CBC and write an HMAC-SHA256 integrity sidecar (<file>.enc.hmac) per file (requires openssl on $PATH)")
 	dumpCmd.Flags().StringVar(&dmpEncryptKey, "encrypt-key", "", "Path to encryption key file (default: ~/.config/bintrail/dump.key; generate with 'bintrail generate-key')")
 	_ = dumpCmd.MarkFlagRequired("source-dsn")
 	_ = dumpCmd.MarkFlagRequired("output-dir")
@@ -341,6 +341,25 @@ func runDump(cmd *cobra.Command, args []string) error {
 	if err := baseline.WriteStartedAtMarker(dmpOutputDir, dumpStartedAt); err != nil {
 		slog.Warn("could not write dump-start marker; baseline conversion will fall back to mydumper's local-time 'Started dump at' line",
 			"output_dir", dmpOutputDir, "error", err)
+	}
+
+	// CBC gives no authentication (#960): authenticate every encrypted file
+	// with an HMAC-SHA256 sidecar so `bintrail baseline --encrypt` can refuse
+	// a tampered/bit-rotted .enc instead of decrypting it into garbled SQL.
+	// A failure here is a hard error — an unauthenticated encrypted dump is
+	// exactly what this step exists to prevent — but the dump directory is
+	// kept (dumpSucceeded is already true) so the operator can retry.
+	if encryptKeyPath != "" {
+		key, err := readHMACKey(encryptKeyPath)
+		if err != nil {
+			return err
+		}
+		n, err := writeDumpHMACSidecars(dmpOutputDir, key)
+		if err != nil {
+			return fmt.Errorf("write HMAC integrity sidecars: %w", err)
+		}
+		slog.Info("wrote HMAC-SHA256 integrity sidecars for encrypted dump files",
+			"files", n, "output_dir", dmpOutputDir)
 	}
 
 	if dmpFormat == "json" {

--- a/cliapp/dumpintegrity.go
+++ b/cliapp/dumpintegrity.go
@@ -1,0 +1,120 @@
+package cliapp
+
+// Integrity authentication for encrypted dump files (#960).
+//
+// `openssl enc -aes-256-cbc` gives confidentiality but NO authentication: a
+// tampered or bit-rotted .enc file decrypts "successfully" to garbled SQL that
+// would flow silently into baseline conversion and everything downstream of it
+// (reconstruct, recover). `openssl enc` does not support AEAD modes (GCM), so
+// the fix is encrypt-then-MAC: after mydumper completes, every .enc file gets
+// an HMAC-SHA256 sidecar (`<name>.enc.hmac`, lowercase hex digest) keyed with
+// the raw bytes of the encryption key file. `bintrail baseline --encrypt`
+// verifies the sidecar BEFORE decrypting; a mismatch is a hard error (the file
+// is never decrypted), a missing sidecar (pre-fix legacy dump) is a warning
+// and decryption proceeds for backward compatibility.
+//
+// The key bytes are read in-process only — they never appear on argv or in the
+// environment.
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// hmacSidecarSuffix is appended to the encrypted file name, so a sidecar for
+// `mydb.orders.00000.sql.enc` is `mydb.orders.00000.sql.enc.hmac`. Sidecars do
+// not end in ".enc", so the decrypt walk in decryptDumpFiles never tries to
+// decrypt them, and the baseline converter's mydumper-pattern matching ignores
+// them.
+const hmacSidecarSuffix = ".hmac"
+
+// readHMACKey reads the raw bytes of the encryption key file for use as the
+// HMAC key. Kept as a helper so every call site gets the same error framing.
+func readHMACKey(keyPath string) ([]byte, error) {
+	key, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read encryption key for HMAC: %w", err)
+	}
+	if len(key) == 0 {
+		return nil, fmt.Errorf("encryption key file %s is empty", keyPath)
+	}
+	return key, nil
+}
+
+// computeFileHMAC streams path through HMAC-SHA256 keyed with key and returns
+// the lowercase hex digest.
+func computeFileHMAC(path string, key []byte) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open %s for HMAC: %w", path, err)
+	}
+	defer f.Close()
+
+	mac := hmac.New(sha256.New, key)
+	if _, err := io.Copy(mac, f); err != nil {
+		return "", fmt.Errorf("read %s for HMAC: %w", path, err)
+	}
+	return hex.EncodeToString(mac.Sum(nil)), nil
+}
+
+// writeDumpHMACSidecars walks dir and writes a `<name>.enc.hmac` sidecar for
+// every `.enc` file, returning how many were written. Called by `bintrail dump`
+// after mydumper completes successfully with --encrypt.
+func writeDumpHMACSidecars(dir string, key []byte) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, fmt.Errorf("read dump directory: %w", err)
+	}
+
+	written := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".enc") {
+			continue
+		}
+		encPath := filepath.Join(dir, e.Name())
+		digest, err := computeFileHMAC(encPath, key)
+		if err != nil {
+			return written, err
+		}
+		sidecar := encPath + hmacSidecarSuffix
+		if err := os.WriteFile(sidecar, []byte(digest+"\n"), 0o600); err != nil {
+			return written, fmt.Errorf("write HMAC sidecar %s: %w", sidecar, err)
+		}
+		written++
+	}
+	return written, nil
+}
+
+// verifyEncFileHMAC checks encPath against its `.hmac` sidecar.
+//
+// Returns (false, nil) when no sidecar exists — a legacy dump written before
+// sidecars existed; the caller warns and proceeds. Returns an error (and never
+// asks the caller to decrypt) when the sidecar exists but the recomputed
+// HMAC-SHA256 does not match.
+func verifyEncFileHMAC(encPath string, key []byte) (hadSidecar bool, err error) {
+	sidecar := encPath + hmacSidecarSuffix
+	want, err := os.ReadFile(sidecar)
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read HMAC sidecar %s: %w", sidecar, err)
+	}
+
+	got, err := computeFileHMAC(encPath, key)
+	if err != nil {
+		return true, err
+	}
+	if !hmac.Equal([]byte(got), []byte(strings.TrimSpace(string(want)))) {
+		return true, fmt.Errorf("integrity check failed for %s: HMAC-SHA256 mismatch with its .hmac sidecar — the encrypted file was modified after the dump (or a different --encrypt-key is in use); refusing to decrypt it", filepath.Base(encPath))
+	}
+	return true, nil
+}

--- a/cliapp/dumpintegrity_test.go
+++ b/cliapp/dumpintegrity_test.go
@@ -1,0 +1,159 @@
+package cliapp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTestEncDir creates a temp dump dir with one fake .enc file and a key
+// file, returning (dir, encPath, keyPath, key bytes).
+func writeTestEncDir(t *testing.T) (dir, encPath, keyPath string, key []byte) {
+	t.Helper()
+	dir = t.TempDir()
+	encPath = filepath.Join(dir, "mydb.orders.00000.sql.enc")
+	if err := os.WriteFile(encPath, []byte("fake-ciphertext-bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	key = []byte("0123456789abcdef0123456789abcdef")
+	keyPath = filepath.Join(dir, "dump.key")
+	if err := os.WriteFile(keyPath, key, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir, encPath, keyPath, key
+}
+
+func TestHMACSidecarRoundTrip(t *testing.T) {
+	dir, encPath, _, key := writeTestEncDir(t)
+
+	n, err := writeDumpHMACSidecars(dir, key)
+	if err != nil {
+		t.Fatalf("writeDumpHMACSidecars: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("wrote %d sidecars, want 1", n)
+	}
+	if _, err := os.Stat(encPath + hmacSidecarSuffix); err != nil {
+		t.Fatalf("sidecar not written: %v", err)
+	}
+
+	hadSidecar, err := verifyEncFileHMAC(encPath, key)
+	if err != nil {
+		t.Fatalf("verifyEncFileHMAC on untampered file: %v", err)
+	}
+	if !hadSidecar {
+		t.Fatal("hadSidecar = false, want true")
+	}
+}
+
+func TestWriteDumpHMACSidecarsOnlyTargetsEncFiles(t *testing.T) {
+	dir, encPath, _, key := writeTestEncDir(t)
+	// A plaintext mydumper file and a pre-existing sidecar must both be
+	// ignored — no .sql.hmac and no .enc.hmac.hmac.
+	if err := os.WriteFile(filepath.Join(dir, "metadata"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeDumpHMACSidecars(dir, key); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := writeDumpHMACSidecars(dir, key) // second pass sees the sidecar
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("second pass wrote %d sidecars, want 1 (the .enc only)", n)
+	}
+	if _, err := os.Stat(encPath + hmacSidecarSuffix + hmacSidecarSuffix); err == nil {
+		t.Fatal("a sidecar-of-a-sidecar was written")
+	}
+}
+
+func TestVerifyEncFileHMACTampered(t *testing.T) {
+	dir, encPath, _, key := writeTestEncDir(t)
+	if _, err := writeDumpHMACSidecars(dir, key); err != nil {
+		t.Fatal(err)
+	}
+	// Flip content after the sidecar was written.
+	if err := os.WriteFile(encPath, []byte("Take-ciphertext-bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	hadSidecar, err := verifyEncFileHMAC(encPath, key)
+	if !hadSidecar {
+		t.Fatal("hadSidecar = false, want true")
+	}
+	if err == nil || !strings.Contains(err.Error(), "HMAC-SHA256 mismatch") {
+		t.Fatalf("err = %v, want HMAC-SHA256 mismatch", err)
+	}
+	if !strings.Contains(err.Error(), "mydb.orders.00000.sql.enc") {
+		t.Fatalf("error does not name the file: %v", err)
+	}
+}
+
+func TestVerifyEncFileHMACWrongKey(t *testing.T) {
+	dir, encPath, _, key := writeTestEncDir(t)
+	if _, err := writeDumpHMACSidecars(dir, key); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifyEncFileHMAC(encPath, []byte("a different key")); err == nil ||
+		!strings.Contains(err.Error(), "HMAC-SHA256 mismatch") {
+		t.Fatalf("err = %v, want HMAC-SHA256 mismatch", err)
+	}
+}
+
+func TestVerifyEncFileHMACMissingSidecarIsLegacy(t *testing.T) {
+	_, encPath, _, key := writeTestEncDir(t)
+	hadSidecar, err := verifyEncFileHMAC(encPath, key)
+	if err != nil {
+		t.Fatalf("missing sidecar must not error (legacy dump): %v", err)
+	}
+	if hadSidecar {
+		t.Fatal("hadSidecar = true, want false")
+	}
+}
+
+// TestDecryptDumpFilesRefusesTamperedFile drives the REAL production entry
+// point (`bintrail baseline --encrypt` → decryptDumpFiles): a tampered .enc
+// must be refused BEFORE openssl is ever invoked — which also means this test
+// needs no openssl. If the verify call is removed from decryptDumpFiles, the
+// error becomes an openssl failure (or "openssl not found") and the mismatch
+// assertion goes red.
+func TestDecryptDumpFilesRefusesTamperedFile(t *testing.T) {
+	dir, encPath, keyPath, key := writeTestEncDir(t)
+	if _, err := writeDumpHMACSidecars(dir, key); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(encPath, []byte("tampered!"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := decryptDumpFiles(dir, keyPath)
+	if err == nil || !strings.Contains(err.Error(), "HMAC-SHA256 mismatch") {
+		t.Fatalf("decryptDumpFiles err = %v, want HMAC-SHA256 mismatch", err)
+	}
+	// The tampered file must never have been decrypted.
+	if _, statErr := os.Stat(strings.TrimSuffix(encPath, ".enc")); statErr == nil {
+		t.Fatal("tampered file was decrypted despite the HMAC mismatch")
+	}
+}
+
+// The .enc.hmac sidecars themselves must be invisible to the decrypt walk: a
+// directory holding only a sidecar (no .enc) decrypts nothing and succeeds.
+func TestDecryptDumpFilesSkipsSidecars(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "mydb.orders.00000.sql.enc.hmac"), []byte("deadbeef\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keyPath := filepath.Join(dir, "dump.key")
+	if err := os.WriteFile(keyPath, []byte("k"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanup, err := decryptDumpFiles(dir, keyPath)
+	if err != nil {
+		t.Fatalf("decryptDumpFiles: %v", err)
+	}
+	cleanup()
+}

--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -129,9 +129,18 @@ This dumps **every accessible schema** into `/tmp/mydumper-output` — bare `bin
 | `--mydumper-path` | `mydumper` | Path to the mydumper binary. When set, skips Docker fallback. |
 | `--mydumper-image` | `mydumper/mydumper:latest` | Docker image for mydumper. Used only when no local binary is found. |
 | `--threads` | `4` | Number of parallel dump threads |
-| `--encrypt` | `false` | Encrypt dump files at rest using AES-256-CBC (requires `openssl` on `$PATH`) |
+| `--encrypt` | `false` | Encrypt dump files at rest using AES-256-CBC, with an HMAC-SHA256 integrity sidecar per file (requires `openssl` on `$PATH`) |
 | `--encrypt-key` | `~/.config/bintrail/dump.key` | Path to the encryption key file (generate with `bintrail generate-key`) |
 | `--format` | `text` | Output format: `text` or `json` |
+
+### Encryption and integrity (`--encrypt`)
+
+With `--encrypt`, every dump file is piped through `openssl enc -aes-256-cbc -pbkdf2` as mydumper writes it, producing `<file>.enc`. CBC encrypts but does **not** authenticate, so after the dump completes bintrail also writes an HMAC-SHA256 digest of each `.enc` file to a `<file>.enc.hmac` sidecar, keyed with your `--encrypt-key` file. Keep the sidecars next to the `.enc` files (copy/upload them together).
+
+`bintrail baseline --encrypt` verifies each sidecar **before** decrypting:
+
+- **Mismatch** — the `.enc` file was modified (tampering, bit rot, truncated copy) or a different key is in use. This is a **hard error**; the file is never decrypted, so corrupted SQL can't silently flow into your baseline.
+- **Sidecar missing** — a dump made by an older bintrail. Decryption proceeds with a warning (`legacy unauthenticated dump, integrity cannot be verified`). Re-run `bintrail dump --encrypt` to get authenticated dumps.
 
 ### Schema and table filtering
 
@@ -222,7 +231,7 @@ bintrail baseline \
 | `--tables` | *(all)* | Comma-separated `db.table` filter |
 | `--compression` | `zstd` | Parquet compression: `zstd`, `snappy`, `gzip`, `none` |
 | `--row-group-size` | `500000` | Rows per Parquet row group |
-| `--encrypt` | `false` | Decrypt encrypted dump files (`.enc`, from `dump --encrypt`) before processing (requires `openssl` on `$PATH`) |
+| `--encrypt` | `false` | Decrypt encrypted dump files (`.enc`, from `dump --encrypt`) before processing, verifying each file's `.enc.hmac` integrity sidecar first — a mismatch is a hard error, a missing sidecar (legacy dump) warns and proceeds (requires `openssl` on `$PATH`) |
 | `--encrypt-key` | `~/.config/bintrail/dump.key` | Path to the decryption key file |
 | `--upload` | *(disabled)* | S3 URL to upload Parquet files after generation |
 | `--upload-region` | *(from AWS env)* | AWS region for `--upload` |


### PR DESCRIPTION
Fixes #960

## Problem

`dump --encrypt` pipes each mydumper file through `openssl enc -aes-256-cbc -pbkdf2` (via `--exec-per-thread`). CBC provides no authentication: a tampered or bit-rotted `.enc` decrypts without error into garbled SQL that flows silently into `baseline` → `reconstruct`/`recover`. `openssl enc` does not support GCM/AEAD, so switching modes is not implementable with the pipe design — this takes the issue's blessed alternative: encrypt-then-MAC with integrity metadata.

## Design (per-file sidecar, no wire-format change)

- **Encrypt side (`cliapp/dump.go`)**: after mydumper succeeds with `--encrypt`, walk the output dir and write an HMAC-SHA256 hex digest of every `.enc` file to `<name>.enc.hmac`, keyed with the raw bytes of the key file (read in Go — the key never appears on argv or in env). Sidecar-write failure is a hard error (an unauthenticated encrypted dump is what this step prevents), but the dump directory is kept for retry. Summary logged.
- **Decrypt side (`cliapp/baseline.go` `decryptDumpFiles`)**: before invoking openssl on each `.enc`, verify the sidecar with `hmac.Equal`. Mismatch = hard error naming the file; the file is never decrypted. Missing sidecar = warning (`legacy unauthenticated dump, integrity cannot be verifiable`) and decryption proceeds — pre-fix dumps keep working.
- Per-file sidecars over a single manifest: they survive partial uploads and need no format. Sidecars don't end in `.enc`, so the decrypt walk skips them and the baseline converter's mydumper-pattern matching ignores them; `upload` just carries them along.
- Helpers live in `cliapp/dumpintegrity.go` (`readHMACKey` / `computeFileHMAC` / `writeDumpHMACSidecars` / `verifyEncFileHMAC`).

## Docs

`docs/dump-and-baseline.md`: new "Encryption and integrity" section (operator-facing: keep sidecars next to the `.enc` files; tamper = hard error; legacy dumps warn) + both `--encrypt` flag rows and help strings updated.

## Tests

`cliapp/dumpintegrity_test.go` (pure Go, no openssl needed — a tampered file is refused *before* exec):

- compute/verify round-trip; sidecar writer targets only `.enc` (no sidecar-of-sidecar)
- tampered file and wrong key → `HMAC-SHA256 mismatch` naming the file
- missing sidecar → legacy path, no error
- **through the production entry point**: `decryptDumpFiles` on a tampered dump errors with the mismatch and never produces decrypted output; a dir with only a `.enc.hmac` decrypts nothing. Mutation-verified: bypassing the verify call in `decryptDumpFiles` turns the test red.

Existing `TestDecryptDumpFiles_roundTrip` (real openssl) now also exercises the missing-sidecar warn path.

`go build ./...`, `go vet ./...`, `go test ./cliapp/... -count=1 -race` all green (unit tier; integration tests not run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
