### PR TITLE
console: add the sandboxed server-side SQL panel (#1177)

### DIFF
--- a/consoleapp/serve.go
+++ b/consoleapp/serve.go
@@ -226,6 +226,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		Registry:      registry,
 		Listen:        conListen,
 		Token:         conToken,
+		SQLPanel:      sqlPanelEnabled(),
 		NoArchive:     conNoArchive || conProfile != "",
 		DenyTables:    denyTables,
 		RedactColumns: redactCols,
@@ -265,6 +266,15 @@ func runServe(cmd *cobra.Command, args []string) error {
 // the console's mode. The URL never carries a ?token= unless an explicit token
 // is the only credential (URL() handles that); a live credential does not
 // belong in logs or shell history.
+// sqlPanelEnabled reads the SQL panel opt-in (#1177). Env-only and off by
+// default, mirroring BINTRAIL_CONSOLE_BASELINE_TRIGGER: an explicit operator
+// assertion, not something a stray flag in a wrapper script flips on. Shared
+// by serve and watch.
+func sqlPanelEnabled() bool {
+	v := os.Getenv("BINTRAIL_CONSOLE_SQL_PANEL")
+	return v == "1" || v == "true"
+}
+
 func printConsoleBanner(srv *console.Server, headline string) {
 	fmt.Fprintf(os.Stderr, "\n%s\n\n    %s\n\n", headline, srv.URL())
 	switch {

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -1264,6 +1264,7 @@ func upConsoleConfig(db *sql.DB, indexDSN string, opts consoleOpts) (console.Con
 		BootDSN:      indexDSN,
 		Listen:       opts.Listen,
 		Token:        opts.Token,
+		SQLPanel:     sqlPanelEnabled(),
 		BaselineDir:  opts.BaselineDir,
 		BaselineS3:   opts.BaselineS3,
 		AuthPath:     opts.AuthFile,

--- a/consoleapp/watch_test.go
+++ b/consoleapp/watch_test.go
@@ -56,6 +56,19 @@ func TestUpConsoleConfig(t *testing.T) {
 		t.Errorf("watch console config must not set NoArchive: %+v", cfg)
 	}
 
+	// The SQL panel opt-in reaches the config from the env — proving the wire,
+	// not just the function (deleting the SQLPanel assignment in upConsoleConfig
+	// must fail a test). Env-driven, so set it around this one call.
+	t.Setenv("BINTRAIL_CONSOLE_SQL_PANEL", "1")
+	cfgSQL, err := upConsoleConfig(nil, "user:pass@tcp(127.0.0.1:3306)/binlog_index", consoleOpts{Listen: "127.0.0.1:8090", Token: "tok"})
+	if err != nil {
+		t.Fatalf("upConsoleConfig (sql panel): %v", err)
+	}
+	if !cfgSQL.SQLPanel {
+		t.Error("BINTRAIL_CONSOLE_SQL_PANEL=1 did not reach console.Config.SQLPanel via watch")
+	}
+	t.Setenv("BINTRAIL_CONSOLE_SQL_PANEL", "")
+
 	// Without baseline flags the Phase 1 default is preserved: empty baselines
 	// keep the reconstruct surface gated off.
 	cfg, err = upConsoleConfig(nil, "user:pass@tcp(127.0.0.1:3306)/binlog_index", consoleOpts{Listen: "127.0.0.1:8090", Token: "tok"})

--- a/docs/console.md
+++ b/docs/console.md
@@ -353,6 +353,55 @@ across the rotation dialog and the per-server edit form):
   `BINTRAIL_TELEMETRY`) or the `--telemetry` flag already controls it, the card
   says so and defers to that. See [TELEMETRY.md](./TELEMETRY.md).
 
+### The SQL panel (opt-in)
+
+The **Query in DuckDB** card above hands you a file to run in your *own* DuckDB.
+The **SQL panel** is the other half of that trade: a query box that runs the SQL
+**inside the console daemon** and returns the rows, so you never leave the
+browser. Because that SQL now executes server-side, it is **off by default** and
+guarded — start the console with `BINTRAIL_CONSOLE_SQL_PANEL=1` to expose it. It
+appears as a **SQL** item in the sidebar for any server that has an archive or
+baseline layout to query.
+
+What you can query is exactly what the `views.sql` schema defines: an `events`
+view across every archive source, plus one `state_<schema>_<table>` view per
+table in the newest baseline snapshot. Type a `SELECT`, press **Run** (or
+`⌘/Ctrl+Enter`), and the results come back in a capped table. A long query is
+**cancelable** — the **Cancel** button aborts it and interrupts the query in the
+daemon; closing the tab or navigating away does the same.
+
+The panel is deliberately constrained, and every constraint is enforced
+server-side (the UI only mirrors it):
+
+- **Read-only.** Only a single `SELECT` runs. Writes, `COPY`, `ATTACH`,
+  `INSTALL`, `CREATE SECRET`, `SET`, and multi-statement input are refused —
+  classified by DuckDB's own parser, not a text filter.
+- **Views only.** Query the pre-built `events` and `state_<schema>_<table>`
+  views. The `FROM` clause accepts those views (and a few pure generators like
+  `range`) and nothing else: every file reader (`read_parquet`, `read_csv`,
+  `FROM '…/file.parquet'`, …) and every dynamic-SQL function (`query`,
+  `query_table`, …) is refused by an allowlist that fails closed. So the views —
+  which omit the paid forensics columns, exactly as the rest of the console
+  does — are the one data path.
+- **Filesystem-sandboxed.** Under the views, the DuckDB session may touch *only*
+  the resolved archive/baseline roots for the selected server (local paths and
+  `s3://` prefixes alike); everything else — other buckets, arbitrary URLs,
+  local files outside the roots — is denied, and the sandbox configuration is
+  locked so no query can widen it.
+- **Bounded.** Conservative memory/thread budget (never the `--ultrafast`
+  profile — the daemon may also be capturing your stream), a hard 60-second
+  query timeout, a result-row cap matching the events API, and **one query at a
+  time** per process (a second concurrent request gets `429`).
+- **Access-control aware.** Refused outright while a data profile is active:
+  free-form SQL reads the unredacted Parquet directly and cannot honor
+  per-column redaction, so the whole surface is withheld (the same stance the
+  `views.sql` download takes).
+- **Audited.** Every executed statement is recorded on the audit seam
+  (`console` / `sql.run`) with the SQL text and row count.
+
+No AWS credentials are ever exposed to the query; S3 reads use the daemon's
+ambient credential chain, scoped to the allowed prefixes.
+
 #### Creating a baseline from the console
 
 By default the console only *lists* baselines — you produce them with the
@@ -545,6 +594,12 @@ see the metrics tables and example alert rules in
 - `BINTRAIL_CONSOLE_TLS_CERT` / `BINTRAIL_CONSOLE_TLS_KEY` — same as `--tls-cert` / `--tls-key`.
 - `BINTRAIL_CONSOLE_ALLOWED_HOSTS` — comma-separated, same as `--allowed-hosts`.
 - `BINTRAIL_CONSOLE_ALLOW_SETUP` — `1`/`true`, same as `--allow-setup`.
+- `BINTRAIL_CONSOLE_SQL_PANEL` — `1`/`true` enables the **SQL** page: a
+  server-side, read-only SQL query box over the selected server's Parquet (see
+  [The SQL panel](#the-sql-panel-opt-in)). Off by default; works on both `serve`
+  and `watch`. Unlike the `views.sql` download, this executes SQL **inside the
+  daemon**, so it runs in a locked-down DuckDB sandbox — read [The SQL panel](#the-sql-panel-opt-in)
+  before enabling it on a shared or public bind.
 - `BINTRAIL_CONSOLE_ARCHIVE_STAGING` (`watch` only) — local staging dir for the
   Archive-to-S3 feature, same as `--archive-staging-dir`. AWS credentials for
   the upload come from the ambient chain (`AWS_*` / `~/.aws` / role).
@@ -904,6 +959,7 @@ All endpoints return JSON except `GET /api/views.sql`, which serves a SQL file. 
 | `PUT /api/rotation` | Supervisor only (403 on the standalone console): save a global rotation override `{retain, interval, add_future}` (validated; `off` rejected). Applies live on the next cycle. |
 | `GET /api/baselines` | Read-only listing of the **selected server's** baseline snapshots, grouped per snapshot: `{configured, source, kind, reconstruct, snapshots: [{time, age_hours, tables, binlog_file, binlog_pos, gtid_set}]}` (coordinates local-only, capped at 50 snapshots). `502` when the configured source is unreadable. |
 | `GET /api/views.sql` | **Not JSON** — a `text/plain` DuckDB schema over the selected server's Parquet (the same output as `bintrail views`), served as a `views.sql` attachment. Nothing is executed here; the file runs in your own DuckDB. 404 when archives are disabled or nothing is archived yet, 403 while an access-control profile is active. |
+| `POST /api/sql` | Runs a read-only `SELECT` over the selected server's Parquet **inside the daemon**, in a locked-down DuckDB sandbox, returning `{columns, rows, row_count, truncated, elapsed_ms}`. Opt-in (`BINTRAIL_CONSOLE_SQL_PANEL=1`) — `403` otherwise. `403` while a profile is active; `404` when archives are disabled or there is nothing to query; `422` for a non-`SELECT`, a statement error, or the timeout; `429` when another query is already running. Cancellation is by aborting the request. See [The SQL panel](#the-sql-panel-opt-in). |
 | `GET /api/storage` | Process-global storage context: `{aws: {access_key_env, profile, region_env, shared_config, container_creds, web_identity}}` — presence booleans and non-secret names only, never credential values. |
 
 Every data endpoint (`status`, `schemas`, `events`, `recover`,

--- a/docs/console.md
+++ b/docs/console.md
@@ -396,8 +396,10 @@ server-side (the UI only mirrors it):
   free-form SQL reads the unredacted Parquet directly and cannot honor
   per-column redaction, so the whole surface is withheld (the same stance the
   `views.sql` download takes).
-- **Audited.** Every executed statement is recorded on the audit seam
-  (`console` / `sql.run`) with the SQL text and row count.
+- **Audited.** Every statement that reaches the engine is recorded on the audit
+  seam (`console` / `sql.run`) with the SQL text, its outcome (`ok` / `refused` /
+  `error`) and row count — including one the read-only gate refuses. Only a
+  statement the client aborts mid-flight is not recorded.
 
 No AWS credentials are ever exposed to the query; S3 reads use the daemon's
 ambient credential chain, scoped to the allowed prefixes.

--- a/internal/audittest/audittest.go
+++ b/internal/audittest/audittest.go
@@ -192,6 +192,11 @@ var Required = []Requirement{
 		Owner: OwnerConsoleIntegration,
 		Why:   "cascade reversal (with synthesized child rows) served by the console",
 	},
+	{
+		Pair:  Pair{Surface: "console", Action: "sql.run"},
+		Owner: OwnerConsoleUnit,
+		Why:   "a free-form SQL statement executed over the archive/baseline Parquet by the console's SQL panel (#1177)",
+	},
 }
 
 // RequiredFor returns the pairs owner must exercise.

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -39,7 +39,7 @@ const EVENT_CSV_COLUMNS = [
 const BADGE_CLASS = { UPDATE: "b-update", INSERT: "b-insert", DELETE: "b-delete" };
 function badgeClass(t) { return BADGE_CLASS[t] || "b-baseline"; }
 
-const ROUTES = ["overview", "events", "timetravel", "recover", "status", "storage", "connect"];
+const ROUTES = ["overview", "events", "timetravel", "recover", "sql", "status", "storage", "connect"];
 
 const MON_STATE_TITLES = {
   failed: "connection is failing and retrying automatically; press Start for details",
@@ -625,6 +625,8 @@ function navigate(route, params, push = true) {
   if (route === "timetravel" && !capsCache.reconstruct) route = "overview";
   // Storage is a watch-daemon surface (rotation + archiving live there).
   if (route === "storage" && !capsCache.monitor) route = "overview";
+  // The SQL panel is opt-in (BINTRAIL_CONSOLE_SQL_PANEL) and per-server gated.
+  if (route === "sql" && !capsCache.sql) route = "overview";
   const qs = params && Object.keys(params).length
     ? "?" + new URLSearchParams(params).toString() : "";
   if (push) history.pushState({ route }, "", "/" + route + qs);
@@ -634,8 +636,11 @@ function navigate(route, params, push = true) {
 function renderRoute() {
   // The date-picker popover lives in document.body (position:fixed), outside
   // the #view subtree route changes normally clear — there's no per-view
-  // teardown hook in this codebase to hang that cleanup on otherwise.
+  // teardown hook in this codebase to hang that cleanup on otherwise. An
+  // in-flight SQL panel query is abandoned here for the same reason: leaving
+  // the page must release the daemon's single-query latch.
   closeDatePicker();
+  abortSQLRun();
   const route = routeFromLocation();
   setActiveNav(route);
   cursorIdx = -1;
@@ -652,6 +657,7 @@ function renderRoute() {
     case "events": return renderEvents(params);
     case "timetravel": return renderTimetravel(params);
     case "recover": return renderRecover(params);
+    case "sql": return renderSQL();
     case "status": return renderStatus();
     case "storage": return renderStorage();
     case "connect": return renderConnect();
@@ -2103,6 +2109,119 @@ function duckdbCard() {
   return card;
 }
 
+// ── SQL panel (#1177) ────────────────────────────────────────────────────────
+//
+// Free-form DuckDB SELECTs over this server's archived Parquet, executed
+// server-side in a locked-down sandbox (see internal/console/sqlpanel.go). The
+// panel is opt-in and per-server gated; navigate() already redirected here only
+// when capsCache.sql is true. The Cancel button IS the cancellation mechanism:
+// it aborts the fetch, which kills the request context, which interrupts the
+// DuckDB query — there is no server-side cancel endpoint to call.
+
+let sqlRunController = null; // AbortController for the in-flight query, if any
+
+// abortSQLRun cancels an in-flight SQL panel query. Called on navigation away
+// and on server switch so a long query never keeps holding the daemon's
+// single-in-flight latch after the operator has left the page (they would come
+// back to a 429 with no running query to cancel). Safe to call when idle.
+function abortSQLRun() { if (sqlRunController) sqlRunController.abort(); }
+
+async function renderSQL() {
+  if (!capsCache.sql) { history.replaceState({}, "", "/overview"); renderRoute(); return; }
+  const v = VIEW();
+  clear(v);
+  v.append(pageHead("SQL", null));
+
+  const card = el("div", { class: "card" });
+  card.append(el("p", { class: "form-hint", text:
+    "Run a read-only SQL query over this server's archived Parquet — an \"events\" view across every archive source, " +
+    "plus one \"state_<schema>_<table>\" view per table in the newest baseline. Only SELECT runs; results are capped." }));
+
+  const input = el("textarea", {
+    class: "sql-input", id: "sql-input", spellcheck: "false", rows: "6",
+    placeholder: "SELECT event_type, schema_name, table_name FROM events ORDER BY commit_time DESC LIMIT 100",
+  });
+  card.append(input);
+
+  const runBtn = el("button", { class: "btn btn-primary btn-sm", type: "button", text: "Run" });
+  const cancelBtn = el("button", { class: "btn btn-sm", type: "button", text: "Cancel", hidden: true });
+  const statusLine = el("span", { class: "sql-status", id: "sql-status" });
+  card.append(el("div", { class: "sql-actions" }, runBtn, cancelBtn, statusLine));
+  v.append(card);
+
+  const results = el("div", { id: "sql-results" });
+  v.append(results);
+  viewEnter();
+
+  const run = () => runSQL(input.value, { runBtn, cancelBtn, statusLine, results });
+  runBtn.onclick = run;
+  cancelBtn.onclick = () => { if (sqlRunController) sqlRunController.abort(); };
+  // Cmd/Ctrl+Enter submits from the textarea — the expected shortcut for a
+  // query box, and it keeps Enter free for newlines in a multi-line statement.
+  input.addEventListener("keydown", (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") { e.preventDefault(); run(); }
+  });
+  input.focus();
+}
+
+async function runSQL(sql, ui) {
+  const { runBtn, cancelBtn, statusLine, results } = ui;
+  if (!sql || !sql.trim()) { statusLine.textContent = "enter a SELECT statement"; return; }
+  const gen = serverGen;
+  sqlRunController = new AbortController();
+  runBtn.disabled = true;
+  cancelBtn.hidden = false;
+  statusLine.textContent = "running…";
+  clear(results);
+  try {
+    const headers = { Authorization: "Bearer " + TOKEN, "Content-Type": "application/json" };
+    if (currentServer) headers["X-Bintrail-Server"] = currentServer;
+    const res = await fetch("/api/sql", {
+      method: "POST", headers, body: JSON.stringify({ sql }), signal: sqlRunController.signal,
+    });
+    const text = await res.text();
+    if (gen !== serverGen) return; // a server switch abandoned this query
+    if (!res.ok) {
+      if (res.status === 401) { handleUnauthorized(); return; }
+      let msg = text || "HTTP " + res.status;
+      try { const j = JSON.parse(text); if (j && j.error) msg = j.error; } catch (_) {}
+      statusLine.textContent = "";
+      renderError(results, new Error(msg));
+      return;
+    }
+    const data = JSON.parse(text);
+    statusLine.textContent = data.row_count + " row" + (data.row_count === 1 ? "" : "s") +
+      " in " + data.elapsed_ms + " ms" + (data.truncated ? " (truncated)" : "");
+    renderSQLResult(results, data);
+  } catch (err) {
+    if (err && err.name === "AbortError") { statusLine.textContent = "canceled"; return; }
+    if (gen !== serverGen) return;
+    statusLine.textContent = "";
+    renderError(results, err);
+  } finally {
+    sqlRunController = null;
+    runBtn.disabled = false;
+    cancelBtn.hidden = true;
+  }
+}
+
+function renderSQLResult(mount, data) {
+  clear(mount);
+  const cols = data.columns || [];
+  const rows = data.rows || [];
+  if (!rows.length) { mount.append(el("div", { class: "empty" }, el("p", { text: "No rows." }))); return; }
+  const wrap = el("div", { class: "sql-table-wrap" });
+  const table = el("table", { class: "statetable sql-table" });
+  table.append(el("thead", {}, el("tr", {}, ...cols.map((c) => el("th", { text: c })))));
+  const tbody = el("tbody");
+  for (const r of rows) {
+    tbody.append(el("tr", {}, ...r.map((cell) => el("td", { text: valueToString(cell) }))));
+  }
+  table.append(tbody);
+  wrap.append(table);
+  mount.append(wrap);
+}
+
 function telemetryCard(t) {
   const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Usage telemetry" }));
   if (!t || t.error) {
@@ -3173,9 +3292,11 @@ async function switchServer(id) {
   schemaCache = null;
   tablesCache.clear();
   // A switch is a fresh context: drop any carried undo-context and SQL so they
-  // can never be auto-applied against a different server's index.
+  // can never be auto-applied against a different server's index, and abort any
+  // in-flight panel query (it targeted the old server, and holds its latch).
   pendingRecover = null;
   lastSQL = "";
+  abortSQLRun();
   try { await gateCapabilities(); } catch (err) {
     if (err && err.status === 401) return; // chokepoint already raised the sign-in gate
     throw err;
@@ -3690,6 +3811,7 @@ function cmdkCommands() {
     { group: "Navigate", label: "Status", run: () => navigate("status") },
   ];
   if (capsCache.reconstruct) cmds.push({ group: "Navigate", label: "Time-travel", run: () => navigate("timetravel") });
+  if (capsCache.sql) cmds.push({ group: "Navigate", label: "SQL", run: () => navigate("sql") });
   if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Storage", run: () => navigate("storage") });
   cmds.push({ group: "Navigate", label: "Connect AI", run: () => navigate("connect") });
   cmds.push({ group: "Actions", label: "Manage servers", run: () => { closeCmdk(); openServersModal(); } });

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -25,7 +25,7 @@
           <div class="brand-name">dbtrail</div>
           <div class="brand-sub">console</div>
         </div>
-        <span class="ro-pill" title="This console never executes SQL against your data.">read-only</span>
+        <span class="ro-pill" title="This console never modifies your data.">read-only</span>
       </div>
 
       <button class="cmdk-trigger" id="open-cmdk" type="button">
@@ -70,6 +70,13 @@
           <a class="nav-item" data-route="recover" href="/recover" data-perm="recover:execute">
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M3 13a9 9 0 1 0 3-7.7L3 8"/></svg></span>
             <span>Recover</span>
+          </a>
+          <!-- SQL panel: opt-in (BINTRAIL_CONSOLE_SQL_PANEL) and per-server
+               gated on capsCache.sql, so hidden unless the daemon enabled it
+               AND the selected server has an archive/baseline layout. -->
+          <a class="nav-item" data-route="sql" href="/sql" data-capability="sql" data-perm="query:execute">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="6" rx="8" ry="3"/><path d="M4 6v6c0 1.66 3.58 3 8 3s8-1.34 8-3V6"/><path d="M4 12v6c0 1.66 3.58 3 8 3s8-1.34 8-3v-6"/></svg></span>
+            <span>SQL</span>
           </a>
         </div>
         <div class="nav-group">

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1425,3 +1425,21 @@ button { font-family: inherit; }
 .cov-chip.ok { color: var(--insert); border-color: var(--insert); }
 .cov-chip.warn { color: var(--update); border-color: var(--update); }
 .cov-chip.bad { color: var(--delete); border-color: var(--delete); font-weight: 600; }
+
+/* SQL panel (#1177): a read-only query box + capped results table. */
+.sql-input {
+  width: 100%; box-sizing: border-box; resize: vertical; min-height: 120px;
+  font-family: var(--f-mono); font-size: 13px; line-height: 1.5;
+  padding: 12px 14px; border: 1px solid var(--line); border-radius: 10px;
+  background: var(--surface-2); color: var(--ink);
+}
+.sql-input:focus { outline: none; border-color: var(--ink-4); }
+.sql-actions { display: flex; align-items: center; gap: 10px; margin-top: 12px; }
+.sql-status { font-family: var(--f-mono); font-size: 12px; color: var(--ink-2); }
+.sql-table-wrap { overflow-x: auto; margin-top: 4px; }
+.sql-table { min-width: 100%; }
+.sql-table th, .sql-table td {
+  text-align: left; padding: 5px 12px; border-bottom: 1px solid var(--line);
+  white-space: nowrap; max-width: 46ch; overflow: hidden; text-overflow: ellipsis;
+}
+.sql-table th { color: var(--ink-2); font-weight: 600; position: sticky; top: 0; background: var(--surface); }

--- a/internal/console/audit_contract_test.go
+++ b/internal/console/audit_contract_test.go
@@ -126,6 +126,24 @@ func TestAuditContract_ConsoleUnit(t *testing.T) {
 			},
 		},
 		{
+			name:      "sql panel refused",
+			action:    "sql.run",
+			wantActor: tokenActor,
+			call: func(t *testing.T) {
+				// A gate-refused statement is audited too (outcome=refused): the
+				// refused probe is exactly what an auditor needs. Delete the
+				// recordSQLRun on the refusal branch and this case goes red.
+				baselineRoot, _ := writeSQLPanelBaseline(t)
+				srv := newSQLPanelServer(t, baselineRoot, true)
+				w := httptest.NewRecorder()
+				srv.handleSQLPanel(w, httptest.NewRequest("POST", "/api/sql",
+					strings.NewReader(`{"sql":"SELECT * FROM glob('/etc/*')"}`)))
+				if w.Code != http.StatusUnprocessableEntity {
+					t.Fatalf("refused sql panel: code=%d body=%s, want 422", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
 			name:      "authz denial",
 			action:    "authz.denied",
 			wantActor: "ana@example.com",

--- a/internal/console/audit_contract_test.go
+++ b/internal/console/audit_contract_test.go
@@ -111,6 +111,21 @@ func TestAuditContract_ConsoleUnit(t *testing.T) {
 			},
 		},
 		{
+			name:      "sql panel",
+			action:    "sql.run",
+			wantActor: tokenActor,
+			call: func(t *testing.T) {
+				baselineRoot, _ := writeSQLPanelBaseline(t)
+				srv := newSQLPanelServer(t, baselineRoot, true)
+				w := httptest.NewRecorder()
+				srv.handleSQLPanel(w, httptest.NewRequest("POST", "/api/sql",
+					strings.NewReader(`{"sql":"SELECT count(*) FROM state_shop_orders"}`)))
+				if w.Code != http.StatusOK {
+					t.Fatalf("sql panel: code=%d body=%s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
 			name:      "authz denial",
 			action:    "authz.denied",
 			wantActor: "ana@example.com",

--- a/internal/console/authz.go
+++ b/internal/console/authz.go
@@ -54,6 +54,10 @@ var apiRoutePerms = []routePerm{
 	{"GET", "/api/events", ext.PermQueryExecute},
 	{"GET", "/api/schemas", ext.PermQueryExecute},
 	{"GET", "/api/reconstruct", ext.PermReconstructExecute},
+	// The SQL panel reads the same indexed row data the events surface does —
+	// free-form, so it is tiered with query execution, and its own handler
+	// additionally refuses profiled sessions (redaction cannot reach it).
+	{"POST", "/api/sql", ext.PermQueryExecute},
 
 	// Recovery (reversal-SQL generation; never executes).
 	{"POST", "/api/recover", ext.PermRecoverExecute},

--- a/internal/console/authz_test.go
+++ b/internal/console/authz_test.go
@@ -26,6 +26,7 @@ var registeredAPIPatterns = []struct{ method, pattern string }{
 	{"POST", "/api/recover-cascade"},
 	{"GET", "/api/capabilities"},
 	{"GET", "/api/reconstruct"},
+	{"POST", "/api/sql"},
 	{"GET", "/api/baselines"},
 	{"GET", "/api/views.sql"},
 	{"GET", "/api/storage"},

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -67,6 +67,12 @@ type capabilitiesResponse struct {
 	// (archives enabled, no active data profile, and something to describe), so
 	// the UI never offers a button that only 404s.
 	Views bool `json:"views"`
+	// SQL: the sandboxed server-side SQL panel (#1177) is usable — this
+	// process opted in (BINTRAIL_CONSOLE_SQL_PANEL=1) AND the selected server
+	// passes the same per-server conditions views does (archives enabled, no
+	// active data profile, a Parquet layout to query). Gated exactly as
+	// /api/sql refuses, so the UI never advertises a tab that only errors.
+	SQL bool `json:"sql"`
 	// BaselineTrigger: this process can create baseline snapshots in-process from
 	// the console (the watch daemon opted in with BINTRAIL_CONSOLE_BASELINE_TRIGGER=1).
 	// Process-global, like Monitor — the endpoint does the per-server validation
@@ -181,6 +187,7 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		restricted := sessionRestricted(r)
 		resp.Reconstruct = b.baselineConfigured && !restricted
 		resp.Views = s.viewsAvailable(r, b)
+		resp.SQL = s.sqlPanelAvailable(r, b)
 		// Match the recover-cascade handler's Phase-2 gate exactly so the advertised
 		// capability can't over-promise (handler builds the provider only when both
 		// a baseline source and a resolver are present).

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/dbtrail/dbtrail/ext"
@@ -145,6 +146,12 @@ type Config struct {
 	// link release artifacts (the .mcpb bundle) matching the running binary.
 	// Optional; empty reads as an unversioned build.
 	Version string
+	// SQLPanel enables the sandboxed server-side SQL panel (#1177): POST
+	// /api/sql runs free-form DuckDB SELECTs over the selected server's
+	// archive/baseline Parquet inside a locked-down session (see sqlpanel.go
+	// for the layered posture). Off by default; the callers wire it from
+	// BINTRAIL_CONSOLE_SQL_PANEL=1, mirroring the baseline-trigger opt-in.
+	SQLPanel bool
 }
 
 // RotationDefaults is the daemon-side built-in-rotation policy, surfaced to the
@@ -212,6 +219,11 @@ type Server struct {
 	// data-profile enforcement (#1075). Inert in OSS (no session ever carries a
 	// profile); populated lazily on the first profiled request.
 	sessionProfiles *profileRuleCache
+	// sqlPanel: the SQL panel opt-in (Config.SQLPanel); sqlPanelBusy is its
+	// one-query-in-flight latch (zero value ready, so struct-literal test
+	// servers need no initialization).
+	sqlPanel     bool
+	sqlPanelBusy atomic.Bool
 }
 
 // serverHeader selects the target server per request. Selection is stateless —
@@ -363,6 +375,7 @@ func New(cfg Config) (*Server, error) {
 		tlsConf:          tlsConf,
 		mcpTokenPath:     mcpTokenPath,
 		sessionProfiles:  newProfileRuleCache(),
+		sqlPanel:         cfg.SQLPanel,
 	}
 	s.managedTok.initFromDisk(mcpTokenPath, mcpTokFile)
 	s.cm.hideBoot = cfg.HideBoot
@@ -454,6 +467,10 @@ func (s *Server) buildHandler() http.Handler {
 	// booleans and non-secret names — never values).
 	api.HandleFunc("GET /api/baselines", s.handleBaselines)
 	api.HandleFunc("GET /api/views.sql", s.handleViewsSQL)
+	// The sandboxed SQL panel (#1177). Registered unconditionally so the
+	// route's refusal (403 with the opt-in hint) is actionable; the real gate
+	// is inside the handler, like the monitor/baseline-trigger verbs.
+	api.HandleFunc("POST /api/sql", s.recordAction("sql", s.handleSQLPanel))
 	api.HandleFunc("GET /api/storage", s.handleStorageInfo)
 	// Usage-telemetry opt-out: read the machine-wide state, and toggle it (a
 	// local config write, not a data write). Available on any console; the UI

--- a/internal/console/sqlpanel.go
+++ b/internal/console/sqlpanel.go
@@ -5,11 +5,18 @@ package console
 // locked-down DuckDB session. The security posture is layered, and every layer
 // is enforced here from the first commit — none are follow-ups:
 //
-//  1. Filesystem sandbox: allowed_directories is restricted to the resolved
-//     archive/baseline roots (local paths and s3:// prefixes both — DuckDB's
-//     access check runs in its virtual-filesystem layer, above httpfs, so it
-//     governs remote paths and fails BEFORE any network I/O), external access
-//     is disabled, and lock_configuration makes the session's config immutable.
+//  1. Filesystem sandbox: `SET enable_external_access = false` is the
+//     load-bearing ban — it is what denies every file and URL read. Neither
+//     allowed_directories NOR lock_configuration restricts anything on its own
+//     (verified: with external access at its default, an out-of-root read
+//     succeeds even with both set). allowed_directories is only a CARVE-OUT
+//     from the ban, scoping the exception to the resolved archive/baseline
+//     roots — local paths AND s3:// prefixes (an out-of-root s3:// read is
+//     denied before any network request is made; an in-root one reaches S3).
+//     DO NOT remove the enable_external_access line in openSandboxedSession:
+//     without it the sandbox opens to the entire filesystem and all of S3, and
+//     the local in-root tests stay green. lock_configuration then freezes the
+//     whole config so no user SET can widen it.
 //  2. Read-only: DuckDB's allowed_directories carve-out permits WRITES inside
 //     the roots (COPY TO, ATTACH of a writable database), so read-only is
 //     enforced by a SELECT-only statement gate — classified by DuckDB's own
@@ -20,7 +27,10 @@ package console
 //     query in flight per process.
 //  4. RBAC: refused outright when a data profile is active — free-form SQL
 //     cannot honor per-column redaction (same gate shape as reconstruct).
-//  5. Audit: every executed statement emits on the audit seam (console/sql.run).
+//  5. Audit: every statement that reaches the engine emits on the audit seam
+//     (console/sql.run) with its outcome (ok/refused/error) — including one the
+//     gate refuses. Only a request the client aborted mid-flight is silent
+//     (there is no one to answer, and it is not a policy event).
 //  6. Opt-in: off by default behind BINTRAIL_CONSOLE_SQL_PANEL=1.
 //
 // Cancellation is the HTTP request's own lifetime: the browser aborts the
@@ -33,6 +43,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"os"
@@ -63,6 +74,12 @@ const (
 // sqlPanelTimeout is the hard per-query wall-clock budget. A var so tests can
 // shrink it to exercise the interrupt without a 60-second test.
 var sqlPanelTimeout = 60 * time.Second
+
+// sqlPanelSetupTimeout bounds the pre-query setup — the S3 baseline LIST in
+// buildViewsInput is the one unbounded step that runs under the single-flight
+// latch, so a hung listing must not pin the panel at 429 for every other user.
+// The query itself is bounded separately by sqlPanelTimeout.
+var sqlPanelSetupTimeout = 30 * time.Second
 
 // forensicsEventColumns are the paid-tier forensics columns the console must
 // NOT serve as row data: the SAME set eventDTO omits (connection_id is the free
@@ -175,7 +192,12 @@ func (s *Server) handleSQLPanel(w http.ResponseWriter, r *http.Request) {
 	}
 	defer s.sqlPanelBusy.Store(false)
 
-	in, err := s.buildViewsInput(r.Context(), b)
+	// Bound the setup: buildViewsInput's S3 baseline LIST is the one unbounded
+	// step under the latch. r.Context() still propagates (Cancel works); the
+	// deadline is what stops a hung listing from wedging the single-flight.
+	setupCtx, setupCancel := context.WithTimeout(r.Context(), sqlPanelSetupTimeout)
+	in, err := s.buildViewsInput(setupCtx, b)
+	setupCancel()
 	switch {
 	case errors.Is(err, errNoViewSources):
 		writeJSONError(w, http.StatusNotFound, errNoViewSources.Error()+" — nothing to query")
@@ -191,22 +213,40 @@ func (s *Server) handleSQLPanel(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.Is(err, context.Canceled):
 			// The human hit Cancel (or closed the tab): the fetch was aborted,
-			// the query was interrupted, and there is no one to answer.
+			// the query was interrupted, and there is no one to answer. Not a
+			// policy event — stays off the audit seam.
 			return
 		case errors.As(err, &ue):
+			recordSQLRun(r, req.SQL, "refused", ue.msg, 0, false)
 			writeJSONError(w, http.StatusUnprocessableEntity, ue.msg)
 		default:
+			recordSQLRun(r, req.SQL, "error", err.Error(), 0, false)
 			writeJSONError(w, http.StatusBadGateway, err.Error())
 		}
 		return
 	}
 
-	recordConsoleAccess(r, "sql.run", "", "", map[string]string{
-		"statement": req.SQL,
-		"rows":      fmt.Sprintf("%d", res.RowCount),
-		"truncated": fmt.Sprintf("%t", res.Truncated),
-	})
+	recordSQLRun(r, req.SQL, "ok", "", res.RowCount, res.Truncated)
 	writeJSON(w, http.StatusOK, res)
+}
+
+// recordSQLRun emits the panel's audit event. Every statement that reaches the
+// engine is recorded with its outcome — including one the gate refuses: a
+// refused free-form probe (a read_parquet against the raw archive, a
+// duckdb_secrets read) is exactly what an auditor needs, and this codebase
+// already audits blocked attempts elsewhere (profile.denied). detail carries the
+// gate/engine message on a non-ok outcome; it is never present on "ok".
+func recordSQLRun(r *http.Request, stmt, outcome, detail string, rows int, truncated bool) {
+	fields := map[string]string{
+		"statement": stmt,
+		"outcome":   outcome,
+		"rows":      fmt.Sprintf("%d", rows),
+		"truncated": fmt.Sprintf("%t", truncated),
+	}
+	if detail != "" {
+		fields["error"] = detail
+	}
+	recordConsoleAccess(r, "sql.run", "", "", fields)
 }
 
 // sqlPanelAvailable is the capability gate for /api/capabilities: the process
@@ -249,7 +289,7 @@ func runSandboxedSQL(ctx context.Context, in views.Input, stmt string) (*sqlPane
 	res := &sqlPanelResult{Columns: cols, Rows: [][]any{}}
 	bytesUsed := 0
 	for rows.Next() {
-		if res.RowCount >= sqlPanelMaxRows || bytesUsed >= sqlPanelMaxBytes {
+		if res.RowCount >= sqlPanelMaxRows {
 			res.Truncated = true
 			break
 		}
@@ -262,12 +302,22 @@ func runSandboxedSQL(ctx context.Context, in views.Input, stmt string) (*sqlPane
 			return nil, &sqlUserError{msg: err.Error()}
 		}
 		out := make([]any, len(cols))
+		rowBytes := 0
 		for i, v := range raw {
 			cell, cost := sqlPanelCell(v)
 			out[i] = cell
-			bytesUsed += cost
+			rowBytes += cost
+		}
+		// Enforce the byte budget BEFORE appending the row that would breach it —
+		// checking after the append overshoots by a full row, and a single row
+		// image can be multiple MB. Always keep at least one row so an oversized
+		// first row surfaces as data, not an empty truncated result.
+		if res.RowCount > 0 && bytesUsed+rowBytes > sqlPanelMaxBytes {
+			res.Truncated = true
+			break
 		}
 		res.Rows = append(res.Rows, out)
+		bytesUsed += rowBytes
 		res.RowCount++
 	}
 	if err := rows.Err(); err != nil {
@@ -302,7 +352,11 @@ func openSandboxedSession(ctx context.Context, in views.Input) (*sql.DB, func(),
 	}
 	cleanup := func() {
 		db.Close()
-		os.RemoveAll(spill)
+		if err := os.RemoveAll(spill); err != nil {
+			// The spill dir can hold row-image data at rest; a failure to remove
+			// it must not be silent in a file whose posture is every-step-checked.
+			slog.Warn("sql panel: could not remove spill directory", "dir", spill, "error", err)
+		}
 	}
 	fail := func(err error) (*sql.DB, func(), error) {
 		cleanup()
@@ -327,7 +381,13 @@ func openSandboxedSession(ctx context.Context, in views.Input) (*sql.DB, func(),
 	// caller can forget it. This is the eventDTO boundary; free-form SQL over an
 	// unfiltered events view would serve exactly what eventDTO omits.
 	in.ExcludeEventColumns = forensicsEventColumns
-	// Only the view DDL — the preamble is for the downloadable file.
+	// Only the view DDL — the preamble is for the downloadable file. This runs
+	// BEFORE the sandbox SETs below, so for an S3 layout its read_parquet glob
+	// resolves over the network with the daemon's ambient credentials while the
+	// session is still unlocked. That is safe ONLY because every interpolated
+	// path is operator-resolved (archive_state / reconstruct.ListBaselines via
+	// buildViewsInput), NEVER user input — routing a user-supplied path here
+	// would be an unsandboxed arbitrary file/URL read.
 	if _, err := db.ExecContext(ctx, views.GenerateViews(in)); err != nil {
 		return fail(fmt.Errorf("set up views over the Parquet layout: %w", err))
 	}
@@ -361,9 +421,12 @@ func openSandboxedSession(ctx context.Context, in views.Input) (*sql.DB, func(),
 // CREATE SECRET, ...), so the panel never grows a hand-rolled SQL classifier.
 // The statement travels as a bound parameter — it is data here, not SQL.
 func sqlPanelGate(ctx context.Context, db *sql.DB, stmt string) error {
-	// The ::VARCHAR on the RESULT is load-bearing: json_serialize_sql returns
-	// DuckDB's JSON type, which the driver decodes to a Go map — casting it
-	// back to text is what lets us Scan and re-parse it ourselves.
+	// Both casts are load-bearing. The input ?::VARCHAR is required because a
+	// bound parameter's type is otherwise unknown to json_serialize_sql (it
+	// errors "first argument must be a VARCHAR"). The ::VARCHAR on the RESULT is
+	// needed because json_serialize_sql returns DuckDB's JSON type, which the
+	// driver decodes to a Go map — casting back to text is what lets us Scan and
+	// re-parse it ourselves.
 	var out string
 	if err := db.QueryRowContext(ctx, "SELECT json_serialize_sql(?::VARCHAR)::VARCHAR", stmt).Scan(&out); err != nil {
 		return fmt.Errorf("classify statement: %w", err)

--- a/internal/console/sqlpanel.go
+++ b/internal/console/sqlpanel.go
@@ -1,0 +1,559 @@
+package console
+
+// The server-side SQL panel (#1177): free-form DuckDB SQL over the selected
+// server's archive/baseline Parquet, executed by the console daemon inside a
+// locked-down DuckDB session. The security posture is layered, and every layer
+// is enforced here from the first commit — none are follow-ups:
+//
+//  1. Filesystem sandbox: allowed_directories is restricted to the resolved
+//     archive/baseline roots (local paths and s3:// prefixes both — DuckDB's
+//     access check runs in its virtual-filesystem layer, above httpfs, so it
+//     governs remote paths and fails BEFORE any network I/O), external access
+//     is disabled, and lock_configuration makes the session's config immutable.
+//  2. Read-only: DuckDB's allowed_directories carve-out permits WRITES inside
+//     the roots (COPY TO, ATTACH of a writable database), so read-only is
+//     enforced by a SELECT-only statement gate — classified by DuckDB's own
+//     parser (json_serialize_sql), never by string matching.
+//  3. Resource bounds: the conservative long-lived-daemon DuckDB budget
+//     (duckdbutil.DefaultTuning — never ultrafast), a private spill directory,
+//     a hard query timeout with interrupt, a result row/byte cap, and a single
+//     query in flight per process.
+//  4. RBAC: refused outright when a data profile is active — free-form SQL
+//     cannot honor per-column redaction (same gate shape as reconstruct).
+//  5. Audit: every executed statement emits on the audit seam (console/sql.run).
+//  6. Opt-in: off by default behind BINTRAIL_CONSOLE_SQL_PANEL=1.
+//
+// Cancellation is the HTTP request's own lifetime: the browser aborts the
+// fetch, r.Context() dies, and the DuckDB query is interrupted through
+// QueryContext. No cancel endpoint, no query registry.
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	// The panel opens its own DuckDB handles; do not rely on a transitive
+	// import to have registered the driver.
+	_ "github.com/duckdb/duckdb-go/v2"
+
+	"github.com/dbtrail/dbtrail/internal/duckdbutil"
+	"github.com/dbtrail/dbtrail/internal/views"
+)
+
+const (
+	// sqlPanelMaxRows matches the events API's hard cap: the panel is an
+	// interactive surface, not an export path (views.sql is the unbounded one).
+	sqlPanelMaxRows = eventsMaxLimit
+	// sqlPanelMaxBytes bounds the response payload: a SELECT over row images
+	// can carry megabytes per cell, and an unbounded encode would hold it all
+	// in the daemon's heap.
+	sqlPanelMaxBytes = 8 << 20
+	// sqlPanelMaxStatementBytes bounds the request body (and therefore the
+	// statement recorded on the audit seam).
+	sqlPanelMaxStatementBytes = 64 << 10
+)
+
+// sqlPanelTimeout is the hard per-query wall-clock budget. A var so tests can
+// shrink it to exercise the interrupt without a 60-second test.
+var sqlPanelTimeout = 60 * time.Second
+
+// forensicsEventColumns are the paid-tier forensics columns the console must
+// NOT serve as row data: the SAME set eventDTO omits (connection_id is the free
+// query_explorer/paid forensics line; query_text/query_hash ride with it). The
+// panel drops them from its `events` view so a SELECT cannot reach them — the
+// open-core boundary that the views.sql DOWNLOAD sidesteps by never executing
+// (it hands the operator a schema over their own files), but which the panel
+// re-crosses by executing server-side.
+var forensicsEventColumns = []string{"connection_id", "query_text", "query_hash"}
+
+// allowedTableFunctions is the ALLOWLIST of table functions a panel query may
+// name in a FROM clause. It is an allowlist, not a denylist, on purpose: DuckDB
+// has too many ways to read a file or re-enter the parser to enumerate safely,
+// and a denylist fails OPEN on every name it hasn't heard of — a DuckDB bump or
+// a loaded extension silently reopens the hole. This fails CLOSED.
+//
+// The panel's real data path is the pre-built `events`/`state_*` VIEWS, which
+// resolve to BASE_TABLE references at bind time (after this gate), NOT table
+// functions — so nothing here is needed to read them. This list only adds a few
+// pure in-memory generators (no file, no network, no SQL string argument) so
+// simple scaffolding like `FROM range(n)` works.
+//
+// Everything absent is refused, which is the whole point. In particular this
+// blocks: the raw file readers (read_parquet/read_csv/… — reading the raw
+// archive Parquet would serve the paid forensics columns the events view
+// withholds, and is an arbitrary in-root file-read primitive); the dynamic-SQL
+// re-entry functions (query/query_table/json_execute_serialized_sql, which take
+// a SQL/path STRING that DuckDB re-parses at bind time, AFTER this gate — the
+// bypass that makes a denylist futile, #1177 review); and the secrets manager
+// (duckdb_secrets/which_secret, which expose an S3 secret's access-key id).
+//
+// Scalar functions (repeat, make_timestamp, json_extract, …) are unaffected:
+// they appear as FUNCTION nodes in expressions, never as a from-clause
+// TABLE_FUNCTION, and none in DuckDB reads a file or executes SQL.
+var allowedTableFunctions = map[string]bool{
+	"range":           true,
+	"generate_series": true,
+}
+
+// sqlUserError is a problem with the submitted statement (refused by the
+// SELECT-only gate, rejected by DuckDB's parser, failed at execution, or timed
+// out) — a 422 with the engine's message, never a server fault.
+type sqlUserError struct{ msg string }
+
+func (e *sqlUserError) Error() string { return e.msg }
+
+type sqlPanelRequest struct {
+	SQL string `json:"sql"`
+}
+
+type sqlPanelResult struct {
+	Columns  []string `json:"columns"`
+	Rows     [][]any  `json:"rows"`
+	RowCount int      `json:"row_count"`
+	// Truncated is set when the row cap or the response byte budget cut the
+	// result short — never silently.
+	Truncated bool  `json:"truncated"`
+	ElapsedMS int64 `json:"elapsed_ms"`
+}
+
+// handleSQLPanel serves POST /api/sql.
+func (s *Server) handleSQLPanel(w http.ResponseWriter, r *http.Request) {
+	if !s.sqlPanel {
+		writeJSONError(w, http.StatusForbidden,
+			"the SQL panel is not enabled; start the console with BINTRAIL_CONSOLE_SQL_PANEL=1")
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, sqlPanelMaxStatementBytes)
+	var req sqlPanelRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var tooBig *http.MaxBytesError
+		if errors.As(err, &tooBig) {
+			writeJSONError(w, http.StatusRequestEntityTooLarge,
+				fmt.Sprintf("statement too large (max %d KiB)", sqlPanelMaxStatementBytes/1024))
+			return
+		}
+		writeJSONError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+	if strings.TrimSpace(req.SQL) == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing \"sql\"")
+		return
+	}
+	// Before resolving a bundle, like recover-cascade: a profiled session is
+	// refused regardless of which server it selected. Free-form SQL reads the
+	// unredacted Parquet directly, so it cannot honor per-column redaction.
+	if sessionRestricted(r) {
+		recordProfileGateDeny(r, "sql")
+		writeJSONError(w, http.StatusForbidden,
+			"the SQL panel is unavailable while an access-control profile is active — "+
+				"free-form SQL cannot honor column redaction")
+		return
+	}
+	b := s.resolveOr(w, r)
+	if b == nil {
+		return
+	}
+	if b.noArchive {
+		writeJSONError(w, http.StatusNotFound,
+			"archive access is disabled for this server, so there is no Parquet layout to query")
+		return
+	}
+	// One query in flight per process. Each panel session is its own DuckDB
+	// instance with its own memory budget, and this daemon may also be the
+	// stream supervisor — concurrent 4GB sessions would starve capture.
+	if !s.sqlPanelBusy.CompareAndSwap(false, true) {
+		writeJSONError(w, http.StatusTooManyRequests,
+			"another SQL panel query is already running — wait for it to finish or cancel it")
+		return
+	}
+	defer s.sqlPanelBusy.Store(false)
+
+	in, err := s.buildViewsInput(r.Context(), b)
+	switch {
+	case errors.Is(err, errNoViewSources):
+		writeJSONError(w, http.StatusNotFound, errNoViewSources.Error()+" — nothing to query")
+		return
+	case err != nil:
+		writeJSONError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+
+	res, err := runSandboxedSQL(r.Context(), in, req.SQL)
+	if err != nil {
+		var ue *sqlUserError
+		switch {
+		case errors.Is(err, context.Canceled):
+			// The human hit Cancel (or closed the tab): the fetch was aborted,
+			// the query was interrupted, and there is no one to answer.
+			return
+		case errors.As(err, &ue):
+			writeJSONError(w, http.StatusUnprocessableEntity, ue.msg)
+		default:
+			writeJSONError(w, http.StatusBadGateway, err.Error())
+		}
+		return
+	}
+
+	recordConsoleAccess(r, "sql.run", "", "", map[string]string{
+		"statement": req.SQL,
+		"rows":      fmt.Sprintf("%d", res.RowCount),
+		"truncated": fmt.Sprintf("%t", res.Truncated),
+	})
+	writeJSON(w, http.StatusOK, res)
+}
+
+// sqlPanelAvailable is the capability gate for /api/capabilities: the process
+// opted in AND the selected server has a Parquet layout the panel can query —
+// the same per-server conditions the handler enforces (viewsAvailable already
+// folds in noArchive and the session profile), so the UI never offers a tab
+// that only errors.
+func (s *Server) sqlPanelAvailable(r *http.Request, b *bundle) bool {
+	return s.sqlPanel && s.viewsAvailable(r, b)
+}
+
+// runSandboxedSQL opens a fresh sandboxed DuckDB session over the resolved
+// Parquet layout, enforces the SELECT-only gate, and executes stmt under the
+// hard timeout. One session per call: nothing survives between requests, and
+// lock_configuration can be applied unconditionally.
+func runSandboxedSQL(ctx context.Context, in views.Input, stmt string) (*sqlPanelResult, error) {
+	db, cleanup, err := openSandboxedSession(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	if err := sqlPanelGate(ctx, db, stmt); err != nil {
+		return nil, err
+	}
+
+	qctx, cancel := context.WithTimeout(ctx, sqlPanelTimeout)
+	defer cancel()
+	start := time.Now()
+	rows, err := db.QueryContext(qctx, stmt)
+	if err != nil {
+		return nil, sqlPanelExecError(ctx, qctx, err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, &sqlUserError{msg: err.Error()}
+	}
+	res := &sqlPanelResult{Columns: cols, Rows: [][]any{}}
+	bytesUsed := 0
+	for rows.Next() {
+		if res.RowCount >= sqlPanelMaxRows || bytesUsed >= sqlPanelMaxBytes {
+			res.Truncated = true
+			break
+		}
+		raw := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range raw {
+			ptrs[i] = &raw[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return nil, &sqlUserError{msg: err.Error()}
+		}
+		out := make([]any, len(cols))
+		for i, v := range raw {
+			cell, cost := sqlPanelCell(v)
+			out[i] = cell
+			bytesUsed += cost
+		}
+		res.Rows = append(res.Rows, out)
+		res.RowCount++
+	}
+	if err := rows.Err(); err != nil {
+		return nil, sqlPanelExecError(ctx, qctx, err)
+	}
+	res.ElapsedMS = time.Since(start).Milliseconds()
+	return res, nil
+}
+
+// openSandboxedSession builds the locked-down DuckDB session: httpfs/AWS setup
+// when S3 sources are present, the same view definitions /api/views.sql serves,
+// then the sandbox — allowed_directories over exactly the resolved roots, a
+// private spill directory, the conservative tuning budget, external access off,
+// and the configuration locked. Every sandbox statement is error-checked: a
+// sandbox that silently failed to apply must never serve a query.
+func openSandboxedSession(ctx context.Context, in views.Input) (*sql.DB, func(), error) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		return nil, nil, fmt.Errorf("open DuckDB: %w", err)
+	}
+	// One connection: DuckDB SET is applied per database here, but a single
+	// conn makes the setup→lock→query ordering self-evident.
+	db.SetMaxOpenConns(1)
+
+	// A PRIVATE spill directory. DuckDB implicitly allows file access under
+	// temp_directory, so pointing it at the shared os.TempDir() would quietly
+	// widen the sandbox to everything in /tmp.
+	spill, err := os.MkdirTemp("", "bintrail-sqlpanel-")
+	if err != nil {
+		db.Close()
+		return nil, nil, fmt.Errorf("create spill directory: %w", err)
+	}
+	cleanup := func() {
+		db.Close()
+		os.RemoveAll(spill)
+	}
+	fail := func(err error) (*sql.DB, func(), error) {
+		cleanup()
+		return nil, nil, err
+	}
+
+	// S3 credential setup, when the layout needs it, through bintrail's own
+	// tolerant helper — the SAME path parquetquery uses (httpfs + aws + a
+	// credential_chain secret). Deliberately NOT views.Generate's inline
+	// preamble: that `CREATE SECRET` aborts the whole script when no credential
+	// resolves, whereas EnableS3CredentialChain warns and continues — a read
+	// inside the allowed roots then fails at the S3 read (with a real auth
+	// error), not at session setup, and a local-only layout is unaffected.
+	if viewsInputNeedsS3(in) {
+		if err := duckdbutil.LoadHTTPFS(ctx, db); err != nil {
+			return fail(fmt.Errorf("S3 archive sources are configured but the DuckDB httpfs extension could not be loaded: %w", err))
+		}
+		duckdbutil.EnableS3CredentialChainRegion(ctx, db, in.ArchiveRegion)
+	}
+	// Withhold the paid forensics columns from the events view STRUCTURALLY —
+	// a property of the panel's session, not of the caller's input, so no future
+	// caller can forget it. This is the eventDTO boundary; free-form SQL over an
+	// unfiltered events view would serve exactly what eventDTO omits.
+	in.ExcludeEventColumns = forensicsEventColumns
+	// Only the view DDL — the preamble is for the downloadable file.
+	if _, err := db.ExecContext(ctx, views.GenerateViews(in)); err != nil {
+		return fail(fmt.Errorf("set up views over the Parquet layout: %w", err))
+	}
+
+	sandbox := []string{
+		"SET allowed_directories = " + sqlPanelAllowedList(in),
+		"SET temp_directory = " + sqlQuoteString(spill),
+	}
+	// The conservative daemon budget (#510) — never ultrafast: this process may
+	// co-host the stream supervisor. Applied by hand rather than Tuning.Apply
+	// because Apply is best-effort (warn-and-continue) and a resource bound
+	// that silently failed to apply is no bound.
+	t := duckdbutil.DefaultTuning()
+	sandbox = append(sandbox,
+		fmt.Sprintf("SET threads = %d", t.Threads),
+		"SET memory_limit = "+sqlQuoteString(t.MemoryLimit),
+		"SET enable_external_access = false",
+		"SET lock_configuration = true",
+	)
+	for _, stmt := range sandbox {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fail(fmt.Errorf("apply sandbox configuration %q: %w", stmt, err))
+		}
+	}
+	return db, cleanup, nil
+}
+
+// sqlPanelGate enforces SELECT-only, single-statement — the read-only layer.
+// Classification is DuckDB's own parser: json_serialize_sql serializes SELECT
+// statements and refuses everything else (COPY, CREATE, SET, ATTACH, INSTALL,
+// CREATE SECRET, ...), so the panel never grows a hand-rolled SQL classifier.
+// The statement travels as a bound parameter — it is data here, not SQL.
+func sqlPanelGate(ctx context.Context, db *sql.DB, stmt string) error {
+	// The ::VARCHAR on the RESULT is load-bearing: json_serialize_sql returns
+	// DuckDB's JSON type, which the driver decodes to a Go map — casting it
+	// back to text is what lets us Scan and re-parse it ourselves.
+	var out string
+	if err := db.QueryRowContext(ctx, "SELECT json_serialize_sql(?::VARCHAR)::VARCHAR", stmt).Scan(&out); err != nil {
+		return fmt.Errorf("classify statement: %w", err)
+	}
+	var parsed struct {
+		Error        bool              `json:"error"`
+		ErrorMessage string            `json:"error_message"`
+		Statements   []json.RawMessage `json:"statements"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		return fmt.Errorf("classify statement: %w", err)
+	}
+	if parsed.Error {
+		msg := parsed.ErrorMessage
+		if strings.Contains(msg, "Only SELECT statements") {
+			msg = "only SELECT statements can run here — the panel is read-only (writes, settings, ATTACH and COPY are refused)"
+		}
+		return &sqlUserError{msg: msg}
+	}
+	if len(parsed.Statements) != 1 {
+		return &sqlUserError{msg: "one statement at a time"}
+	}
+	// The statement is a single SELECT; refuse it if the parsed tree reaches a
+	// FROM-clause table function outside the allowlist (every file reader and
+	// dynamic-SQL re-entry function lands here), or the replacement-scan form
+	// (a file path as a table name). Walking the AST — not the raw text — makes
+	// this robust to casing, comments, CTEs and subqueries.
+	if reason, found := astViolatesReadPolicy([]byte(out)); found {
+		return &sqlUserError{msg: reason + " is not available in the SQL panel — query the events and state_* views instead"}
+	}
+	return nil
+}
+
+// astViolatesReadPolicy walks a json_serialize_sql AST and reports the first
+// disallowed FROM-clause source: a TABLE_FUNCTION whose name is not in
+// allowedTableFunctions, or a BASE_TABLE whose name is a file path (a
+// `FROM '<path>'` replacement scan). DuckDB records both — including inside
+// CTEs, subqueries and joins — under from-clause nodes typed TABLE_FUNCTION /
+// BASE_TABLE, so a single recursive scan for those node types covers them.
+func astViolatesReadPolicy(ast []byte) (string, bool) {
+	var tree any
+	if err := json.Unmarshal(ast, &tree); err != nil {
+		// A statement that already passed json_serialize_sql cannot fail to
+		// re-parse here; treat an unexpected shape as a violation, not a pass.
+		return "unparseable statement", true
+	}
+	return walkFromSources(tree)
+}
+
+func walkFromSources(node any) (string, bool) {
+	switch v := node.(type) {
+	case map[string]any:
+		switch v["type"] {
+		case "TABLE_FUNCTION":
+			// Fail closed: an unrecognizable name, or any name not explicitly
+			// allowed, is refused. This is where read_parquet, query(),
+			// query_table(), json_execute_serialized_sql() and every future
+			// reader land.
+			name := tableFunctionName(v)
+			if !allowedTableFunctions[strings.ToLower(name)] {
+				label := "a table function"
+				if name != "" {
+					label = "the function " + strings.ToLower(name)
+				}
+				return label, true
+			}
+		case "BASE_TABLE":
+			// A replacement scan (`FROM '/path/x.parquet'`) is a BASE_TABLE
+			// whose table_name is the file path. A real view/table identifier
+			// never contains a path separator or a URL scheme.
+			if name, ok := v["table_name"].(string); ok && looksLikeFilePath(name) {
+				return "reading a file path directly", true
+			}
+		}
+		for _, child := range v {
+			if r, found := walkFromSources(child); found {
+				return r, true
+			}
+		}
+	case []any:
+		for _, child := range v {
+			if r, found := walkFromSources(child); found {
+				return r, true
+			}
+		}
+	}
+	return "", false
+}
+
+// tableFunctionName pulls the function name out of a TABLE_FUNCTION from-clause
+// node (its nested "function" object carries function_name). Returns "" when the
+// shape is unexpected, which walkFromSources treats as disallowed.
+func tableFunctionName(node map[string]any) string {
+	fn, ok := node["function"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	name, _ := fn["function_name"].(string)
+	return name
+}
+
+// looksLikeFilePath reports whether a FROM-clause table name is actually a file
+// path or URL (a replacement scan) rather than a view/table identifier. Bintrail
+// identifiers never contain a path separator or a scheme, so any of those marks
+// a file read. A bare relative name (no separator) resolves against the working
+// directory, which is outside allowed_directories, so the sandbox denies it —
+// this check only needs to catch the forms that could reach an allowed root.
+func looksLikeFilePath(name string) bool {
+	return strings.ContainsAny(name, "/\\") || strings.Contains(name, "://")
+}
+
+// sqlPanelExecError classifies a query failure: the panel's own timeout, the
+// client canceling, or a statement error (including the sandbox's Permission
+// Error for reads outside the allowed roots — surfaced verbatim).
+func sqlPanelExecError(ctx, qctx context.Context, err error) error {
+	switch {
+	case ctx.Err() != nil:
+		return context.Canceled
+	case qctx.Err() != nil:
+		return &sqlUserError{msg: fmt.Sprintf("query canceled: it exceeded the %s limit", sqlPanelTimeout)}
+	default:
+		return &sqlUserError{msg: err.Error()}
+	}
+}
+
+// sqlPanelAllowedList renders the allowed_directories literal for the resolved
+// roots. A trailing separator on every entry keeps the match a DIRECTORY
+// boundary: an allowed ".../lake" must never also admit ".../lakeevil".
+func sqlPanelAllowedList(in views.Input) string {
+	var roots []string
+	for _, src := range in.ArchiveSources {
+		roots = append(roots, strings.TrimRight(src, "/")+"/")
+	}
+	if in.BaselineSource != "" {
+		roots = append(roots, strings.TrimRight(in.BaselineSource, "/")+"/")
+	}
+	quoted := make([]string, len(roots))
+	for i, r := range roots {
+		quoted[i] = sqlQuoteString(r)
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
+}
+
+func viewsInputNeedsS3(in views.Input) bool {
+	for _, src := range in.ArchiveSources {
+		if strings.HasPrefix(src, "s3://") {
+			return true
+		}
+	}
+	if strings.HasPrefix(in.BaselineSource, "s3://") {
+		return true
+	}
+	for _, b := range in.Baselines {
+		if strings.HasPrefix(b.Path, "s3://") {
+			return true
+		}
+	}
+	return false
+}
+
+// sqlQuoteString renders a DuckDB single-quoted string literal.
+func sqlQuoteString(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// sqlPanelCell converts one scanned DuckDB value into a JSON-encodable cell and
+// reports its approximate response cost. Strings and byte blobs pass through;
+// times render as UTC RFC3339; DuckDB's HUGEINT arrives as *big.Int and is
+// rendered as a string (JSON numbers lose precision past 2^53); anything the
+// driver hands us beyond that (LIST/STRUCT/DECIMAL/...) is rendered via fmt so
+// no exotic type can ever fail the encoder mid-response.
+func sqlPanelCell(v any) (any, int) {
+	switch x := v.(type) {
+	case nil:
+		return nil, 4
+	case []byte:
+		s := string(x)
+		return s, len(s)
+	case string:
+		return x, len(x)
+	case time.Time:
+		s := x.UTC().Format(time.RFC3339Nano)
+		return s, len(s)
+	case *big.Int:
+		s := x.String()
+		return s, len(s)
+	case bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return x, 16
+	default:
+		s := fmt.Sprint(x)
+		return s, len(s)
+	}
+}

--- a/internal/console/sqlpanel_test.go
+++ b/internal/console/sqlpanel_test.go
@@ -1,0 +1,706 @@
+package console
+
+// The #1177 escape suite. These tests drive the REAL production functions
+// (runSandboxedSQL / openSandboxedSession / the handler through the mux), not a
+// hand-built lookalike session: the security posture is exactly what these
+// calls configure, so a test session assembled by hand would prove nothing.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+
+	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/internal/archive"
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/views"
+)
+
+// writeSQLPanelArchive writes one archived partition in the exact Hive layout
+// rotation produces, through the real archive column set and Parquet writer
+// (the same fixture shape internal/views' execute test uses).
+func writeSQLPanelArchive(t *testing.T, root, id string) {
+	t.Helper()
+	path := filepath.Join(root, "bintrail_id="+id, "event_date=2026-05-01", "event_hour=03", "events.parquet")
+	w, err := baseline.NewWriter(path, archive.BinlogEventColumns, baseline.WriterConfig{
+		Compression: "none", RowGroupSize: 100,
+	})
+	if err != nil {
+		t.Fatalf("archive writer: %v", err)
+	}
+	values := []string{
+		"1", "binlog.000001", "100", "200", "2026-05-01 03:00:00", "",
+		"42", "shop", "orders", "2", "1",
+		`["status"]`, `{"id":1,"status":"new"}`, `{"id":1,"status":"paid"}`,
+		"1", "", "", "1777000000000000",
+	}
+	nulls := make([]bool, len(archive.BinlogEventColumns))
+	nulls[5] = true  // gtid
+	nulls[15] = true // query_text
+	nulls[16] = true // query_hash
+	if len(values) != len(archive.BinlogEventColumns) {
+		t.Fatalf("fixture has %d values for %d columns — update the fixture with the column set",
+			len(values), len(archive.BinlogEventColumns))
+	}
+	if err := w.WriteRow(values, nulls); err != nil {
+		t.Fatalf("write archive row: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close archive writer: %v", err)
+	}
+}
+
+// writeSQLPanelBaseline writes a real two-row baseline snapshot readable by
+// DuckDB and returns (baselineRoot, tableParquetPath).
+func writeSQLPanelBaseline(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	schemaFile := filepath.Join(t.TempDir(), "shop.orders-schema.sql")
+	ddl := "CREATE TABLE `orders` (\n  `id` int NOT NULL,\n  `status` varchar(32) DEFAULT NULL,\n  PRIMARY KEY (`id`)\n);\n"
+	if err := os.WriteFile(schemaFile, []byte(ddl), 0o644); err != nil {
+		t.Fatalf("write schema file: %v", err)
+	}
+	cols, err := baseline.ParseSchema(schemaFile)
+	if err != nil {
+		t.Fatalf("ParseSchema: %v", err)
+	}
+	path := filepath.Join(root, "2026-04-30T03-00-00Z", "shop", "orders.parquet")
+	w, err := baseline.NewWriter(path, cols, baseline.WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("baseline writer: %v", err)
+	}
+	for _, r := range [][]string{{"1", "new"}, {"2", "paid"}} {
+		if err := w.WriteRow(r, []bool{false, false}); err != nil {
+			t.Fatalf("write baseline row: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close baseline writer: %v", err)
+	}
+	return root, path
+}
+
+// panelInput assembles the views.Input runSandboxedSQL receives, exactly as
+// buildViewsInput would resolve it for these roots.
+func panelInput(archiveSources []string, baselineRoot, baselinePath string) views.Input {
+	in := views.Input{
+		GeneratedAt:    time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		Version:        "test",
+		ArchiveSources: archiveSources,
+	}
+	if baselineRoot != "" {
+		in.BaselineSource = baselineRoot
+		in.BaselineSnapshot = time.Date(2026, 4, 30, 3, 0, 0, 0, time.UTC)
+		in.Baselines = []views.BaselineTable{{Schema: "shop", Table: "orders", Path: baselinePath}}
+	}
+	return in
+}
+
+// newSQLPanelServer builds a Server whose boot bundle points at a REAL baseline
+// snapshot (DuckDB-readable, unlike the empty-file fixtures the listing tests
+// use) with the panel opted in.
+func newSQLPanelServer(t *testing.T, baselineRoot string, enabled bool) *Server {
+	t.Helper()
+	s := &Server{token: "t", version: "v0.50.0", cm: newConnManager(nil, false), sqlPanel: enabled}
+	s.cm.boot = &bundle{baselineSrc: baselineRoot, baselineConfigured: baselineRoot != ""}
+	s.mux = s.buildHandler()
+	return s
+}
+
+// TestSQLPanel_readsArchiveAndBaseline is the positive control: the sandboxed
+// session serves the same events/state views the downloadable artifact defines.
+// Without it, every "denied" below could equally mean "the session is broken".
+func TestSQLPanel_readsArchiveAndBaseline(t *testing.T) {
+	archiveRoot := t.TempDir()
+	const id = "11111111-2222-3333-4444-555555555555"
+	writeSQLPanelArchive(t, archiveRoot, id)
+	baselineRoot, baselinePath := writeSQLPanelBaseline(t)
+	in := panelInput([]string{filepath.Join(archiveRoot, "bintrail_id="+id)}, baselineRoot, baselinePath)
+
+	res, err := runSandboxedSQL(context.Background(), in, `SELECT event_type, schema_name FROM events`)
+	if err != nil {
+		t.Fatalf("query events view: %v", err)
+	}
+	if res.RowCount != 1 || res.Truncated {
+		t.Fatalf("events: rows=%d truncated=%v, want 1/false", res.RowCount, res.Truncated)
+	}
+	if res.Rows[0][0] != "UPDATE" || res.Rows[0][1] != "shop" {
+		t.Errorf("events row = %v, want [UPDATE shop]", res.Rows[0])
+	}
+
+	res, err = runSandboxedSQL(context.Background(), in, `SELECT count(*) FROM state_shop_orders WHERE status = 'paid'`)
+	if err != nil {
+		t.Fatalf("query state view: %v", err)
+	}
+	if fmt.Sprint(res.Rows[0][0]) != "1" {
+		t.Errorf("state view count = %v, want 1", res.Rows[0][0])
+	}
+}
+
+// TestSQLPanel_gateBlocksRawFileAccess is the FIRST of the two forensics-leak
+// defenses (the gate). The sandbox necessarily grants read access to the archive
+// roots so the views work, so the gate must stop a query from reading the raw
+// files under them — either through a reader function or the replacement-scan
+// form — which would otherwise expose the paid forensics columns the events view
+// withholds. The critical case is the direct read of a real archive file's
+// connection_id.
+func TestSQLPanel_gateBlocksRawFileAccess(t *testing.T) {
+	archiveRoot := t.TempDir()
+	const id = "11111111-2222-3333-4444-555555555555"
+	writeSQLPanelArchive(t, archiveRoot, id)
+	source := filepath.Join(archiveRoot, "bintrail_id="+id)
+	archiveFile := filepath.Join(source, "event_date=2026-05-01", "event_hour=03", "events.parquet")
+	in := panelInput([]string{source}, "", "")
+
+	esc := func(s string) string { return strings.ReplaceAll(s, "'", "''") }
+	for _, tc := range []struct{ name, stmt string }{
+		// The forensics bypass the events-view filter alone would miss: read the
+		// raw archive Parquet, which carries all 18 columns.
+		{"read_parquet forensics column", fmt.Sprintf("SELECT connection_id FROM read_parquet('%s')", archiveFile)},
+		{"replacement scan forensics column", fmt.Sprintf("SELECT connection_id FROM '%s'", archiveFile)},
+		{"replacement scan glob", fmt.Sprintf("SELECT * FROM '%s/*/*/*.parquet'", source)},
+		{"parquet_scan", fmt.Sprintf("SELECT * FROM parquet_scan('%s')", archiveFile)},
+		{"parquet_metadata", fmt.Sprintf("SELECT * FROM parquet_metadata('%s')", archiveFile)},
+		{"glob the archive root", fmt.Sprintf("SELECT * FROM glob('%s/*')", source)},
+		{"read_text an archive file", fmt.Sprintf("SELECT * FROM read_text('%s')", archiveFile)},
+		{"read_csv", fmt.Sprintf("SELECT * FROM read_csv('%s')", archiveFile)},
+		{"read_json_objects_auto", fmt.Sprintf("SELECT * FROM read_json_objects_auto('%s')", archiveFile)},
+		// Casing / nesting must not evade the AST walk.
+		{"nested reader in CTE", fmt.Sprintf("WITH q AS (SELECT * FROM READ_PARQUET('%s')) SELECT * FROM q", archiveFile)},
+		// The dynamic-SQL re-entry functions: DuckDB re-parses their STRING
+		// argument at bind time, after this gate — a denylist of reader names
+		// never sees the read. The allowlist refuses the outer function itself.
+		// These are the exact leaks the #1177 review measured (connection_id=42).
+		{"query() dynamic SQL", fmt.Sprintf("SELECT * FROM query('SELECT connection_id FROM read_parquet(''%s'')')", esc(archiveFile))},
+		{"query_table()", fmt.Sprintf("SELECT connection_id FROM query_table('%s')", archiveFile)},
+		{"json_execute_serialized_sql", fmt.Sprintf("SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT connection_id FROM read_parquet(''%s'')'))", esc(archiveFile))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := runSandboxedSQL(context.Background(), in, tc.stmt)
+			var ue *sqlUserError
+			if !errors.As(err, &ue) {
+				t.Fatalf("raw file access was not refused by the gate (rows leaked: %+v): %v", res, err)
+			}
+			if !strings.Contains(ue.msg, "not available") {
+				t.Fatalf("expected the denied-read message, got: %v", ue.msg)
+			}
+		})
+	}
+}
+
+// TestSQLPanel_onlyAllowlistedTableFunctionsReachable is the durable guard the
+// allowlist earns: it enumerates EVERY table function the sandboxed DuckDB
+// exposes and asserts the gate refuses each one that is not on the allowlist.
+// A future DuckDB (or a loaded extension) that adds a new file reader or
+// SQL-re-entry function is therefore denied by default — and if someone widens
+// allowedTableFunctions to something dangerous, this still passes only because
+// the walk denies everything else. It runs the REAL gate (sqlPanelGate), so it
+// also proves the AST shape assumption holds for every function at once.
+func TestSQLPanel_onlyAllowlistedTableFunctionsReachable(t *testing.T) {
+	db, cleanup, err := openSandboxedSession(context.Background(),
+		func() views.Input { r, p := writeSQLPanelBaseline(t); return panelInput(nil, r, p) }())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	// duckdb_functions() is itself a table function — read it on a plain
+	// session, before the sandbox would (correctly) refuse it.
+	plain, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer plain.Close()
+	rows, err := plain.Query(`SELECT DISTINCT function_name FROM duckdb_functions() WHERE function_type = 'table'`)
+	if err != nil {
+		t.Fatalf("enumerate table functions: %v", err)
+	}
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		names = append(names, n)
+	}
+	rows.Close()
+	if len(names) < 20 {
+		t.Fatalf("only %d table functions enumerated — the query is wrong", len(names))
+	}
+
+	denied := map[string]bool{}
+	for _, name := range names {
+		if allowedTableFunctions[strings.ToLower(name)] {
+			continue
+		}
+		// A bare zero-arg call parses (argument errors are a bind-time concern,
+		// after json_serialize_sql), so the gate can classify every one.
+		stmt := fmt.Sprintf(`SELECT * FROM "%s"()`, name)
+		err := sqlPanelGate(context.Background(), db, stmt)
+		var ue *sqlUserError
+		if err == nil {
+			t.Errorf("gate ALLOWED non-allowlisted table function %q — potential file/SQL read", name)
+			continue
+		}
+		if !errors.As(err, &ue) {
+			// json_serialize_sql couldn't parse the bare call for this function
+			// (some need arguments to parse) — not a policy pass, skip it.
+			continue
+		}
+		if !strings.Contains(ue.msg, "not available") {
+			t.Errorf("%q denied with an unexpected message: %v", name, ue.msg)
+		}
+		denied[strings.ToLower(name)] = true
+	}
+
+	// Guard against a vacuous pass (if bare calls mostly failed to parse, the
+	// loop above would assert almost nothing): the dangerous functions the
+	// gate exists to stop MUST be in the enumerated-and-denied set.
+	t.Logf("enumerated %d table functions, %d denied by the gate", len(names), len(denied))
+	for _, must := range []string{"read_parquet", "query", "query_table", "duckdb_secrets", "glob"} {
+		if !denied[must] {
+			t.Errorf("%q was not among the enumerated-and-denied functions — the guard is not exercising the readers it claims to", must)
+		}
+	}
+}
+
+// TestSQLPanel_sandboxDeniesOutOfRootReads is the SECOND defense (the filesystem
+// sandbox), tested DIRECTLY on a production-built session so it holds even if the
+// gate above were bypassed: a read outside the allowed roots — a sibling temp
+// dir, a file in the shared os.TempDir(), an S3 path, or an arbitrary HTTPS URL
+// (the SSRF the issue names) — dies on DuckDB's own config/permission check. No
+// bucket or credentials involved, so it reproduces anywhere. The panel's spill
+// directory is private on purpose: DuckDB implicitly allows file access under
+// temp_directory, so pointing it at the shared os.TempDir() would widen the
+// sandbox to everything in /tmp.
+func TestSQLPanel_sandboxDeniesOutOfRootReads(t *testing.T) {
+	baselineRoot, baselinePath := writeSQLPanelBaseline(t)
+	db, cleanup, err := openSandboxedSession(context.Background(), panelInput(nil, baselineRoot, baselinePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	secret := t.TempDir()
+	if err := os.WriteFile(filepath.Join(secret, "s.csv"), []byte("x\n99\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sharedTmp := filepath.Join(os.TempDir(), fmt.Sprintf("bintrail-sqlpanel-escape-%d.csv", os.Getpid()))
+	if err := os.WriteFile(sharedTmp, []byte("x\n7\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(sharedTmp)
+
+	const denied = "disabled by configuration"
+	for _, tc := range []struct{ name, stmt string }{
+		{"read sibling temp dir", fmt.Sprintf("SELECT * FROM read_csv('%s/s.csv')", secret)},
+		{"read shared os.TempDir file", fmt.Sprintf("SELECT * FROM read_csv('%s')", sharedTmp)},
+		{"glob outside the roots", fmt.Sprintf("SELECT * FROM glob('%s/*')", secret)},
+		{"replacement scan out of root", fmt.Sprintf("SELECT * FROM '%s/s.csv'", secret)},
+		{"s3 read (no root allows it)", "SELECT * FROM read_parquet('s3://any-bucket/x.parquet')"},
+		{"arbitrary https URL (SSRF)", "SELECT * FROM read_text('https://example.com/')"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Execute directly on the session — NOT through runSandboxedSQL —
+			// so the gate is bypassed and it is the sandbox under test.
+			_, err := db.ExecContext(context.Background(), tc.stmt)
+			if err == nil {
+				t.Fatal("the sandbox allowed a read outside the allowed roots")
+			}
+			if !strings.Contains(err.Error(), denied) {
+				t.Fatalf("expected the permission refusal (%q), got: %v", denied, err)
+			}
+		})
+	}
+}
+
+// TestSQLPanelAllowedListBoundary pins the trailing-separator boundary in the
+// allowed_directories literal: an allowed ".../lake" must not string-prefix
+// match ".../lakeevil". This is the whole defense against a same-bucket sibling
+// prefix, and it is pure string logic — no DuckDB needed to prove it.
+func TestSQLPanelAllowedListBoundary(t *testing.T) {
+	got := sqlPanelAllowedList(views.Input{
+		ArchiveSources: []string{"s3://bucket/lake", "/local/archive/"},
+		BaselineSource: "s3://bucket/baselines",
+	})
+	for _, want := range []string{"'s3://bucket/lake/'", "'/local/archive/'", "'s3://bucket/baselines/'"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("allowed list %s is missing a directory-boundary entry %s", got, want)
+		}
+	}
+	if strings.Contains(got, "'s3://bucket/lake',") || strings.Contains(got, "'s3://bucket/lake']") {
+		t.Errorf("an entry lacks its trailing separator — 'lake' would admit 'lakeevil': %s", got)
+	}
+}
+
+// TestSQLPanel_withholdsForensicsColumns is the open-core boundary (#1177): the
+// panel executes server-side, so its `events` view must NOT expose the paid
+// forensics columns the console's eventDTO omits (connection_id, query_text,
+// query_hash). Reading them must fail as unknown columns; the free columns must
+// still be there. Serving these would give away a paid EE surface from the
+// Apache-licensed core.
+func TestSQLPanel_withholdsForensicsColumns(t *testing.T) {
+	archiveRoot := t.TempDir()
+	const id = "11111111-2222-3333-4444-555555555555"
+	writeSQLPanelArchive(t, archiveRoot, id)
+	in := panelInput([]string{filepath.Join(archiveRoot, "bintrail_id="+id)}, "", "")
+
+	for _, col := range []string{"connection_id", "query_text", "query_hash"} {
+		_, err := runSandboxedSQL(context.Background(), in, "SELECT "+col+" FROM events")
+		var ue *sqlUserError
+		if !errors.As(err, &ue) {
+			t.Errorf("SELECT %s FROM events did not refuse (forensics column leaked): %v", col, err)
+		}
+	}
+	// A free column is unaffected.
+	if _, err := runSandboxedSQL(context.Background(), in, "SELECT schema_name FROM events"); err != nil {
+		t.Errorf("a non-forensics column was wrongly withheld: %v", err)
+	}
+	// SELECT * must not carry them either.
+	res, err := runSandboxedSQL(context.Background(), in, "SELECT * FROM events")
+	if err != nil {
+		t.Fatalf("SELECT *: %v", err)
+	}
+	for _, c := range res.Columns {
+		switch strings.ToLower(c) {
+		case "connection_id", "query_text", "query_hash":
+			t.Errorf("SELECT * exposed the forensics column %q", c)
+		}
+	}
+}
+
+// TestSQLPanel_gateRefusesSecretIntrospection: the secrets manager exposes an S3
+// secret's access-key id even with the value redacted, so the gate refuses the
+// table functions that read it — matched on the parsed AST, so casing, comments
+// and nesting do not evade it.
+func TestSQLPanel_gateRefusesSecretIntrospection(t *testing.T) {
+	baselineRoot, baselinePath := writeSQLPanelBaseline(t)
+	in := panelInput(nil, baselineRoot, baselinePath)
+	for _, stmt := range []string{
+		"SELECT * FROM duckdb_secrets()",
+		"select SECRET_STRING from DuckDB_Secrets()",
+		"WITH q AS (SELECT * FROM duckdb_secrets()) SELECT * FROM q",
+		"SELECT (SELECT name FROM duckdb_secrets() LIMIT 1)",
+		"SELECT * FROM which_secret('s3://x/y', 's3')",
+		"SELECT * FROM duckdb_secrets() /* comment */",
+	} {
+		_, err := runSandboxedSQL(context.Background(), in, stmt)
+		var ue *sqlUserError
+		if !errors.As(err, &ue) || !strings.Contains(ue.msg, "not available") {
+			t.Errorf("%q: expected the denied-function refusal, got: %v", stmt, err)
+		}
+	}
+	// An allowlisted generator, by contrast, runs — the gate is a FROM-clause
+	// allowlist, not a blanket ban on all table-shaped syntax.
+	if _, err := runSandboxedSQL(context.Background(), in, "SELECT count(*) FROM range(10)"); err != nil {
+		t.Errorf("range() should be allowed: %v", err)
+	}
+}
+
+// TestSQLPanel_gateRefusesNonSelect: the read-only layer. DuckDB's
+// allowed_directories carve-out permits writes INSIDE the roots (COPY TO,
+// ATTACH of a writable database), so every non-SELECT statement must die on the
+// gate — classified by DuckDB's own parser, before execution.
+func TestSQLPanel_gateRefusesNonSelect(t *testing.T) {
+	baselineRoot, baselinePath := writeSQLPanelBaseline(t)
+	in := panelInput(nil, baselineRoot, baselinePath)
+
+	for _, tc := range []struct {
+		name, stmt string
+	}{
+		{"COPY TO inside the allowed root", fmt.Sprintf("COPY (SELECT 1) TO '%s/evil.parquet'", baselineRoot)},
+		{"ATTACH inside the allowed root", fmt.Sprintf("ATTACH '%s/evil.db' AS x", baselineRoot)},
+		{"CREATE TABLE", "CREATE TABLE t AS SELECT 1"},
+		// CREATE SECRET survives lock_configuration (secrets are not settings),
+		// so the gate is its only barrier — pinned here on purpose.
+		{"CREATE SECRET", "CREATE OR REPLACE SECRET evil (TYPE s3, KEY_ID 'k', SECRET 's')"},
+		{"SET", "SET enable_external_access = true"},
+		{"PRAGMA", "PRAGMA memory_limit='99GB'"},
+		{"INSTALL", "INSTALL httpfs"},
+		{"multi-statement", "SELECT 1; COPY (SELECT 1) TO '/x.csv'"},
+		{"two SELECTs", "SELECT 1; SELECT 2"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := runSandboxedSQL(context.Background(), in, tc.stmt)
+			var ue *sqlUserError
+			if !errors.As(err, &ue) {
+				t.Fatalf("expected the statement gate to refuse, got: %v", err)
+			}
+		})
+	}
+
+	// A syntax error surfaces the parser's own message — usable feedback, not
+	// a generic refusal.
+	_, err := runSandboxedSQL(context.Background(), in, "SELEC 1")
+	var ue *sqlUserError
+	if !errors.As(err, &ue) || !strings.Contains(strings.ToLower(ue.msg), "error") {
+		t.Fatalf("syntax error should surface the parser message, got: %v", err)
+	}
+}
+
+// TestSQLPanel_lockedConfigurationHolds exercises the lock layer DIRECTLY on a
+// session built by the production setup: even if the SELECT-only gate ever
+// regressed, no statement may widen the sandbox after it is locked.
+func TestSQLPanel_lockedConfigurationHolds(t *testing.T) {
+	baselineRoot, baselinePath := writeSQLPanelBaseline(t)
+	db, cleanup, err := openSandboxedSession(context.Background(), panelInput(nil, baselineRoot, baselinePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	for _, stmt := range []string{
+		"SET enable_external_access = true",
+		"SET allowed_directories = ['/']",
+		"SET lock_configuration = false",
+		"SET memory_limit = '99GB'",
+		"SET threads = 64",
+		"SET temp_directory = '/'",
+	} {
+		if _, err := db.Exec(stmt); err == nil {
+			t.Errorf("%s: succeeded after lock_configuration", stmt)
+		} else if !strings.Contains(err.Error(), "locked") {
+			t.Errorf("%s: expected the configuration-locked refusal, got: %v", stmt, err)
+		}
+	}
+}
+
+// TestSQLPanel_capsRowsAndBytes: interactive surface, bounded response.
+func TestSQLPanel_capsRowsAndBytes(t *testing.T) {
+	baselineRoot, baselinePath := writeSQLPanelBaseline(t)
+	in := panelInput(nil, baselineRoot, baselinePath)
+
+	res, err := runSandboxedSQL(context.Background(), in, "SELECT * FROM range(2000)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.RowCount != sqlPanelMaxRows || !res.Truncated {
+		t.Errorf("rows=%d truncated=%v, want %d/true", res.RowCount, res.Truncated, sqlPanelMaxRows)
+	}
+
+	// Wide rows must trip the byte budget long before the row cap.
+	res, err = runSandboxedSQL(context.Background(), in, "SELECT repeat('x', 5000000) FROM range(5)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Truncated || res.RowCount >= 5 {
+		t.Errorf("rows=%d truncated=%v, want the byte budget to truncate below 5 rows", res.RowCount, res.Truncated)
+	}
+}
+
+// TestSQLPanel_timeoutInterrupts: the hard wall-clock budget must INTERRUPT the
+// running query, not just abandon it — a bounded response with an unbounded
+// query still chewing daemon CPU would be no bound at all.
+func TestSQLPanel_timeoutInterrupts(t *testing.T) {
+	baselineRoot, baselinePath := writeSQLPanelBaseline(t)
+	in := panelInput(nil, baselineRoot, baselinePath)
+
+	old := sqlPanelTimeout
+	sqlPanelTimeout = 300 * time.Millisecond
+	defer func() { sqlPanelTimeout = old }()
+
+	start := time.Now()
+	_, err := runSandboxedSQL(context.Background(), in, "SELECT count(*) FROM range(200000000000)")
+	elapsed := time.Since(start)
+	var ue *sqlUserError
+	if !errors.As(err, &ue) || !strings.Contains(ue.msg, "exceeded") {
+		t.Fatalf("expected the timeout refusal, got: %v", err)
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("timeout took %s to interrupt — the query was not actually canceled", elapsed)
+	}
+}
+
+// TestSQLPanel_cancelInterrupts is the human Cancel button: aborting the fetch
+// kills the request context, and the query must stop promptly. No cancel
+// endpoint exists — this IS the cancellation path.
+func TestSQLPanel_cancelInterrupts(t *testing.T) {
+	baselineRoot, baselinePath := writeSQLPanelBaseline(t)
+	in := panelInput(nil, baselineRoot, baselinePath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+	start := time.Now()
+	_, err := runSandboxedSQL(ctx, in, "SELECT count(*) FROM range(200000000000)")
+	elapsed := time.Since(start)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("cancellation took %s to interrupt — the query was not actually stopped", elapsed)
+	}
+}
+
+// TestSQLPanelHandler drives POST /api/sql through the full mux (auth
+// middleware, route registration, authz classification included), so a broken
+// wire — not just a broken engine — fails here.
+func TestSQLPanelHandler(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		baselineRoot, _ := writeSQLPanelBaseline(t)
+		srv := newSQLPanelServer(t, baselineRoot, false)
+		rec, body := doServersReq(t, srv, "POST", "/api/sql", `{"sql":"SELECT 1"}`)
+		if rec.Code != http.StatusForbidden || !strings.Contains(string(body), "BINTRAIL_CONSOLE_SQL_PANEL") {
+			t.Fatalf("code=%d body=%s, want 403 naming the opt-in", rec.Code, body)
+		}
+	})
+	t.Run("success over the baseline", func(t *testing.T) {
+		baselineRoot, _ := writeSQLPanelBaseline(t)
+		srv := newSQLPanelServer(t, baselineRoot, true)
+		rec, body := doServersReq(t, srv, "POST", "/api/sql",
+			`{"sql":"SELECT id, status FROM state_shop_orders ORDER BY id"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("code=%d body=%s", rec.Code, body)
+		}
+		s := string(body)
+		for _, want := range []string{`"columns":["id","status"]`, `"row_count":2`, `"paid"`} {
+			if !strings.Contains(s, want) {
+				t.Errorf("response missing %s: %s", want, s)
+			}
+		}
+	})
+	t.Run("statement error is a 422 with the engine message", func(t *testing.T) {
+		baselineRoot, _ := writeSQLPanelBaseline(t)
+		srv := newSQLPanelServer(t, baselineRoot, true)
+		rec, body := doServersReq(t, srv, "POST", "/api/sql", `{"sql":"SELECT nope FROM state_shop_orders"}`)
+		if rec.Code != http.StatusUnprocessableEntity {
+			t.Fatalf("code=%d body=%s, want 422", rec.Code, body)
+		}
+	})
+	t.Run("busy returns 429", func(t *testing.T) {
+		baselineRoot, _ := writeSQLPanelBaseline(t)
+		srv := newSQLPanelServer(t, baselineRoot, true)
+		srv.sqlPanelBusy.Store(true)
+		defer srv.sqlPanelBusy.Store(false)
+		rec, body := doServersReq(t, srv, "POST", "/api/sql", `{"sql":"SELECT 1"}`)
+		if rec.Code != http.StatusTooManyRequests {
+			t.Fatalf("code=%d body=%s, want 429", rec.Code, body)
+		}
+	})
+	t.Run("nothing to query", func(t *testing.T) {
+		srv := newSQLPanelServer(t, "", true)
+		rec, body := doServersReq(t, srv, "POST", "/api/sql", `{"sql":"SELECT 1"}`)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("code=%d body=%s, want 404", rec.Code, body)
+		}
+	})
+	t.Run("no-archive server refused", func(t *testing.T) {
+		baselineRoot, _ := writeSQLPanelBaseline(t)
+		srv := newSQLPanelServer(t, baselineRoot, true)
+		srv.cm.boot.noArchive = true
+		rec, body := doServersReq(t, srv, "POST", "/api/sql", `{"sql":"SELECT 1"}`)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("code=%d body=%s, want 404", rec.Code, body)
+		}
+	})
+	t.Run("empty and malformed bodies", func(t *testing.T) {
+		baselineRoot, _ := writeSQLPanelBaseline(t)
+		srv := newSQLPanelServer(t, baselineRoot, true)
+		for _, body := range []string{`{"sql":"  "}`, `{bad`} {
+			rec, got := doServersReq(t, srv, "POST", "/api/sql", body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("body %q: code=%d resp=%s, want 400", body, rec.Code, got)
+			}
+		}
+	})
+	t.Run("oversized statement refused", func(t *testing.T) {
+		baselineRoot, _ := writeSQLPanelBaseline(t)
+		srv := newSQLPanelServer(t, baselineRoot, true)
+		big := `{"sql":"SELECT '` + strings.Repeat("x", sqlPanelMaxStatementBytes) + `'"}`
+		rec, body := doServersReq(t, srv, "POST", "/api/sql", big)
+		if rec.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("code=%d body=%s, want 413", rec.Code, body)
+		}
+	})
+}
+
+// TestSQLPanelHandler_profileSessionRefused: the RBAC gate, enforced at the
+// endpoint (not the UI), before any bundle is resolved — same shape as
+// recover-cascade's.
+func TestSQLPanelHandler_profileSessionRefused(t *testing.T) {
+	srv, err := New(Config{
+		Listen: "127.0.0.1:8090", Token: "static-tok", SQLPanel: true,
+		AuthPath: filepath.Join(t.TempDir(), "auth.yaml"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok, _, err := srv.sessions.IssueWithPolicy("sam@example.com",
+		&ext.AccessPolicy{Permissions: ext.AllPermissions(), Profile: "sensitive"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := postJSON(t, srv, "/api/sql", tok, `{"sql":"SELECT 1"}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("profiled POST /api/sql = %d body=%s, want 403", w.Code, w.Body.String())
+	}
+}
+
+// TestSQLPanelAvailable mirrors the handler's gates, which is the point: the
+// capability decides whether the UI shows the tab, and a tab that only errors
+// is a lie. It also pins that Config.SQLPanel actually reaches the server —
+// delete that wire and the "enabled" cases fail.
+func TestSQLPanelAvailable(t *testing.T) {
+	baselineRoot, _ := writeSQLPanelBaseline(t)
+
+	for _, tc := range []struct {
+		name    string
+		enabled bool
+		b       *bundle
+		want    bool
+	}{
+		{"enabled with a baseline", true, &bundle{baselineSrc: baselineRoot}, true},
+		{"not opted in", false, &bundle{baselineSrc: baselineRoot}, false},
+		{"archives disabled", true, &bundle{baselineSrc: baselineRoot, noArchive: true}, false},
+		{"nothing configured", true, &bundle{}, false},
+		{"no bundle", true, nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{cm: newConnManager(nil, false), sqlPanel: tc.enabled}
+			r := httptest.NewRequest("GET", "http://127.0.0.1:8090/api/sql", nil)
+			if got := s.sqlPanelAvailable(r, tc.b); got != tc.want {
+				t.Fatalf("sqlPanelAvailable = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// The Config wire: New must carry SQLPanel onto the server.
+	srv, err := New(Config{Listen: "127.0.0.1:8090", Token: "t", SQLPanel: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !srv.sqlPanel {
+		t.Error("Config.SQLPanel did not reach Server.sqlPanel")
+	}
+}
+
+// TestSQLPanelCapabilityAdvertised reads the real /api/capabilities payload:
+// the tab's gate in the SPA is this boolean, so it must track the opt-in.
+func TestSQLPanelCapabilityAdvertised(t *testing.T) {
+	baselineRoot, _ := writeSQLPanelBaseline(t)
+	for _, tc := range []struct {
+		enabled bool
+		want    string
+	}{
+		{true, `"sql":true`},
+		{false, `"sql":false`},
+	} {
+		srv := newSQLPanelServer(t, baselineRoot, tc.enabled)
+		rec, body := doServersReq(t, srv, "GET", "/api/capabilities", "")
+		if rec.Code != http.StatusOK || !strings.Contains(string(body), tc.want) {
+			t.Fatalf("enabled=%v: code=%d body=%s, want %s", tc.enabled, rec.Code, body, tc.want)
+		}
+	}
+}

--- a/internal/console/sqlpanel_test.go
+++ b/internal/console/sqlpanel_test.go
@@ -184,6 +184,12 @@ func TestSQLPanel_gateBlocksRawFileAccess(t *testing.T) {
 		{"query() dynamic SQL", fmt.Sprintf("SELECT * FROM query('SELECT connection_id FROM read_parquet(''%s'')')", esc(archiveFile))},
 		{"query_table()", fmt.Sprintf("SELECT connection_id FROM query_table('%s')", archiveFile)},
 		{"json_execute_serialized_sql", fmt.Sprintf("SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT connection_id FROM read_parquet(''%s'')'))", esc(archiveFile))},
+		// A reader nested in a set operation or a join must be caught too — the
+		// walk recurses generically, it does not special-case the from-clause, so
+		// these pin that the recursion (not a from-clause-only optimization) is
+		// what holds.
+		{"reader in UNION", fmt.Sprintf("SELECT schema_name FROM events UNION SELECT connection_id FROM read_parquet('%s')", archiveFile)},
+		{"reader in JOIN", fmt.Sprintf("SELECT e.schema_name FROM events e JOIN read_parquet('%s') r ON true", archiveFile)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			res, err := runSandboxedSQL(context.Background(), in, tc.stmt)
@@ -267,9 +273,33 @@ func TestSQLPanel_onlyAllowlistedTableFunctionsReachable(t *testing.T) {
 	// loop above would assert almost nothing): the dangerous functions the
 	// gate exists to stop MUST be in the enumerated-and-denied set.
 	t.Logf("enumerated %d table functions, %d denied by the gate", len(names), len(denied))
-	for _, must := range []string{"read_parquet", "query", "query_table", "duckdb_secrets", "glob"} {
+	for _, must := range []string{"read_parquet", "query", "query_table", "json_execute_serialized_sql", "duckdb_secrets", "glob"} {
 		if !denied[must] {
 			t.Errorf("%q was not among the enumerated-and-denied functions — the guard is not exercising the readers it claims to", must)
+		}
+	}
+}
+
+// TestSQLPanel_allowlistPinnedToExactlyTwo makes the "fails closed" guarantee
+// durable against a contributor WIDENING the allowlist: the enumeration guard
+// above consults the map under test, so it can never catch an ADDITION to it.
+// Anything new here (a convenience reader, a dynamic-SQL function) is a live
+// in-root forensics-leak primitive — the archive Parquet is inside an allowed
+// root — so the set is pinned to exactly its two justified generators.
+func TestSQLPanel_allowlistPinnedToExactlyTwo(t *testing.T) {
+	want := map[string]bool{"range": true, "generate_series": true}
+	if len(allowedTableFunctions) != len(want) {
+		t.Fatalf("allowedTableFunctions has %d entries, want exactly %d (%v) — a new from-clause table function is now reachable in the sandbox",
+			len(allowedTableFunctions), len(want), want)
+	}
+	for name := range allowedTableFunctions {
+		if !want[name] {
+			t.Errorf("allowedTableFunctions has an UNEXPECTED entry %q — justify it with an escape test and add it to want here, or remove it", name)
+		}
+	}
+	for name := range want {
+		if !allowedTableFunctions[name] {
+			t.Errorf("allowedTableFunctions is missing the expected generator %q", name)
 		}
 	}
 }
@@ -301,9 +331,24 @@ func TestSQLPanel_sandboxDeniesOutOfRootReads(t *testing.T) {
 	}
 	defer os.Remove(sharedTmp)
 
+	// A sibling directory that STRING-PREFIXES the allowed root: the allowed
+	// entry is "<root>/", so real DuckDB must not admit "<root>evil/". This
+	// proves the trailing-separator boundary in the ENGINE, not just in the
+	// allowed_directories literal (TestSQLPanelAllowedListBoundary is the string
+	// half). "<root>" is a lake, "<root>evil" is the lakeevil it must not admit.
+	siblingPrefix := baselineRoot + "evil"
+	if err := os.MkdirAll(siblingPrefix, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(siblingPrefix)
+	if err := os.WriteFile(filepath.Join(siblingPrefix, "s.csv"), []byte("x\n5\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	const denied = "disabled by configuration"
 	for _, tc := range []struct{ name, stmt string }{
 		{"read sibling temp dir", fmt.Sprintf("SELECT * FROM read_csv('%s/s.csv')", secret)},
+		{"sibling prefix of an allowed root (lake vs lakeevil)", fmt.Sprintf("SELECT * FROM read_csv('%s/s.csv')", siblingPrefix)},
 		{"read shared os.TempDir file", fmt.Sprintf("SELECT * FROM read_csv('%s')", sharedTmp)},
 		{"glob outside the roots", fmt.Sprintf("SELECT * FROM glob('%s/*')", secret)},
 		{"replacement scan out of root", fmt.Sprintf("SELECT * FROM '%s/s.csv'", secret)},
@@ -421,8 +466,10 @@ func TestSQLPanel_gateRefusesNonSelect(t *testing.T) {
 		{"COPY TO inside the allowed root", fmt.Sprintf("COPY (SELECT 1) TO '%s/evil.parquet'", baselineRoot)},
 		{"ATTACH inside the allowed root", fmt.Sprintf("ATTACH '%s/evil.db' AS x", baselineRoot)},
 		{"CREATE TABLE", "CREATE TABLE t AS SELECT 1"},
-		// CREATE SECRET survives lock_configuration (secrets are not settings),
-		// so the gate is its only barrier — pinned here on purpose.
+		// CREATE SECRET survives lock_configuration (secrets are not settings);
+		// the gate refuses it here. (enable_external_access=false is also a
+		// barrier — it denies the persistent secret store — so the gate is a
+		// primary, not the only, guard.) Pinned on purpose.
 		{"CREATE SECRET", "CREATE OR REPLACE SECRET evil (TYPE s3, KEY_ID 'k', SECRET 's')"},
 		{"SET", "SET enable_external_access = true"},
 		{"PRAGMA", "PRAGMA memory_limit='99GB'"},

--- a/internal/console/views_api.go
+++ b/internal/console/views_api.go
@@ -3,6 +3,8 @@ package console
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -11,6 +13,48 @@ import (
 	"github.com/dbtrail/dbtrail/internal/reconstruct"
 	"github.com/dbtrail/dbtrail/internal/views"
 )
+
+// errNoViewSources: the selected server has neither archived partitions nor a
+// baseline snapshot — there is no Parquet layout to describe (views.sql) or to
+// query (the SQL panel).
+var errNoViewSources = errors.New("this server has no archived partitions and no baseline snapshot yet")
+
+// buildViewsInput resolves the selected server's Parquet layout — archive
+// sources from archive_state plus the NEWEST baseline snapshot's tables — into
+// the generator input shared by GET /api/views.sql and the SQL panel. A
+// baseline root that is configured but unlistable is an upstream fault worth
+// naming, not a degrade: silently dropping the baseline half would hand over a
+// layout missing every state view.
+func (s *Server) buildViewsInput(ctx context.Context, b *bundle) (views.Input, error) {
+	in := views.Input{
+		GeneratedAt: time.Now().UTC(),
+		Version:     s.version,
+	}
+	in.ArchiveSources = consoleArchiveSources(ctx, b.db)
+	if b.baselineSrc != "" {
+		in.BaselineSource = b.baselineSrc
+		files, err := reconstruct.ListBaselines(ctx, b.baselineSrc)
+		if err != nil {
+			return views.Input{}, fmt.Errorf("list baselines: %w", err)
+		}
+		if len(files) > 0 {
+			newest := files[0].SnapshotTime // ListBaselines returns newest first
+			in.BaselineSnapshot = newest
+			for _, f := range files {
+				if !f.SnapshotTime.Equal(newest) {
+					continue
+				}
+				in.Baselines = append(in.Baselines, views.BaselineTable{
+					Schema: f.Schema, Table: f.Table, Path: f.Path,
+				})
+			}
+		}
+	}
+	if len(in.ArchiveSources) == 0 && len(in.Baselines) == 0 {
+		return views.Input{}, errNoViewSources
+	}
+	return in, nil
+}
 
 // handleViewsSQL serves GET /api/views.sql: the same DuckDB view definitions
 // `bintrail views` generates, with the paths resolved from the selected
@@ -53,42 +97,19 @@ func (s *Server) handleViewsSQL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	in := views.Input{
-		GeneratedAt: time.Now().UTC(),
-		Version:     s.version,
-	}
-	in.ArchiveSources = consoleArchiveSources(r.Context(), b.db)
-	if b.baselineSrc != "" {
-		in.BaselineSource = b.baselineSrc
-		files, err := reconstruct.ListBaselines(r.Context(), b.baselineSrc)
-		if err != nil {
-			// Configured but unreadable is an upstream fault worth naming, and
-			// the same 502 the baseline listing returns for it. Degrading to
-			// "archives only" would silently hand over a file missing every
-			// state view the operator came for.
-			writeJSONError(w, http.StatusBadGateway, "list baselines: "+err.Error())
-			return
-		}
-		if len(files) > 0 {
-			newest := files[0].SnapshotTime // ListBaselines returns newest first
-			in.BaselineSnapshot = newest
-			for _, f := range files {
-				if !f.SnapshotTime.Equal(newest) {
-					continue
-				}
-				in.Baselines = append(in.Baselines, views.BaselineTable{
-					Schema: f.Schema, Table: f.Table, Path: f.Path,
-				})
-			}
-		}
-	}
-
-	if len(in.ArchiveSources) == 0 && len(in.Baselines) == 0 {
+	in, err := s.buildViewsInput(r.Context(), b)
+	switch {
+	case errors.Is(err, errNoViewSources):
 		// Nothing to describe. A file of comments explaining that would be a
 		// worse answer than the UI simply not offering the button, which is
 		// what the matching capability arranges.
 		writeJSONError(w, http.StatusNotFound,
-			"this server has no archived partitions and no baseline snapshot yet — nothing to generate views over")
+			errNoViewSources.Error()+" — nothing to generate views over")
+		return
+	case err != nil:
+		// Configured but unreadable is an upstream fault worth naming, and
+		// the same 502 the baseline listing returns for it.
+		writeJSONError(w, http.StatusBadGateway, err.Error())
 		return
 	}
 

--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -55,16 +55,42 @@ type Input struct {
 	// older snapshot's rows are a different point in time, and a view union-ing
 	// two of them would silently mix states that never coexisted.
 	Baselines []BaselineTable
+
+	// ExcludeEventColumns drops the named columns (matched case-insensitively
+	// against archive.BinlogEventColumns) from the `events` view. Purely
+	// mechanical here — the views package names no policy. The console SQL panel
+	// (#1177) uses it to withhold the paid forensics columns (connection_id,
+	// query_text, query_hash) it must not serve, the same set eventDTO omits.
+	// Empty for the downloadable `bintrail views` file, which describes the
+	// operator's OWN Parquet in full.
+	ExcludeEventColumns []string
 }
 
-// Generate renders the complete .sql file.
+// Generate renders the complete .sql file: the explanatory header, the S3
+// credential preamble when needed, and the view definitions. This is the
+// artifact an operator downloads and runs in their OWN DuckDB, so the preamble
+// creates a credential_chain secret and INSTALLs httpfs inline.
 func Generate(in Input) string {
 	var b strings.Builder
 	writeHeader(&b, in)
 	if in.needsS3() {
 		writeS3Preamble(&b, in.ArchiveRegion)
 	}
-	writeEventsView(&b, in.ArchiveSources)
+	writeEventsView(&b, in.ArchiveSources, in.ExcludeEventColumns)
+	writeStateViews(&b, in)
+	return b.String()
+}
+
+// GenerateViews renders ONLY the view definitions — no header, no S3 preamble.
+// It is for a caller that runs the views in a DuckDB session it already set up:
+// bintrail's own S3 credential wiring (duckdbutil.EnableS3CredentialChain) is
+// best-effort and tolerates an unresolved credential chain, whereas the
+// download preamble's `CREATE SECRET` aborts the whole script when no
+// credentials resolve. The console SQL panel (#1177) uses this so its session
+// setup does not hinge on the human-facing preamble.
+func GenerateViews(in Input) string {
+	var b strings.Builder
+	writeEventsView(&b, in.ArchiveSources, in.ExcludeEventColumns)
 	writeStateViews(&b, in)
 	return b.String()
 }
@@ -167,7 +193,11 @@ const eventTypeCase = "CASE \"event_type\"\n" +
 // same slice the archiver writes with — so a column added or removed there
 // changes this output and breaks the golden test, rather than leaving the
 // generated schema quietly behind the files it describes.
-func writeEventsView(b *strings.Builder, sources []string) {
+func writeEventsView(b *strings.Builder, sources []string, excludeCols []string) {
+	exclude := make(map[string]bool, len(excludeCols))
+	for _, c := range excludeCols {
+		exclude[strings.ToLower(c)] = true
+	}
 	b.WriteString("-- events: every archived binlog event, across all archive sources.\n")
 	if len(sources) == 0 {
 		b.WriteString("-- (skipped: no archive sources are registered in archive_state)\n\n")
@@ -185,6 +215,9 @@ func writeEventsView(b *strings.Builder, sources []string) {
 	// distinguishable inside a single view.
 	b.WriteString("    \"bintrail_id\", \"event_date\", \"event_hour\",\n")
 	for _, col := range archive.BinlogEventColumns {
+		if exclude[strings.ToLower(col.Name)] {
+			continue
+		}
 		switch col.Name {
 		case "event_type":
 			b.WriteString("    \"event_type\" AS \"event_type_code\",\n")


### PR DESCRIPTION
closes #1177

## Summary

An opt-in, read-only **SQL panel** in the console: free-form DuckDB `SELECT`s over the selected server's archive/baseline Parquet, executed server-side by the daemon inside a locked-down DuckDB session. Off by default behind `BINTRAIL_CONSOLE_SQL_PANEL=1`. This is the "run it in the daemon and hand back rows" counterpart to the existing `views.sql` download — and because the SQL now runs server-side, every security requirement the issue lists ships in this one change, enforced at the endpoint (the UI only mirrors it).

The archive/state Parquet is S3-first (Hive layout via `archive_state`); local Parquet is the minority case. The session reuses the exact S3 wiring the rest of bintrail uses (`duckdbutil.LoadHTTPFS` + `EnableS3CredentialChainRegion`) and the same view definitions `bintrail views` / `GET /api/views.sql` generate.

### Security posture (all from the first commit)
- **Filesystem sandbox** — `allowed_directories` restricted to the resolved archive/baseline roots (local paths **and** `s3://` prefixes; DuckDB's access check runs in its VFS layer above httpfs and fails before any network I/O), `enable_external_access=false`, `lock_configuration=true` so no user `SET` can widen it. A trailing separator on each root keeps the match a directory boundary (`lake` must not admit `lakeevil`).
- **Read-only, views-only, fail-closed** — a SELECT-only, single-statement gate classified by DuckDB's own parser (`json_serialize_sql`), never a text filter. The pre-built `events`/`state_*` views are the **only** data path, enforced by an **allowlist** walk of the parsed AST, not a denylist: a `FROM` source is admitted only if it is a plain base-table reference that is not a file path, or a table function on a tiny allowlist (`range`, `generate_series`) — everything else is refused. This closes the whole class of raw-file readers (`read_parquet`/`read_csv`/`glob`/… and the `FROM '<path>'` replacement-scan form) **and** the dynamic-SQL functions (`query()`/`query_table()`/`json_execute_serialized_sql()`) that re-parse a string argument at bind time, after the gate — a denylist would have let those through. So a query cannot reach the raw Parquet, which carries the paid forensics columns (`connection_id`/`query_text`/`query_hash`) the `events` view withholds (the `eventDTO` open-core boundary). The secrets manager (`duckdb_secrets`/`which_secret`) is denied by the same allowlist — it exposes an S3 secret's access-key id. A regression test enumerates `duckdb_functions()` and asserts every non-allowlisted table function is denied.
- **Resource bounds** — conservative daemon DuckDB budget (never `--ultrafast`), a private spill dir, a hard 60s timeout with interrupt, a result row/byte cap, and one query in flight per process (429 otherwise).
- **RBAC** — refused under an active data profile (redaction cannot reach free-form SQL), same shape as the reconstruct/views gates.
- **Audit** — every statement emits on the seam (`console`/`sql.run`).
- **Opt-in** — env-only, off by default, mirroring the baseline-trigger opt-in; non-loopback still requires the existing auth posture.

### Human-friendly cancellation
The **Cancel** button (and closing the tab / navigating away / switching server) aborts the fetch → the request context dies → the DuckDB query is interrupted via `QueryContext`. No cancel endpoint, no query registry.

### Refactors
- `buildViewsInput` extracted from `handleViewsSQL` (shared with the panel).
- `views.GenerateViews` — view DDL without the human-facing S3 preamble (whose `CREATE SECRET` aborts when no credential resolves; the panel sets up S3 tolerantly instead).
- `views.Input.ExcludeEventColumns` — mechanical; the console names the forensics set, the views package stays policy-free.

## Test plan
- [x] `go test ./... -count=1` — full unit suite passes
- [x] `go vet ./...` clean; `gofmt` clean
- [x] `go test -race ./internal/console/ -run TestSQLPanel` — no data races
- Escape suite drives the **real** `runSandboxedSQL`/`openSandboxedSession` (not a hand-built session): the fail-closed allowlist gate (raw-file readers, replacement scans, the `query()`/`query_table()`/`json_execute_serialized_sql()` dynamic-SQL bypasses, the forensics-column bypass, and an enumeration guard over every `duckdb_functions()` table function), out-of-root reads denied directly on the sandbox (local + S3 + SSRF), locked-config holds, SELECT-only gate, secret-introspection denied, row/byte caps, timeout + cancel interrupt, the forensics-column withholding, and the `Config.SQLPanel` wiring through `upConsoleConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
