### PR TITLE
shim: opt-in per-tenant allowed_schemas authorization (#824)

### DIFF
--- a/docs/time-travel-sql.md
+++ b/docs/time-travel-sql.md
@@ -182,6 +182,40 @@ Edit `shim.yaml`, uncomment the two TODO lines, and paste the values:
 
 > **Auth note**: both `bintrail shim` and ProxySQL validate the application's password against the same `mysql_password`. The default is `mysql_native_password`; `caching_sha2_password` is opt-in via `--auth-method` (see Step 4). The shim's listen address defaults to `127.0.0.1:3308` so it is not reachable from the network. Treat `shim.yaml` as you'd treat `.bintrail.env` — it contains a password and ships at 0o600.
 
+### Isolating tenants with `allowed_schemas`
+
+Authentication alone does not scope what a tenant can *query*: the shim answers
+every time-travel query from one shared index, so in a multi-tenant `shim.yaml`
+any authenticated tenant could `USE` (or fully qualify) another tenant's schema
+and read its entire indexed history — including deleted rows.
+
+Add the optional `allowed_schemas` list to each tenant to enforce isolation:
+
+```yml
+tenants:
+  - mysql_user: app_a
+    mysql_password: '...'
+    source_dsn: 'a:pw@tcp(db-a:3306)/app_a'
+    allowed_schemas: [app_a]
+  - mysql_user: app_b
+    mysql_password: '...'
+    source_dsn: 'b:pw@tcp(db-b:3306)/app_b'
+    allowed_schemas: [app_b, app_b_audit]
+```
+
+With `allowed_schemas` set, a `USE` of — or any time-travel query resolving to
+— a schema outside the list is rejected with MySQL error 1044
+(`ER_DBACCESS_DENIED_ERROR`), the same code a real mysqld returns for a
+database the user has no grants on. The check applies to every statement
+shape, including fully qualified forms that never issue `USE`
+(`SELECT /*+ DBTRAIL_AT='…' */ * FROM other_schema.t`). Schema names are
+matched case-insensitively.
+
+The field is **opt-in**: a tenant without it keeps the historical
+any-schema behaviour, so existing configs are unaffected. When `shim.yaml`
+has more than one tenant and any of them lacks `allowed_schemas`, the shim
+logs a startup warning that cross-schema isolation is not enforced.
+
 ---
 
 ## Step 2 — Install ProxySQL

--- a/internal/cli/shim.go
+++ b/internal/cli/shim.go
@@ -194,6 +194,19 @@ func runShim(cmd *cobra.Command, args []string) error {
 	// below catches the more interesting case where so many tenants
 	// have unusable DSNs that the operator should notice at startup.
 	userSchemas := buildUserSchemas(tenantCfgs)
+	// Per-tenant schema allowlists (#824). Opt-in: a tenant without
+	// allowed_schemas keeps the historical any-schema behaviour, but a
+	// multi-tenant shim.yaml that leaves any tenant unrestricted means
+	// tenants can read each other's indexed history — say so once at
+	// startup instead of letting the operator discover it in an audit.
+	userAllowedSchemas := buildUserAllowedSchemas(tenantCfgs)
+	if unrestricted := tenantsWithoutAllowedSchemas(tenantCfgs); len(tenantCfgs) > 1 && len(unrestricted) > 0 {
+		slog.Warn(
+			"shim: cross-schema isolation is NOT enforced for some tenants; any of them can query every schema in the index. Add allowed_schemas to each tenant in shim.yaml to isolate them",
+			"tenants", len(tenantCfgs),
+			"unrestricted_users", unrestricted,
+		)
+	}
 	if missing := len(tenantCfgs) - len(userSchemas); missing > 0 {
 		// Name the affected users so a 50-tenant deployment doesn't
 		// force the operator to grep the prior per-tenant warnings.
@@ -341,7 +354,7 @@ func runShim(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("auth method: %w", err)
 	}
-	serveLoop(ctx, listener, db, srv, auth, cfg, userSchemas, shMaxConns)
+	serveLoop(ctx, listener, db, srv, auth, cfg, userSchemas, userAllowedSchemas, shMaxConns)
 	// Block until the monitorDeniedTicker has run its final drain.
 	// serveLoop returning means ctx is cancelled; the ticker is
 	// observing the same ctx and will hit its `case <-ctx.Done()`
@@ -366,7 +379,7 @@ func runShim(cmd *cobra.Command, args []string) error {
 // hiccup doesn't burn CPU and a permanent listener wedge doesn't fill
 // the log at ~10 lines/sec. The backoff resets to zero on every
 // successful Accept so a brief spike doesn't poison the steady state.
-func serveLoop(ctx context.Context, listener net.Listener, db *sql.DB, srv *server.Server, auth shim.TenantAuth, cfg shim.Config, userSchemas map[string]string, maxConns int) {
+func serveLoop(ctx context.Context, listener net.Listener, db *sql.DB, srv *server.Server, auth shim.TenantAuth, cfg shim.Config, userSchemas map[string]string, userAllowedSchemas map[string][]string, maxConns int) {
 	var wg sync.WaitGroup
 	defer wg.Wait()
 
@@ -416,7 +429,7 @@ func serveLoop(ctx context.Context, listener net.Listener, db *sql.DB, srv *serv
 			if connSem != nil {
 				defer func() { <-connSem }()
 			}
-			handleConn(ctx, c, db, srv, auth, cfg, userSchemas)
+			handleConn(ctx, c, db, srv, auth, cfg, userSchemas, userAllowedSchemas)
 		}(conn)
 	}
 }
@@ -678,6 +691,37 @@ func buildUserSchemas(tenantCfgs []shim.TenantConfig) map[string]string {
 	return out
 }
 
+// buildUserAllowedSchemas maps mysql_user → allowed_schemas for the
+// tenants that opted into schema isolation (#824). Tenants without the
+// field are simply absent — handleConn's map lookup then yields nil,
+// which Handler.BindAllowedSchemas treats as unrestricted (the exact
+// pre-#824 behaviour).
+func buildUserAllowedSchemas(tenantCfgs []shim.TenantConfig) map[string][]string {
+	out := make(map[string][]string)
+	for _, t := range tenantCfgs {
+		if len(t.AllowedSchemas) > 0 {
+			out[t.MySQLUser] = t.AllowedSchemas
+		}
+	}
+	return out
+}
+
+// tenantsWithoutAllowedSchemas lists the mysql_users that have no
+// allowed_schemas allowlist. runShim warns once at startup when the
+// config has more than one tenant and this list is non-empty: in a
+// multi-tenant shim, an unrestricted tenant can read every other
+// tenant's indexed history. Pure function so the classification is
+// unit-testable without a listener.
+func tenantsWithoutAllowedSchemas(tenantCfgs []shim.TenantConfig) []string {
+	var out []string
+	for _, t := range tenantCfgs {
+		if len(t.AllowedSchemas) == 0 {
+			out = append(out, t.MySQLUser)
+		}
+	}
+	return out
+}
+
 // handleConn wraps one accepted TCP connection in go-mysql/server's
 // Conn (which performs the MySQL handshake + auth) and dispatches
 // every COM_QUERY through our Handler.
@@ -695,7 +739,7 @@ func buildUserSchemas(tenantCfgs []shim.TenantConfig) map[string]string {
 // the Handler, so a client disconnect OR a daemon shutdown cancels any
 // in-flight FetchMerged instead of letting it run to completion for a
 // reader that no longer exists.
-func handleConn(ctx context.Context, c net.Conn, db *sql.DB, srv *server.Server, auth shim.TenantAuth, cfg shim.Config, userSchemas map[string]string) {
+func handleConn(ctx context.Context, c net.Conn, db *sql.DB, srv *server.Server, auth shim.TenantAuth, cfg shim.Config, userSchemas map[string]string, userAllowedSchemas map[string][]string) {
 	defer c.Close()
 
 	wc, connCtx, stop := watchConn(ctx, c)
@@ -726,8 +770,17 @@ func handleConn(ctx context.Context, c net.Conn, db *sql.DB, srv *server.Server,
 	// real per-tenant credentials, so it records its authenticated user rather
 	// than the process owner. Post-handshake: GetUser is only meaningful here.
 	handler.BindActor(mysqlConn.GetUser())
+	// Bind the tenant's allowed_schemas allowlist (#824) BEFORE seeding the
+	// default schema, so a source_dsn-derived default that the operator
+	// excluded from allowed_schemas is refused rather than silently trusted.
+	handler.BindAllowedSchemas(userAllowedSchemas[mysqlConn.GetUser()])
 	if schema, ok := userSchemas[mysqlConn.GetUser()]; ok && schema != "" {
-		_ = handler.UseDB(schema)
+		if err := handler.UseDB(schema); err != nil {
+			slog.Warn(
+				"shim: tenant's default schema (derived from source_dsn) is outside its allowed_schemas; no default schema seeded — queries from this tenant must name an allowed schema",
+				"mysql_user", mysqlConn.GetUser(), "schema", schema,
+			)
+		}
 	}
 	for {
 		if err := mysqlConn.HandleCommand(); err != nil {

--- a/internal/cli/shim_limits_test.go
+++ b/internal/cli/shim_limits_test.go
@@ -267,7 +267,7 @@ func TestShim_ShutdownCancelsInFlightFetch(t *testing.T) {
 	go func() {
 		defer close(done)
 		serveLoop(ctx, listener, db, srv, auth, cfg,
-			map[string]string{"tenant_a": "myapp"}, 0)
+			map[string]string{"tenant_a": "myapp"}, nil, 0)
 	}()
 
 	client, err := sql.Open("mysql", "tenant_a:pw@tcp("+listener.Addr().String()+")/?timeout=2s&readTimeout=60s")

--- a/internal/cli/shim_test.go
+++ b/internal/cli/shim_test.go
@@ -141,7 +141,7 @@ func TestServeLoopExitsOnContextCancel(t *testing.T) {
 	go func() {
 		// db / srv / auth / cfg are unused on this path because Accept
 		// never returns a connection — handleConn is unreachable.
-		serveLoop(ctx, listener, nil, nil, shim.TenantAuth{}, shim.Config{}, nil, 0)
+		serveLoop(ctx, listener, nil, nil, shim.TenantAuth{}, shim.Config{}, nil, nil, 0)
 		close(done)
 	}()
 
@@ -449,5 +449,44 @@ func TestMonitorDeniedPeriodicEmit(t *testing.T) {
 	emitMonitorDenied(logger)
 	if buf.Len() != 0 {
 		t.Errorf("second emit after reset: got %q, want empty", buf.String())
+	}
+}
+
+// TestBuildUserAllowedSchemas pins the opt-in contract of #824 at the
+// serving-layer map: a tenant with allowed_schemas gets its list; a
+// tenant without is ABSENT, so handleConn's lookup yields nil — the
+// value Handler.BindAllowedSchemas reads as unrestricted.
+func TestBuildUserAllowedSchemas(t *testing.T) {
+	cfgs := []shim.TenantConfig{
+		{MySQLUser: "tenant_a", AllowedSchemas: []string{"myapp"}},
+		{MySQLUser: "tenant_b"}, // no allowlist → absent from the map
+	}
+	got := buildUserAllowedSchemas(cfgs)
+	if len(got) != 1 {
+		t.Fatalf("buildUserAllowedSchemas = %v, want only tenant_a", got)
+	}
+	if a := got["tenant_a"]; len(a) != 1 || a[0] != "myapp" {
+		t.Errorf("tenant_a = %v, want [myapp]", a)
+	}
+	if got["tenant_b"] != nil {
+		t.Errorf("tenant without allowed_schemas must map to nil (unrestricted)")
+	}
+}
+
+// TestTenantsWithoutAllowedSchemas feeds runShim's one-time startup
+// warning: in a multi-tenant shim, an unrestricted tenant can read
+// every other tenant's indexed history, and the warning names them.
+func TestTenantsWithoutAllowedSchemas(t *testing.T) {
+	cfgs := []shim.TenantConfig{
+		{MySQLUser: "tenant_a", AllowedSchemas: []string{"myapp"}},
+		{MySQLUser: "tenant_b"},
+		{MySQLUser: "tenant_c"},
+	}
+	got := tenantsWithoutAllowedSchemas(cfgs)
+	if len(got) != 2 || got[0] != "tenant_b" || got[1] != "tenant_c" {
+		t.Errorf("tenantsWithoutAllowedSchemas = %v, want [tenant_b tenant_c]", got)
+	}
+	if got := tenantsWithoutAllowedSchemas(cfgs[:1]); got != nil {
+		t.Errorf("all-restricted config must yield nil, got %v", got)
 	}
 }

--- a/internal/cli/shim_wire_test.go
+++ b/internal/cli/shim_wire_test.go
@@ -66,7 +66,7 @@ func startTestShimFull(t *testing.T, tenants map[string]string, userSchemas map[
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		serveLoop(ctx, listener, db, srv, auth, cfg, userSchemas, maxConns)
+		serveLoop(ctx, listener, db, srv, auth, cfg, userSchemas, nil, maxConns)
 	}()
 
 	t.Cleanup(func() {

--- a/internal/shim/auth.go
+++ b/internal/shim/auth.go
@@ -123,6 +123,14 @@ type TenantConfig struct {
 	// by LoadTenantConfigs — empty here is the #254 silent-auth
 	// regression and is rejected at the loader boundary.
 	MySQLPassword string
+	// AllowedSchemas is the opt-in per-tenant schema allowlist
+	// (issue #824). Empty/nil means unrestricted — the pre-#824
+	// behaviour, kept for single-tenant deployments and backwards
+	// compatibility. Non-empty means the shim rejects `USE` of, and
+	// any time-travel query resolving to, a schema outside this set
+	// with ER_DBACCESS_DENIED_ERROR (1044). Entries are guaranteed
+	// non-empty by LoadTenantConfigs.
+	AllowedSchemas []string
 }
 
 // LoadTenants reads shim.yaml from path and returns username →
@@ -159,13 +167,14 @@ func LoadTenantConfigs(path string) ([]TenantConfig, error) {
 	}
 	var cfg struct {
 		Tenants []struct {
-			ServerID      string `yaml:"server_id"`
-			SourceDSN     string `yaml:"source_dsn"`
-			AgentURL      string `yaml:"agent_url"`
-			AgentToken    string `yaml:"agent_token"`
-			MySQLUser     string `yaml:"mysql_user"`
-			MySQLPassword string `yaml:"mysql_password"`
-			MySQLPassSHA1 string `yaml:"mysql_pass_sha1"`
+			ServerID       string   `yaml:"server_id"`
+			SourceDSN      string   `yaml:"source_dsn"`
+			AgentURL       string   `yaml:"agent_url"`
+			AgentToken     string   `yaml:"agent_token"`
+			MySQLUser      string   `yaml:"mysql_user"`
+			MySQLPassword  string   `yaml:"mysql_password"`
+			MySQLPassSHA1  string   `yaml:"mysql_pass_sha1"`
+			AllowedSchemas []string `yaml:"allowed_schemas"`
 		} `yaml:"tenants"`
 		Listen string `yaml:"listen"`
 	}
@@ -195,11 +204,19 @@ func LoadTenantConfigs(path string) ([]TenantConfig, error) {
 				"tenant", i+1, "mysql_user", t.MySQLUser,
 			)
 		}
+		for _, s := range t.AllowedSchemas {
+			if s == "" {
+				return nil, fmt.Errorf(
+					"%s tenant #%d (mysql_user=%s): allowed_schemas contains an empty entry — remove it or list a schema name",
+					path, i+1, t.MySQLUser)
+			}
+		}
 		out = append(out, TenantConfig{
-			ServerID:      t.ServerID,
-			SourceDSN:     t.SourceDSN,
-			MySQLUser:     t.MySQLUser,
-			MySQLPassword: t.MySQLPassword,
+			ServerID:       t.ServerID,
+			SourceDSN:      t.SourceDSN,
+			MySQLUser:      t.MySQLUser,
+			MySQLPassword:  t.MySQLPassword,
+			AllowedSchemas: t.AllowedSchemas,
 		})
 	}
 	return out, nil

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -156,6 +156,17 @@ type Handler struct {
 	// instead of indistinguishable from a real event.
 	actor string
 
+	// allowedSchemas is the authenticated tenant's opt-in schema
+	// allowlist (issue #824), bound by BindAllowedSchemas after the
+	// handshake — same lifecycle as actor. nil/empty = unrestricted
+	// (the pre-#824 behaviour). Enforced at BOTH chokepoints: UseDB
+	// (COM_INIT_DB) and HandleQuery on the PARSED query's resolved
+	// schema — a client can fully qualify (`_flashback` needs a USE'd
+	// schema, but the hint and bare AS OF forms accept
+	// `<schema>.<table>` directly), so gating USE alone would not
+	// close #824.
+	allowedSchemas []string
+
 	mu sync.Mutex
 	db string // currently selected database (per COM_INIT_DB)
 }
@@ -430,8 +441,14 @@ func (h *Handler) QueryContext() (context.Context, context.CancelFunc) {
 }
 
 // UseDB stores the schema the client selected. _flashback queries
-// without an explicit schema use this value.
+// without an explicit schema use this value. When the tenant has an
+// allowed_schemas allowlist (#824), a USE of a schema outside it is
+// rejected with ER_DBACCESS_DENIED_ERROR — the same 1044 a real mysqld
+// returns for a schema the user has no grants on.
 func (h *Handler) UseDB(dbName string) error {
+	if !h.schemaAllowed(dbName) {
+		return h.schemaDenied(dbName)
+	}
 	h.mu.Lock()
 	h.db = dbName
 	h.mu.Unlock()
@@ -454,11 +471,28 @@ func (h *Handler) HandleQuery(qstr string) (*mysql.Result, error) {
 	// snapshots rather than letting the query fall through to the
 	// real MySQL (which returns ER_BAD_DB on the virtual schema).
 	if m := showTablesFromVirtualRE.FindStringSubmatch(qstr); m != nil {
+		// Belt to the UseDB gate (#824): currentDB can only get here via
+		// UseDB (already gated) or the serving layer's source_dsn seed,
+		// but the listing serves per-schema metadata, so re-check rather
+		// than trust the write path. Empty currentDB keeps the
+		// ER_NO_DB_ERROR path inside runShowTablesFromVirtual.
+		if currentDB != "" && !h.schemaAllowed(currentDB) {
+			return nil, h.schemaDenied(currentDB)
+		}
 		return h.runShowTablesFromVirtual(currentDB, m[1])
 	}
 
 	q, perr := Parse(qstr, currentDB)
 	if perr == nil {
+		// Per-tenant schema authorization (#824), on the RESOLVED target
+		// schema at query execution — not only at USE time. Parse fills
+		// q.Schema from the USE'd schema for the virtual-schema shapes
+		// AND from an explicit `<schema>.<table>` qualification on the
+		// hint / bare AS OF forms, so this single site covers every way
+		// a client can name a schema without a prior USE.
+		if !h.schemaAllowed(q.Schema) {
+			return nil, h.schemaDenied(q.Schema)
+		}
 		// Cross-cut PK validation (#296). Applied here, not inside each
 		// runX, so all four parsed shapes (TypeFlashback, TypeSnapshot,
 		// TypeDiff, and the hint-comment form which Parse normalises

--- a/internal/shim/schema_authz.go
+++ b/internal/shim/schema_authz.go
@@ -1,0 +1,69 @@
+package shim
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
+)
+
+// Per-tenant schema authorization (issue #824).
+//
+// shim.yaml models multiple tenants — each with its own credentials and
+// source_dsn — but the virtual-schema query surface answers against ONE
+// shared index, so before this gate any authenticated tenant could read
+// any other tenant's entire indexed history (including deleted rows) by
+// issuing `USE <other-schema>` or by fully qualifying the target table.
+//
+// The gate is OPT-IN: a tenant without allowed_schemas in shim.yaml keeps
+// the historical unrestricted behaviour, so existing single-tenant
+// deployments are untouched. The standalone `bintrail shim` warns at
+// startup when a multi-tenant config leaves any tenant unrestricted.
+
+// BindAllowedSchemas binds the authenticated tenant's allowed_schemas
+// allowlist to this connection's handler. Call it once per connection,
+// after the handshake and before serving commands — same lifecycle (and
+// same no-lock-needed reasoning) as BindActor. nil or empty means
+// unrestricted.
+func (h *Handler) BindAllowedSchemas(schemas []string) {
+	h.allowedSchemas = schemas
+}
+
+// schemaAllowed reports whether the connection may touch schema. An
+// unbound (nil/empty) allowlist allows everything — the opt-in contract.
+// Comparison is case-insensitive (strings.EqualFold), matching how MySQL
+// folds database identifiers under its default lower_case_table_names
+// packaging on the platforms bintrail ships for; an allowlist must not
+// become bypassable by re-casing the schema name.
+func (h *Handler) schemaAllowed(schema string) bool {
+	if len(h.allowedSchemas) == 0 {
+		return true
+	}
+	for _, s := range h.allowedSchemas {
+		if strings.EqualFold(s, schema) {
+			return true
+		}
+	}
+	return false
+}
+
+// schemaDenied logs the denied cross-schema attempt and returns the
+// wire error for it: ER_DBACCESS_DENIED_ERROR (1044), the code a real
+// mysqld uses when a user has no grants on a database — a proper MySQL
+// error the client library surfaces, never a connection drop. The slog
+// warning is the denial's operator-visible trail; the shim has no
+// denied-side audit action in the ext seam taxonomy (only successful
+// timetravel.query emissions), and this deliberately does not invent
+// one.
+func (h *Handler) schemaDenied(schema string) error {
+	actor := h.actor
+	if actor == "" {
+		actor = unboundActor
+	}
+	if h.logger != nil { // struct-literal handlers in tests may omit it
+		h.logger.Warn("shim: cross-schema access denied by allowed_schemas",
+			"tenant", actor, "schema", schema)
+	}
+	return mysql.NewError(mysql.ER_DBACCESS_DENIED_ERROR, fmt.Sprintf(
+		"Access denied for user '%s' to database '%s'", actor, schema))
+}

--- a/internal/shim/schema_authz_test.go
+++ b/internal/shim/schema_authz_test.go
@@ -1,0 +1,229 @@
+package shim
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// wantSchemaDenied asserts err is the #824 denial: ER_DBACCESS_DENIED_ERROR
+// (1044) — a proper wire error, not a connection drop or a generic 1105.
+func wantSchemaDenied(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected ER_DBACCESS_DENIED_ERROR, got nil")
+	}
+	var myErr *gomysql.MyError
+	if !errors.As(err, &myErr) || myErr.Code != gomysql.ER_DBACCESS_DENIED_ERROR {
+		t.Fatalf("expected ER_DBACCESS_DENIED_ERROR (1044), got %v", err)
+	}
+}
+
+func TestUseDBEnforcesAllowedSchemas(t *testing.T) {
+	h := NewHandler(nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.BindActor("tenant_a")
+	h.BindAllowedSchemas([]string{"myapp", "reporting"})
+
+	if err := h.UseDB("myapp"); err != nil {
+		t.Fatalf("USE of an in-set schema must pass: %v", err)
+	}
+	if err := h.UseDB("MyApp"); err != nil {
+		t.Fatalf("schema match is case-insensitive (MySQL ident folding): %v", err)
+	}
+	err := h.UseDB("tenant_b_db")
+	wantSchemaDenied(t, err)
+	if !strings.Contains(err.Error(), "tenant_a") || !strings.Contains(err.Error(), "tenant_b_db") {
+		t.Errorf("denial should name the user and the schema, got: %v", err)
+	}
+	// The rejected USE must not have replaced the selected schema.
+	h.mu.Lock()
+	got := h.db
+	h.mu.Unlock()
+	if got != "MyApp" {
+		t.Errorf("rejected USE leaked into handler state: db=%q", got)
+	}
+}
+
+// TestHandleQueryEnforcesAllowedSchemas drives the REAL command entry point
+// (HandleQuery — what go-mysql/server dispatches COM_QUERY to), not a leaf
+// validator, so deleting the enforcement call at the query chokepoint turns
+// these red (mutation rule for #824). The current schema is planted directly
+// on the handler — bypassing the UseDB gate on purpose — so this test stays
+// red under a mutant that keeps the UseDB check but drops the query-time one.
+func TestHandleQueryEnforcesAllowedSchemas(t *testing.T) {
+	newRestricted := func() *Handler {
+		h := NewHandler(nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+		h.BindActor("tenant_a")
+		h.BindAllowedSchemas([]string{"myapp"})
+		return h
+	}
+
+	t.Run("virtual_schema_with_out_of_set_current_db", func(t *testing.T) {
+		h := newRestricted()
+		h.mu.Lock()
+		h.db = "tenant_b_db" // planted past the UseDB gate
+		h.mu.Unlock()
+		_, err := h.HandleQuery("SELECT * FROM _flashback.orders AS OF '2026-01-01 00:00:00' WHERE id = 1")
+		wantSchemaDenied(t, err)
+	})
+
+	t.Run("fully_qualified_bare_as_of_without_use", func(t *testing.T) {
+		h := newRestricted() // no USE at all: qualification names the schema
+		_, err := h.HandleQuery("SELECT * FROM tenant_b_db.orders WHERE id = 1 AS OF '2026-01-01 00:00:00'")
+		wantSchemaDenied(t, err)
+	})
+
+	t.Run("fully_qualified_hint_form_without_use", func(t *testing.T) {
+		h := newRestricted()
+		_, err := h.HandleQuery("SELECT /*+ DBTRAIL_AT='2026-01-01 00:00:00' */ * FROM tenant_b_db.orders WHERE id = 1")
+		wantSchemaDenied(t, err)
+	})
+
+	t.Run("diff_with_out_of_set_current_db", func(t *testing.T) {
+		h := newRestricted()
+		h.mu.Lock()
+		h.db = "tenant_b_db"
+		h.mu.Unlock()
+		_, err := h.HandleQuery("SELECT * FROM _diff.orders BETWEEN '2026-01-01 00:00:00' AND '2026-01-02 00:00:00' WHERE id = 1")
+		wantSchemaDenied(t, err)
+	})
+
+	t.Run("show_tables_from_virtual_with_out_of_set_current_db", func(t *testing.T) {
+		h := newRestricted()
+		h.mu.Lock()
+		h.db = "tenant_b_db"
+		h.mu.Unlock()
+		_, err := h.HandleQuery("SHOW TABLES FROM _flashback")
+		wantSchemaDenied(t, err)
+	})
+}
+
+// TestHandleQueryAllowedSchemaStillServes proves the gate lets an in-set
+// query through to the real fetch path: the point-lookup SQL (pk_hash =
+// SHA2, unique to that path) must reach the index DB.
+func TestHandleQueryAllowedSchemaStillServes(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.MatchExpectationsInOrder(false)
+	mock.ExpectQuery("information_schema.PARTITIONS").
+		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME", "PARTITION_DESCRIPTION"}))
+	mock.ExpectQuery("pk_hash = SHA2").
+		WillReturnRows(emptyBinlogEventsRows())
+
+	h := &Handler{
+		indexDB: db,
+		cfg:     Config{AllowGaps: true, IndexDBName: "bintrail_index", NoArchive: true},
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		archiveFetcher: func(ctx context.Context, _ query.Options, _ string) ([]query.ResultRow, error) {
+			return nil, nil
+		},
+	}
+	h.BindActor("tenant_a")
+	h.BindAllowedSchemas([]string{"myapp"})
+	if err := h.UseDB("myapp"); err != nil {
+		t.Fatalf("in-set USE: %v", err)
+	}
+	if _, err := h.HandleQuery("SELECT * FROM _flashback.orders AS OF '2026-01-01 00:00:00' WHERE id = 42"); err != nil {
+		t.Fatalf("in-set query must not be denied: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("in-set query never reached the point-lookup SQL: %v", err)
+	}
+}
+
+// TestHandleQueryUnrestrictedTenantUntouched pins the opt-in contract: a
+// tenant with NO allowed_schemas keeps the historical any-schema behaviour
+// (issue #824's hard requirement of zero behavior change for existing
+// configs).
+func TestHandleQueryUnrestrictedTenantUntouched(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.MatchExpectationsInOrder(false)
+	mock.ExpectQuery("information_schema.PARTITIONS").
+		WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME", "PARTITION_DESCRIPTION"}))
+	mock.ExpectQuery("pk_hash = SHA2").
+		WillReturnRows(emptyBinlogEventsRows())
+
+	h := &Handler{
+		indexDB: db,
+		cfg:     Config{AllowGaps: true, IndexDBName: "bintrail_index", NoArchive: true},
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		archiveFetcher: func(ctx context.Context, _ query.Options, _ string) ([]query.ResultRow, error) {
+			return nil, nil
+		},
+	}
+	// No BindAllowedSchemas: any schema is reachable, exactly as before.
+	if err := h.UseDB("somebody_elses_db"); err != nil {
+		t.Fatalf("unrestricted USE must pass: %v", err)
+	}
+	if _, err := h.HandleQuery("SELECT * FROM _flashback.orders AS OF '2026-01-01 00:00:00' WHERE id = 42"); err != nil {
+		t.Fatalf("unrestricted query must not be denied: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unrestricted query never reached the point-lookup SQL: %v", err)
+	}
+}
+
+func TestLoadTenantConfigsAllowedSchemas(t *testing.T) {
+	write := func(t *testing.T, content string) string {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "shim.yaml")
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	t.Run("parses_allowed_schemas", func(t *testing.T) {
+		p := write(t, `
+tenants:
+  - mysql_user: tenant_a
+    mysql_password: 'pw-a'
+    allowed_schemas: [myapp, reporting]
+  - mysql_user: tenant_b
+    mysql_password: 'pw-b'
+`)
+		cfgs, err := LoadTenantConfigs(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(cfgs) != 2 {
+			t.Fatalf("want 2 tenants, got %d", len(cfgs))
+		}
+		if got := cfgs[0].AllowedSchemas; len(got) != 2 || got[0] != "myapp" || got[1] != "reporting" {
+			t.Errorf("tenant_a allowed_schemas = %v", got)
+		}
+		if cfgs[1].AllowedSchemas != nil {
+			t.Errorf("tenant_b (no field) must stay nil = unrestricted, got %v", cfgs[1].AllowedSchemas)
+		}
+	})
+
+	t.Run("rejects_empty_entry", func(t *testing.T) {
+		p := write(t, `
+tenants:
+  - mysql_user: tenant_a
+    mysql_password: 'pw-a'
+    allowed_schemas: ['myapp', '']
+`)
+		_, err := LoadTenantConfigs(p)
+		if err == nil || !strings.Contains(err.Error(), "allowed_schemas") {
+			t.Fatalf("want an allowed_schemas empty-entry error, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #824

The shim models multiple tenants in `shim.yaml` (each with credentials and a `source_dsn`), but `UseDB` accepted any schema and no query path validated the resolved target schema against the authenticated tenant — any tenant could read any other tenant's entire indexed history (including deleted rows) by issuing `USE <other-schema>` or by fully qualifying the table.

## What changed

**Config** (`internal/shim/auth.go`): optional `allowed_schemas` (`[]string`) per tenant, parsed as a real struct field (the file uses `UnmarshalStrict`). Empty entries are rejected at load. `TenantConfig` carries the list.

**Enforcement** (`internal/shim/handler.go` + `internal/shim/schema_authz.go`) — two chokepoints, both returning a proper wire error (`ER_DBACCESS_DENIED_ERROR`, 1044 — what a real mysqld returns for a database the user has no grants on), never a connection drop:

1. `UseDB` (COM_INIT_DB): a `USE` of a schema outside the set is rejected and does not replace the selected schema.
2. `HandleQuery`, on the **parsed query's resolved schema** (`q.Schema`) at execution time — one site covering all shapes: the `_flashback`/`_snapshot`/`_diff` virtual forms (schema from the USE'd db), and the hint / bare `AS OF` forms where a client can fully qualify `<schema>.<table>` without ever issuing `USE`. The `SHOW TABLES FROM _<virtual>` listing is gated on the current db as well.

Each denial logs a `slog.Warn` naming tenant and schema. No new audit taxonomy: the shim's ext seam has only successful `timetravel.query` emissions and no denied-side pattern (`authz.denied` is console-specific), so a per-denial warning is the trail.

**Binding** (`internal/cli/shim.go`): `handleConn` binds the authenticated tenant's list right after `BindActor`, *before* the `source_dsn`-derived default-schema seed — a seeded default the operator excluded from `allowed_schemas` is refused (with a warning) rather than silently trusted.

**Zero behavior change for existing configs**: a tenant without the field keeps the exact historical any-schema behaviour (nil list = unrestricted). When `shim.yaml` has more than one tenant and any of them lacks `allowed_schemas`, the shim logs a one-time startup warning that cross-schema isolation is not enforced.

**Matching** is case-insensitive (`strings.EqualFold`), so the allowlist is not bypassable by re-casing the schema name.

## Other surfaces checked

- **Console embedded flashback port** (`internal/console/flashback.go` / consoleapp): routes by username to per-server handlers built from the console registry — `shim.yaml` tenants are not involved, no `BindAllowedSchemas` call is made, so its behaviour is unchanged.
- **`bintrail-pg flashback`** shares the `shim.yaml` tenant format but its pgwire session dispatches to the resolve entry points directly (bypassing `HandleQuery`); it binds no allowlist, so it is also unchanged. Extending enforcement to that front-end is a natural follow-up.

## Docs

`docs/time-travel-sql.md` Step 1 gains an "Isolating tenants with `allowed_schemas`" section with a two-tenant example.

## Tests

`internal/shim/schema_authz_test.go` drives the **real command entry point** (`HandleQuery` — what go-mysql/server dispatches COM_QUERY to), not a leaf validator:

- in-set `USE` + `_flashback` query reaches the real point-lookup SQL (sqlmock `pk_hash = SHA2` expectation met);
- out-of-set `USE` → 1044, and the rejected `USE` does not leak into handler state;
- out-of-set fully qualified query **without any prior USE** → 1044 (bare `AS OF` and hint forms);
- virtual-schema and `_diff` forms with an out-of-set current db (planted past the `UseDB` gate, so these stay red under a mutant that keeps the `UseDB` check but drops the query-time one) → 1044;
- `SHOW TABLES FROM _flashback` under an out-of-set current db → 1044;
- tenant without the field: `USE` anywhere + query pass exactly as before;
- loader round-trip + empty-entry rejection.

Mutation check performed: deleting the `HandleQuery` enforcement call turns `TestHandleQueryEnforcesAllowedSchemas` red.

`internal/cli/shim_test.go` covers the serving-layer map (`buildUserAllowedSchemas` — absent tenant maps to nil/unrestricted) and the startup-warning classifier.

Ran: `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, `go test ./internal/shim/... ./internal/cli/... -count=1 -race`, plus `-race` suites for the shim's consumers (`internal/pgshim`, `consoleapp`, `cliapp`, `internal/console`) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
