### PR TITLE
verify: PG-native live-source consistency checksum

### DIFF
--- a/cmd/bintrail-pg/main.go
+++ b/cmd/bintrail-pg/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/dbtrail/dbtrail/internal/cli"
 	"github.com/dbtrail/dbtrail/internal/observe"
+	"github.com/dbtrail/dbtrail/internal/pgverifysource"
 	"github.com/dbtrail/dbtrail/internal/telemetry"
 )
 
@@ -73,6 +74,10 @@ func init() {
 	// shared verbatim with the core binary. The PostgreSQL capture command
 	// (stream) is registered in stream.go's init().
 	cli.AddReadCommands(rootCmd)
+	// PG live-source verify provider (#1024): this binary links the PG driver
+	// stack, so it fills the seam the shared verify command leaves empty in
+	// the postgres-free core binary.
+	cli.SetPGLiveVerifyConnect(pgverifysource.LiveSource)
 	// The index-side maintenance plane (rotate, archive reconcile) — also
 	// source-agnostic, so a PostgreSQL-only install can bound its index growth
 	// with `bintrail-pg rotate` instead of needing the core MySQL binary against

--- a/cmd/bintrail-pg/verify_seam_test.go
+++ b/cmd/bintrail-pg/verify_seam_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/cli"
+)
+
+// TestPGLiveVerifySeamIsFilled is the wiring guard for #1024: this binary's
+// init() must install the PostgreSQL live-source verify provider
+// (cli.SetPGLiveVerifyConnect(pgverifysource.LiveSource)). Delete that call
+// and every other suite stays green while `bintrail-pg verify --source-dsn`
+// refuses at runtime — with a message telling the operator to run the very
+// binary they are already running. Mutation-detecting by construction: the
+// test observes the seam's state after init, not the code that fills it.
+func TestPGLiveVerifySeamIsFilled(t *testing.T) {
+	if !cli.PGLiveVerifySeamFilled() {
+		t.Fatal("the PG live-source verify seam is empty — cmd/bintrail-pg's init() must call cli.SetPGLiveVerifyConnect(pgverifysource.LiveSource)")
+	}
+}

--- a/consoleapp/verify.go
+++ b/consoleapp/verify.go
@@ -256,7 +256,7 @@ func (s *verifySupervisor) run(req console.VerifyRequest, baselineSrc string) {
 			runErr = s.runLiveSource(req, db, resolver, dbName)
 		}
 	case console.VerifyModeRecoverInputs:
-		runErr = s.runRecoverInputs(req, db, resolver, dbName)
+		runErr = s.runRecoverInputs(req, db, resolver, dbName, flavor)
 	case console.VerifyModeBaselineAnchored:
 		runErr = s.runBaselineAnchored(req, baselineSrc, db, resolver, dbName, flavor)
 	default:
@@ -415,6 +415,14 @@ func (s *verifySupervisor) runLiveSourcePG(req console.VerifyRequest, indexDB *s
 	if err != nil {
 		return fmt.Errorf("resolve target tables: %w", err)
 	}
+	// Defensive mirror of the CLI's guard: an empty enumeration must fail the
+	// run loudly, not complete "clean" with zero table results — a verify that
+	// verified nothing is the false assurance this tool exists to prevent.
+	// (Normally unreachable: verify.ResolverFor errors first on an index with
+	// no schema snapshot.)
+	if len(tables) == 0 {
+		return fmt.Errorf("no tables to verify (empty filter and no schema snapshot)")
+	}
 
 	baselineSrc := req.BaselineDir
 	if baselineSrc == "" {
@@ -454,10 +462,19 @@ const recoverInputsLookback = 30 * 24 * time.Hour
 // scheduled runner (#1191) falls back to it for servers with no baseline
 // configured. Window and per-table cap are the CLI's defaults; the
 // conservative archive fetcher is deliberate (this shares the daemon with the
-// stream — #510/#511 keep --ultrafast off daemons).
-func (s *verifySupervisor) runRecoverInputs(req console.VerifyRequest, indexDB *sql.DB, resolver *metadata.Resolver, dbName string) error {
+// stream — #510/#511 keep --ultrafast off daemons). Table enumeration is
+// flavor-routed like the CLI's verifyTargetTablesForFlavor: on a PG index the
+// MAX(snapshot_id) lookup silently names ONE relation, so the PG branch
+// enumerates the per-table resolver instead (#1024 review).
+func (s *verifySupervisor) runRecoverInputs(req console.VerifyRequest, indexDB *sql.DB, resolver *metadata.Resolver, dbName, flavor string) error {
 	ctx := s.ctx
-	tables, err := liveSourceTargetTables(ctx, indexDB, req.Tables)
+	var tables []query.SchemaTable
+	var err error
+	if flavor == console.FlavorPostgres {
+		tables, err = verify.PGTargetTables(resolver, req.Tables)
+	} else {
+		tables, err = liveSourceTargetTables(ctx, indexDB, req.Tables)
+	}
 	if err != nil {
 		return fmt.Errorf("resolve target tables: %w", err)
 	}

--- a/consoleapp/verify.go
+++ b/consoleapp/verify.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/parquetquery"
+	"github.com/dbtrail/dbtrail/internal/pgverifysource"
 	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/verify"
 )
@@ -247,12 +248,10 @@ func (s *verifySupervisor) run(req console.VerifyRequest, baselineSrc string) {
 	var runErr error
 	switch req.Mode {
 	case console.VerifyModeLiveSource:
-		// Live-source verify fingerprints the source with MySQL-only SQL; a PG
-		// source is refused with a clear verdict (not a misleading inconclusive).
-		// Baseline-anchored is the supported PG path. This is an engine-truth
-		// backstop; handleVerifyTrigger already rejects it at the API boundary.
+		// The index's recorded flavor routes the live fingerprint: the MySQL
+		// consistent-snapshot scan, or the PG-native checksum (#1024).
 		if flavor == console.FlavorPostgres {
-			runErr = fmt.Errorf("live-source verify is not supported for PostgreSQL sources; use baseline-anchored verify")
+			runErr = s.runLiveSourcePG(req, db, resolver, dbName)
 		} else {
 			runErr = s.runLiveSource(req, db, resolver, dbName)
 		}
@@ -383,6 +382,58 @@ func (s *verifySupervisor) runLiveSource(req console.VerifyRequest, indexDB *sql
 			return fmt.Errorf("verify interrupted: %w", err)
 		}
 		res, err := verify.VerifyTable(ctx, cfg, st.Schema, st.Table)
+		if err != nil {
+			res = verify.TableResult{Schema: st.Schema, Table: st.Table, Status: verify.StatusError, Detail: err.Error()}
+		}
+		// Live-source mismatches have no explain support in the engine.
+		s.appendResult(req.ServerID, toWireResult(res, false))
+	}
+	return nil
+}
+
+// runLiveSourcePG is runLiveSource for a PostgreSQL source (#1024): the same
+// per-table loop, driving the engine's PG sibling (verify.VerifyTablePG).
+// Two deliberate differences from the MySQL loop:
+//   - the source is reached through pgverifysource.LiveSource — a pinned PG
+//     connection (the render-GUC pin is what makes the live scan
+//     byte-comparable to the baseline/delta text) — opened once and used
+//     serially across tables; this daemon already links the PG capture
+//     stack, so unlike the core CLI no seam indirection is needed;
+//   - target tables come from the resolver (verify.PGTargetTables), never
+//     liveSourceTargetTables' MAX(snapshot_id) query: a PG index stores one
+//     relation per snapshot_id, so that query would silently verify a single
+//     table.
+func (s *verifySupervisor) runLiveSourcePG(req console.VerifyRequest, indexDB *sql.DB, resolver *metadata.Resolver, dbName string) error {
+	ctx := s.ctx
+	sourceChecksum, closeSource, err := pgverifysource.LiveSource(ctx, req.SourceDSN)
+	if err != nil {
+		return fmt.Errorf("connect source: %w", err)
+	}
+	defer func() { _ = closeSource() }()
+
+	tables, err := verify.PGTargetTables(resolver, req.Tables)
+	if err != nil {
+		return fmt.Errorf("resolve target tables: %w", err)
+	}
+
+	baselineSrc := req.BaselineDir
+	if baselineSrc == "" {
+		baselineSrc = req.BaselineS3
+	}
+	// Conservative archive fetcher and zero DuckDB tuning on purpose: this
+	// shares the daemon with the stream (#510/#511 keep --ultrafast off
+	// daemons), same as every other supervisor run mode.
+	cfg := verify.PGLiveConfig{
+		SourceChecksum: sourceChecksum, IndexDB: indexDB, Resolver: resolver,
+		BaselineSource: baselineSrc, IndexDBName: dbName,
+		NoArchive: req.NoArchive, ArchiveFetcher: parquetquery.Fetch,
+	}
+	for _, st := range tables {
+		// See runBaselineAnchored: a shutdown mid-run fails the run loudly.
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("verify interrupted: %w", err)
+		}
+		res, err := verify.VerifyTablePG(ctx, cfg, st.Schema, st.Table)
 		if err != nil {
 			res = verify.TableResult{Schema: st.Schema, Table: st.Table, Status: verify.StatusError, Detail: err.Error()}
 		}

--- a/consoleapp/verify_pg_dispatch_integration_test.go
+++ b/consoleapp/verify_pg_dispatch_integration_test.go
@@ -1,0 +1,93 @@
+//go:build integration
+
+package consoleapp
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// seedPGVerifyIndex marks the test index as a PostgreSQL capture and
+// publishes the given relations — one snapshot_id each, the real
+// WritePGSnapshot shape.
+func seedPGVerifyIndex(t *testing.T, db *sql.DB, tables ...string) {
+	t.Helper()
+	for _, tbl := range tables {
+		if _, err := metadata.WritePGSnapshot(context.Background(), db, &metadata.PGRelationSchema{
+			Schema: "public", Table: tbl,
+			Columns: []metadata.PGRelationColumn{{Name: "id", Ordinal: 1, IsPK: true}},
+		}); err != nil {
+			t.Fatalf("WritePGSnapshot(%s): %v", tbl, err)
+		}
+	}
+	if _, err := db.Exec(`
+		INSERT INTO stream_state (id, mode, binlog_file, binlog_position, gtid_set, flavor, last_checkpoint, server_id)
+		VALUES (1, 'gtid', '0/0', 0, '0/0', 'postgres', UTC_TIMESTAMP(), 1)`); err != nil {
+		t.Fatalf("seed stream_state: %v", err)
+	}
+}
+
+// TestIntegrationVerifySupervisorPGLiveSourceDispatch is the mutation guard
+// for the supervisor's flavor dispatch: a live-source run against a
+// PG-flavored index must route to runLiveSourcePG (the pinned pgx connect —
+// its failure text is pgx's "failed to connect"), never fall into the MySQL
+// runLiveSource, whose config.Connect would reject the postgres:// DSN with a
+// MySQL-driver "invalid DSN" parse error. Deleting the flavor branch in
+// run()'s VerifyModeLiveSource case flips this test's observed error.
+func TestIntegrationVerifySupervisorPGLiveSourceDispatch(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	seedPGVerifyIndex(t, db, "orders")
+
+	s := newVerifySupervisor(context.Background(), nil, nil)
+	if err := s.RunScheduled(console.VerifyRequest{
+		ServerID: "pg1", ServerName: "pg", Mode: console.VerifyModeLiveSource,
+		IndexDSN:  testutil.IntegrationDSN(dbName),
+		SourceDSN: "postgres://bintrail:nope@127.0.0.1:9/appdb",
+		// port 9 (discard) — the connect must fail fast and land in LastError
+		BaselineDir: t.TempDir(),
+	}); err != nil {
+		t.Fatalf("RunScheduled: %v", err)
+	}
+	st := s.Status("pg1")
+	if st.State != console.VerifyStateFailed {
+		t.Fatalf("state = %q, want failed (results=%v)", st.State, st.Results)
+	}
+	if !strings.Contains(st.LastError, "connect source:") || !strings.Contains(st.LastError, "failed to connect") {
+		t.Fatalf("LastError = %q, want the PG path's pgx connect failure — a MySQL-driver 'invalid DSN' here means the flavor dispatch fell into runLiveSource", st.LastError)
+	}
+	if strings.Contains(st.LastError, "invalid DSN") {
+		t.Fatalf("LastError = %q — the postgres:// DSN reached the MySQL driver: flavor dispatch is broken", st.LastError)
+	}
+}
+
+// TestIntegrationVerifySupervisorPGRecoverInputsEnumeration mirrors the CLI's
+// enumeration guard on the console path: recover-inputs on a PG index must
+// enumerate EVERY relation via the resolver, not the one relation the
+// MAX(snapshot_id) lookup names.
+func TestIntegrationVerifySupervisorPGRecoverInputsEnumeration(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	seedPGVerifyIndex(t, db, "orders", "items")
+
+	s := newVerifySupervisor(context.Background(), nil, nil)
+	if err := s.RunScheduled(console.VerifyRequest{
+		ServerID: "pg1", ServerName: "pg", Mode: console.VerifyModeRecoverInputs,
+		IndexDSN: testutil.IntegrationDSN(dbName),
+	}); err != nil {
+		t.Fatalf("RunScheduled: %v", err)
+	}
+	st := s.Status("pg1")
+	if st.State != console.VerifyStateSucceeded {
+		t.Fatalf("state = %q (lastError=%q), want succeeded", st.State, st.LastError)
+	}
+	if len(st.Results) != 2 {
+		t.Fatalf("results = %d tables (%v), want both published relations — one means the enumeration fell back to MAX(snapshot_id)", len(st.Results), st.Results)
+	}
+}

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -453,13 +453,15 @@ directly.
 > across the upgrade, so `--pk` lookups and `--history` can split there;
 > re-baselining resolves this going forward (deltas before the new anchor are
 > not replayed).
-> **Full-table** `reconstruct` (`--output-format mydumper`) and
-> baseline-anchored `verify` remain deliberately out of scope: a PG baseline
-> does not carry the `CREATE TABLE` metadata full-table reconstruct needs.
-> `query` and `recover` (which work from the indexed deltas alone, no baseline
-> required) are the fully-supported recovery surface for PostgreSQL in this
-> release — see [Limitations](#limitations) for the complete
-> picture.
+> **Full-table** `reconstruct` (`--output-format mydumper`) remains
+> deliberately out of scope: a PG baseline does not carry the `CREATE TABLE`
+> metadata it needs. `verify` is not bound by that limit — it digests row
+> content without emitting a dump, so both baseline-anchored and live-source
+> `verify` are supported for PostgreSQL (see
+> [verify — Notes per source](verify.md#notes-per-source)). `query` and
+> `recover` (which work from the indexed deltas alone, no baseline required)
+> round out the recovery surface — see [Limitations](#limitations) for the
+> complete picture.
 
 ### Interactive `AS OF` from `psql`
 
@@ -497,7 +499,7 @@ Scope and behaviour track PostgreSQL's current time-travel maturity:
 - **Single-row `AS OF` only** — a `WHERE <primary-key> = <value>` predicate.
   Full-table `AS OF` is refused with remediation: a PG baseline does not carry
   the `CREATE TABLE` metadata full-table reconstruct needs (the same limit as
-  `reconstruct --output-format mydumper` and baseline-anchored `verify`).
+  `reconstruct --output-format mydumper`).
 - Columns render as **text** (the conservative first cut): read each one as a
   string, or let your driver text-parse it into a typed target. One caveat: a
   binary/`bytea` value containing a `0x00` byte truncates at the first NUL in
@@ -723,9 +725,12 @@ coerce, but verify your own round-trip.
 - **`GENERATED ... AS IDENTITY` / generated columns** can need care on recovery
   (`GENERATED ALWAYS AS IDENTITY` rejects an explicit insert; `STORED` generated
   columns are absent from the stream before PostgreSQL 18). Treat as best-effort.
-- **Full-table `reconstruct` and baseline-anchored `verify` are not wired for
-  PostgreSQL** — a PG baseline deliberately omits the `CREATE TABLE` metadata
-  full-table reconstruct needs (see above). **Single-row** `reconstruct` and
+- **Full-table `reconstruct` is not wired for PostgreSQL** — a PG baseline
+  deliberately omits the `CREATE TABLE` metadata it needs (see above).
+  `verify` is not bound by that limit: baseline-anchored, live-source, and
+  recover-input modes are all supported for PostgreSQL sources (see
+  [verify — Notes per source](verify.md#notes-per-source), including how the
+  live-source coverage check differs). **Single-row** `reconstruct` and
   the shim's single-row `_snapshot` work against a PG baseline and are
   validated end-to-end for scalar types — including the GUC-sensitive set,
   rendered under session GUCs pinned identically at capture and baseline;
@@ -752,8 +757,8 @@ baseline↔delta rendering-GUC identity and its fold-validated type matrix
 (#593), the managed-PostgreSQL smoke matrix (RDS and Aurora — see
 [Managed PostgreSQL](#managed-postgresql)), and source-aware console
 presentation including the live replication-health panel (v0.20.1).
-**Full-table** `reconstruct` and baseline-anchored `verify` remain documented
-out of scope (above).
+**Full-table** `reconstruct` remains documented out of scope (above);
+`verify` — baseline-anchored, live-source, and recover-input — is supported.
 
 ---
 

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -100,6 +100,11 @@ bintrail verify --source-dsn "$SRC" --index-dsn "$IDX" \
   --baseline-s3 s3://bucket/baselines --tables mydb.orders,mydb.users
 ```
 
+For a PostgreSQL source the same command works unchanged — pass the
+`postgres://` DSN as `--source-dsn`; the index's recorded source flavor routes
+the fingerprint. See [Notes per source](#notes-per-source) for how the PG
+fingerprint and its coverage check differ under the hood.
+
 ### Recover-input (`--check recover`)
 
 Pass `--check recover`. Instead of comparing table content, `verify` walks each
@@ -260,8 +265,9 @@ bintrail verify --index-dsn "$IDX" --baseline-dir /data/baselines --format json
   or `no_predecessor` (only one baseline; reported, exit 0, with a `message`).
 - `tables[].status` — `match` / `mismatch` / `inconclusive` / `error`, the same
   bucket counted in `summary`. `anchor` is the point the comparison was anchored
-  to (a GTID set in live-source mode, a `file:pos` binlog coordinate in
-  baseline-anchored mode); `reason` is the detail behind the verdict.
+  to (a GTID set in MySQL live-source mode, a `file:pos` binlog coordinate in
+  MySQL baseline-anchored mode, an `LSN:` WAL position for a PostgreSQL
+  source); `reason` is the detail behind the verdict.
 - `tables[].events_checked` / `chains_checked` / `chains_inconclusive` —
   present only under `--check recover` (omitted entirely otherwise, so a
   content-mode document is unchanged): how many events the chain walk visited,
@@ -313,7 +319,7 @@ diff tool involved.
 | Flag | Default | Description |
 |---|---|---|
 | `--index-dsn` | *(required)* | DSN for the index MySQL database |
-| `--source-dsn` | *(empty)* | Live source DSN. Pass it for **live-source** mode; omit for **baseline-anchored** mode |
+| `--source-dsn` | *(empty)* | Live source DSN (MySQL DSN, or `postgres://` for a PostgreSQL source). Pass it for **live-source** mode; omit for **baseline-anchored** mode |
 | `--baseline-dir` | *(empty)* | Local directory of baseline Parquet snapshots |
 | `--baseline-s3` | *(empty)* | S3 URL prefix of baseline snapshots (e.g. `s3://bucket/baselines/`) |
 | `--tables` | *(all)* | Comma-separated `schema.table` list (default: all tables in the latest schema snapshot; in baseline-anchored mode, snapshot tables with no baseline report `inconclusive` — "never baselined") |
@@ -381,7 +387,30 @@ the contract tag differs.
 
 ## Notes per source
 
-`verify` runs against the MySQL index, so it works for any source family whose
-baselines are wired. Baseline-anchored mode requires baselines; **PostgreSQL
-baselines are not yet wired** (see [PostgreSQL limitations](postgres.md#limitations)),
-so `verify` against a PostgreSQL source is not usable in this release.
+`verify` runs against the MySQL index, so every mode works wherever its data
+sources exist:
+
+- **MySQL** — all three modes. Live-source mode anchors on `@@gtid_executed`
+  and refuses to compare when the index is provably behind the snapshot; on a
+  `gtid_mode=OFF` source it proceeds with a `coverage unverified` note.
+- **MariaDB** — baseline-anchored and recover-input as MySQL. Live-source
+  proceeds with the same `coverage unverified` note (MariaDB has no
+  `@@gtid_executed` to prove containment against).
+- **PostgreSQL** — baseline-anchored and recover-input work against the PG
+  capture (`bintrail-pg stream` / the console's PostgreSQL servers), anchored
+  on WAL LSNs instead of binlog coordinates. Live-source mode is supported
+  too: the source is fingerprinted inside one `REPEATABLE READ` snapshot,
+  read in PostgreSQL's own text rendering under the same pinned session GUCs
+  the capture and baseline run under (`TimeZone=UTC`, `DateStyle=ISO`,
+  `extra_float_digits=3`, `bytea_output=hex`, `IntervalStyle=postgres`), and
+  anchored on `pg_current_wal_lsn()`. Its coverage check differs from MySQL
+  by necessity: an index checkpoint at-or-past the anchor **proves** the
+  index absorbed everything the snapshot reflects; a checkpoint behind it
+  proves nothing (WAL from other databases and non-transactional activity —
+  autovacuum, checkpoints — advances the anchor without ever producing
+  indexable events), so the run proceeds and the result carries a
+  `coverage unverified` note — the same documented trade-off as a GTID-off
+  MySQL source, where a genuinely-behind index surfaces as an investigable
+  mismatch rather than being masked. A stamped permanent capture loss
+  (`gap_lost`) always reports `inconclusive`, never a false mismatch. The
+  quiescent-source requirement applies unchanged.

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -360,6 +360,12 @@ verifies the *other* half — that no events were dropped from the capture strea
 
 ## Charset contract: raw stored bytes
 
+This section (including the digest version tag below) describes the **MySQL**
+rendering contract. A PostgreSQL source has no charset-transcoding layer in
+this path — its rendering contract is the pinned session GUCs described in
+[Notes per source](#notes-per-source); the digests still carry the same
+version tag, and comparisons are always within one source, never across.
+
 The row-content fingerprint is computed over the bytes MySQL returns for each
 column. To make that byte stream independent of the connection charset, the
 checksum scan pins `character_set_results = binary`, so the server returns each
@@ -396,9 +402,10 @@ sources exist:
 - **MariaDB** — baseline-anchored and recover-input as MySQL. Live-source
   proceeds with the same `coverage unverified` note (MariaDB has no
   `@@gtid_executed` to prove containment against).
-- **PostgreSQL** — baseline-anchored and recover-input work against the PG
-  capture (`bintrail-pg stream` / the console's PostgreSQL servers), anchored
-  on WAL LSNs instead of binlog coordinates. Live-source mode is supported
+- **PostgreSQL** — baseline-anchored verify works against the PG capture
+  (`bintrail-pg stream` / the console's PostgreSQL servers), anchored on WAL
+  LSNs instead of binlog coordinates; recover-input works too (index-only —
+  it carries no anchor). Live-source mode is supported
   too: the source is fingerprinted inside one `REPEATABLE READ` snapshot,
   read in PostgreSQL's own text rendering under the same pinned session GUCs
   the capture and baseline run under (`TimeZone=UTC`, `DateStyle=ISO`,
@@ -411,6 +418,9 @@ sources exist:
   indexable events), so the run proceeds and the result carries a
   `coverage unverified` note — the same documented trade-off as a GTID-off
   MySQL source, where a genuinely-behind index surfaces as an investigable
-  mismatch rather than being masked. A stamped permanent capture loss
-  (`gap_lost`) always reports `inconclusive`, never a false mismatch. The
+  mismatch rather than being masked. A permanent capture loss (`gap_lost`)
+  stamped **inside the comparison window** reports `inconclusive`, never a
+  false mismatch; a loss older than the baseline snapshot is outside the
+  window — the baseline is a fresh dump of the source, so it re-covers
+  whatever the gap lost — and does not degrade the verdict. The
   quiescent-source requirement applies unchanged.

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -107,7 +107,7 @@ Examples:
 }
 
 func init() {
-	verifyCmd.Flags().StringVar(&vfySourceDSN, "source-dsn", "", "DSN for the live source MySQL database; pass it for live-source mode, omit for baseline-anchored mode")
+	verifyCmd.Flags().StringVar(&vfySourceDSN, "source-dsn", "", "DSN for the live source database (MySQL DSN, or postgres:// for a PostgreSQL source); pass it for live-source mode, omit for baseline-anchored mode")
 	verifyCmd.Flags().StringVar(&vfyIndexDSN, "index-dsn", "", "DSN for the index MySQL database (required)")
 	verifyCmd.Flags().StringVar(&vfyBaselineDir, "baseline-dir", "", "Local directory of baseline Parquet snapshots")
 	verifyCmd.Flags().StringVar(&vfyBaselineS3, "baseline-s3", "", "S3 URL prefix of baseline Parquet snapshots (e.g. s3://bucket/baselines/)")
@@ -184,10 +184,12 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 
 	flavor := query.SourceFlavor(indexDB)
 	if vfySourceDSN != "" {
-		// Live-source verify fingerprints the source with MySQL-only SQL; refuse
-		// a PG source up front rather than reach a misleading inconclusive.
+		// The index's recorded flavor routes the live fingerprint: MySQL SQL
+		// (CONSISTENT SNAPSHOT + @@gtid_executed) or the PG-native checksum
+		// (REPEATABLE READ + pg_current_wal_lsn, #1024). The flag value itself
+		// is not sniffed — the index is truth, same rule as everywhere else.
 		if flavor == "postgres" {
-			return fmt.Errorf("live-source verify (--source-dsn) is not supported for PostgreSQL sources; omit it to run baseline-anchored verify")
+			return runVerifyLivePG(cmd, indexDB, resolver, indexDBName, baselineSrc, duckTuning)
 		}
 		return runVerifyLive(cmd, indexDB, resolver, indexDBName, baselineSrc, duckTuning)
 	}
@@ -441,6 +443,66 @@ func runVerifyLive(cmd *cobra.Command, indexDB *sql.DB, resolver *metadata.Resol
 			// One table's hard error must not abort the run and hide the other
 			// tables' results (including real mismatches). Record it and continue.
 			res = verify.TableResult{Schema: st.schema, Table: st.table, Status: verify.StatusError, Detail: err.Error()}
+		}
+		results = append(results, res)
+	}
+	rep := verify.NewReport(verify.ModeLive, results)
+	rep.BaselineSource = baselineSrc
+	return emitVerifyReport(cmd, rep)
+}
+
+// runVerifyLivePG is live-source mode for a PostgreSQL source (#1024): the
+// same per-table loop and report as runVerifyLive, driving the engine's PG
+// sibling (verify.VerifyTablePG). Three deliberate differences:
+//   - the source is reached through the pgLiveVerifyConnect seam (a pinned
+//     PG connection — the render-GUC pin is what makes the live scan
+//     byte-comparable), opened ONCE and used serially across tables; the
+//     core bintrail binary leaves the seam empty and refuses here with a
+//     pointer to bintrail-pg, keeping cmd/bintrail postgres-free;
+//   - target tables come from the resolver (verify.PGTargetTables), not the
+//     MAX(snapshot_id) query: a PG index stores one relation per snapshot_id,
+//     so that query would silently verify a single table.
+func runVerifyLivePG(cmd *cobra.Command, indexDB *sql.DB, resolver *metadata.Resolver, indexDBName, baselineSrc string, duckTuning duckdbutil.Tuning) error {
+	if pgLiveVerifyConnect == nil {
+		return fmt.Errorf("live-source verify for a PostgreSQL source is not available in this binary (it links no PostgreSQL driver); run it with `bintrail-pg verify --source-dsn ...`, or omit --source-dsn for baseline-anchored verify")
+	}
+	sourceChecksum, closeSource, err := pgLiveVerifyConnect(cmd.Context(), vfySourceDSN)
+	if err != nil {
+		return fmt.Errorf("connect to source database: %w", err)
+	}
+	defer func() { _ = closeSource() }()
+
+	var explicit []string
+	if vfyTables != "" {
+		explicit = splitAndTrim(vfyTables, ",")
+	}
+	tables, err := verify.PGTargetTables(resolver, explicit)
+	if err != nil {
+		return err
+	}
+	if len(tables) == 0 {
+		return fmt.Errorf("no tables to verify (empty --tables and no schema snapshot)")
+	}
+
+	cfg := verify.PGLiveConfig{
+		SourceChecksum: sourceChecksum,
+		IndexDB:        indexDB,
+		Resolver:       resolver,
+		BaselineSource: baselineSrc,
+		IndexDBName:    indexDBName,
+		NoArchive:      vfyNoArchive,
+		ArchiveFetcher: TunedArchiveFetcher(duckTuning),
+		DuckDBTuning:   duckTuning,
+	}
+
+	results := make([]verify.TableResult, 0, len(tables))
+	for _, st := range tables {
+		res, err := verify.VerifyTablePG(cmd.Context(), cfg, st.Schema, st.Table)
+		if err != nil {
+			// One table's hard error must not abort the run and hide the other
+			// tables' results (including real mismatches) — same isolation as
+			// runVerifyLive.
+			res = verify.TableResult{Schema: st.Schema, Table: st.Table, Status: verify.StatusError, Detail: err.Error()}
 		}
 		results = append(results, res)
 	}

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -176,13 +176,15 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	flavor := query.SourceFlavor(indexDB)
 	if vfyCheck == checkRecover {
-		// Index-only, source-family agnostic: it walks stored event images,
-		// so it needs neither the source flavor nor a baseline.
-		return runVerifyRecoverInputs(cmd, indexDB, resolver, indexDBName, duckTuning)
+		// Index-only: the chain walk reads stored event images, so it needs
+		// no baseline and no live source. The flavor still matters for ONE
+		// thing — table ENUMERATION: the default MAX(snapshot_id) lookup
+		// names a single relation on a PG index (see verifyTargetTablesForFlavor).
+		return runVerifyRecoverInputs(cmd, indexDB, resolver, indexDBName, duckTuning, flavor)
 	}
 
-	flavor := query.SourceFlavor(indexDB)
 	if vfySourceDSN != "" {
 		// The index's recorded flavor routes the live fingerprint: MySQL SQL
 		// (CONSISTENT SNAPSHOT + @@gtid_executed) or the PG-native checksum
@@ -456,8 +458,8 @@ func runVerifyLive(cmd *cobra.Command, indexDB *sql.DB, resolver *metadata.Resol
 // sibling (verify.VerifyTablePG). Three deliberate differences:
 //   - the source is reached through the pgLiveVerifyConnect seam (a pinned
 //     PG connection — the render-GUC pin is what makes the live scan
-//     byte-comparable), opened ONCE and used serially across tables; the
-//     core bintrail binary leaves the seam empty and refuses here with a
+//     byte-comparable), opened ONCE and used serially across tables;
+//   - the core bintrail binary leaves the seam empty and refuses here with a
 //     pointer to bintrail-pg, keeping cmd/bintrail postgres-free;
 //   - target tables come from the resolver (verify.PGTargetTables), not the
 //     MAX(snapshot_id) query: a PG index stores one relation per snapshot_id,
@@ -518,7 +520,7 @@ func runVerifyLivePG(cmd *cobra.Command, indexDB *sql.DB, resolver *metadata.Res
 // It shares the report, the renderer and — critically — Report.ExitError with
 // the content modes, so a recover-input mismatch fails a CI/cron gate exactly
 // like any other mismatch instead of going through a second exit path.
-func runVerifyRecoverInputs(cmd *cobra.Command, indexDB *sql.DB, resolver *metadata.Resolver, indexDBName string, duckTuning duckdbutil.Tuning) error {
+func runVerifyRecoverInputs(cmd *cobra.Command, indexDB *sql.DB, resolver *metadata.Resolver, indexDBName string, duckTuning duckdbutil.Tuning, flavor string) error {
 	lookback, err := cliutil.ParseRetain(vfyLookback)
 	if err != nil {
 		return fmt.Errorf("--lookback: %w", err)
@@ -527,7 +529,7 @@ func runVerifyRecoverInputs(cmd *cobra.Command, indexDB *sql.DB, resolver *metad
 		return fmt.Errorf("--max-events must be >= 0 (0 uses the default of %d)", verify.DefaultRecoverInputsMaxEvents)
 	}
 
-	tables, err := verifyTargetTables(cmd, indexDB)
+	tables, err := verifyTargetTablesForFlavor(cmd, indexDB, resolver, flavor)
 	if err != nil {
 		return err
 	}
@@ -606,6 +608,33 @@ func verifyTableFilter() (map[string]bool, error) {
 }
 
 type schemaTable struct{ schema, table string }
+
+// verifyTargetTablesForFlavor picks the table-enumeration strategy by the
+// index's source flavor: the MySQL default is the MAX(snapshot_id) lookup
+// (verifyTargetTables — one snapshot covers the whole schema), but on a
+// PostgreSQL index that same query silently names ONE relation
+// (WritePGSnapshot stores one relation per snapshot_id), so the PG branch
+// enumerates the per-table resolver instead (verify.PGTargetTables — the same
+// rule runVerifyLivePG applies). Without this split, `verify --check recover`
+// on a PG index verified a single table and reported green (#1024 review).
+func verifyTargetTablesForFlavor(cmd *cobra.Command, indexDB *sql.DB, resolver *metadata.Resolver, flavor string) ([]schemaTable, error) {
+	if flavor != "postgres" {
+		return verifyTargetTables(cmd, indexDB)
+	}
+	var explicit []string
+	if vfyTables != "" {
+		explicit = splitAndTrim(vfyTables, ",")
+	}
+	sts, err := verify.PGTargetTables(resolver, explicit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]schemaTable, len(sts))
+	for i, st := range sts {
+		out[i] = schemaTable{st.Schema, st.Table}
+	}
+	return out, nil
+}
 
 // verifyTargetTables returns the tables to verify: the explicit --tables list,
 // or every table in the latest schema snapshot.

--- a/internal/cli/verify_pg_routing_integration_test.go
+++ b/internal/cli/verify_pg_routing_integration_test.go
@@ -1,0 +1,135 @@
+//go:build integration
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+	"github.com/dbtrail/dbtrail/internal/verify"
+)
+
+// setVerifyGlobals points the verify command's package globals at the test
+// index and restores every touched value on cleanup — the same
+// save/restore-discipline verify_format_test.go's setVerifyFormat applies,
+// extended to the fields this file needs. The seam is reset to nil (its core-
+// binary default) so no other test inherits a stub provider.
+func setVerifyGlobals(t *testing.T, indexDSN, sourceDSN, baselineDir, check, tables string) {
+	t.Helper()
+	prevIdx, prevSrc, prevBase, prevCheck, prevTables := vfyIndexDSN, vfySourceDSN, vfyBaselineDir, vfyCheck, vfyTables
+	vfyIndexDSN, vfySourceDSN, vfyBaselineDir, vfyCheck, vfyTables = indexDSN, sourceDSN, baselineDir, check, tables
+	t.Cleanup(func() {
+		vfyIndexDSN, vfySourceDSN, vfyBaselineDir, vfyCheck, vfyTables = prevIdx, prevSrc, prevBase, prevCheck, prevTables
+		SetPGLiveVerifyConnect(nil)
+	})
+}
+
+// seedPGIndex marks the test index as a PostgreSQL capture (stream_state
+// flavor) and publishes the given relations as schema snapshots — one
+// snapshot_id per relation, exactly the shape WritePGSnapshot gives a real PG
+// index (the shape that makes the MAX(snapshot_id) enumeration name a single
+// table).
+func seedPGIndex(t *testing.T, db *sql.DB, tables ...string) {
+	t.Helper()
+	for _, tbl := range tables {
+		if _, err := metadata.WritePGSnapshot(context.Background(), db, &metadata.PGRelationSchema{
+			Schema: "public", Table: tbl,
+			Columns: []metadata.PGRelationColumn{{Name: "id", Ordinal: 1, IsPK: true}},
+		}); err != nil {
+			t.Fatalf("WritePGSnapshot(%s): %v", tbl, err)
+		}
+	}
+	if _, err := db.Exec(`
+		INSERT INTO stream_state (id, mode, binlog_file, binlog_position, gtid_set, flavor, last_checkpoint, server_id)
+		VALUES (1, 'gtid', '0/0', 0, '0/0', 'postgres', UTC_TIMESTAMP(), 1)`); err != nil {
+		t.Fatalf("seed stream_state: %v", err)
+	}
+}
+
+// TestIntegrationVerifyLivePGRouting covers the two runtime behaviors of the
+// PG live-source seam that no unit test can reach (they need a real index to
+// read the flavor from):
+//
+//   - seam EMPTY (the core bintrail binary): the run refuses with a message
+//     naming bintrail-pg — never a raw MySQL-driver error against the
+//     postgres:// DSN;
+//   - seam FILLED: the flavor routing actually reaches the provider (the
+//     stub's sentinel error comes back through the connect wrapper), proving
+//     runVerify dispatched to runVerifyLivePG and not the MySQL path.
+func TestIntegrationVerifyLivePGRouting(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	seedPGIndex(t, db, "orders")
+	setVerifyGlobals(t, testutil.IntegrationDSN(dbName), "postgres://u:p@127.0.0.1:9/x", t.TempDir(), checkContent, "")
+
+	newCmd := func() *cobra.Command {
+		cmd := &cobra.Command{}
+		// A bare command's Context() is nil until Execute sets one; the verify
+		// paths hand it to database/sql, which panics on a nil Context (and
+		// the deferred db.Close then deadlocks against the panicking query —
+		// a silent 10-minute hang, not a failure).
+		cmd.SetContext(context.Background())
+		cmd.SetOut(&bytes.Buffer{})
+		return cmd
+	}
+
+	t.Run("core binary refuses with a pointer to bintrail-pg", func(t *testing.T) {
+		SetPGLiveVerifyConnect(nil)
+		err := runVerify(newCmd(), nil)
+		if err == nil || !strings.Contains(err.Error(), "bintrail-pg verify") {
+			t.Fatalf("err = %v, want the nil-seam refusal naming bintrail-pg verify", err)
+		}
+	})
+
+	t.Run("filled seam receives the routed connect", func(t *testing.T) {
+		sentinel := errors.New("stub-connect-refused")
+		SetPGLiveVerifyConnect(func(ctx context.Context, dsn string) (verify.PGSourceChecksum, func() error, error) {
+			if dsn != "postgres://u:p@127.0.0.1:9/x" {
+				t.Errorf("seam received dsn %q, want the --source-dsn value", dsn)
+			}
+			return nil, nil, sentinel
+		})
+		err := runVerify(newCmd(), nil)
+		if err == nil || !errors.Is(err, sentinel) {
+			t.Fatalf("err = %v, want the stub's sentinel via the connect wrapper", err)
+		}
+		if !strings.Contains(err.Error(), "connect to source database") {
+			t.Errorf("err = %v, want the connect wrapper's prefix", err)
+		}
+	})
+}
+
+// TestIntegrationVerifyRecoverInputsPGEnumeration is the mutation guard for
+// verifyTargetTablesForFlavor's PG branch: on a PG index (one relation per
+// snapshot_id) the MySQL-default MAX(snapshot_id) enumeration names ONE
+// table, so a default `verify --check recover` silently walked a single
+// relation and reported green. With two published relations, both must appear
+// in the report.
+func TestIntegrationVerifyRecoverInputsPGEnumeration(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	seedPGIndex(t, db, "orders", "items")
+	setVerifyGlobals(t, testutil.IntegrationDSN(dbName), "", "", checkRecover, "")
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background()) // see newCmd in the routing test
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	// The exit status may legitimately be non-nil (two empty chains report
+	// per-table verdicts the report may count as unproven) — the assertion is
+	// the ENUMERATION: both relations must be walked and reported.
+	_ = runVerify(cmd, nil)
+	for _, tbl := range []string{"public.orders", "public.items"} {
+		if !strings.Contains(out.String(), tbl) {
+			t.Errorf("report is missing %s — PG enumeration fell back to the single-relation MAX(snapshot_id) query:\n%s", tbl, out.String())
+		}
+	}
+}

--- a/internal/cli/verify_pg_seam.go
+++ b/internal/cli/verify_pg_seam.go
@@ -24,3 +24,12 @@ var pgLiveVerifyConnect func(ctx context.Context, dsn string) (verify.PGSourceCh
 func SetPGLiveVerifyConnect(connect func(ctx context.Context, dsn string) (verify.PGSourceChecksum, func() error, error)) {
 	pgLiveVerifyConnect = connect
 }
+
+// PGLiveVerifySeamFilled reports whether a provider was installed. It exists
+// for ONE consumer: cmd/bintrail-pg's wiring test, which asserts its init()
+// actually filled the seam — deleting the SetPGLiveVerifyConnect call there
+// would otherwise leave every suite green while `bintrail-pg verify
+// --source-dsn` refused at runtime with a message pointing at... itself.
+func PGLiveVerifySeamFilled() bool {
+	return pgLiveVerifyConnect != nil
+}

--- a/internal/cli/verify_pg_seam.go
+++ b/internal/cli/verify_pg_seam.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/dbtrail/dbtrail/internal/verify"
+)
+
+// pgLiveVerifyConnect opens the live PostgreSQL source for `verify
+// --source-dsn` against a PG-flavored index and returns the fingerprint
+// provider plus its close func. It is nil in the CORE bintrail binary on
+// purpose: the provider (internal/pgverifysource) links the PostgreSQL driver
+// stack, which cliapp's TestCoreBinaryIsPostgresFree bans from cmd/bintrail —
+// PG capture, and with it PG live-source verify, belongs to cmd/bintrail-pg.
+// With the seam empty, runVerifyLivePG refuses with a message that names the
+// binary that can do it, instead of a link-time dependency violation.
+var pgLiveVerifyConnect func(ctx context.Context, dsn string) (verify.PGSourceChecksum, func() error, error)
+
+// SetPGLiveVerifyConnect installs the PostgreSQL live-source provider —
+// called once at startup by pgx-carrying binaries (cmd/bintrail-pg passes
+// pgverifysource.LiveSource). Not a general plugin point: the one intended
+// implementation is internal/pgverifysource, and the indirection exists only
+// so this package can stay pgx-free (see pgLiveVerifyConnect).
+func SetPGLiveVerifyConnect(connect func(ctx context.Context, dsn string) (verify.PGSourceChecksum, func() error, error)) {
+	pgLiveVerifyConnect = connect
+}

--- a/internal/consistency/checksum.go
+++ b/internal/consistency/checksum.go
@@ -61,6 +61,12 @@ type TableChecksum struct {
 	GTIDSet  string
 	RowCount int64
 	Digest   string
+	// LSN is the PostgreSQL WAL anchor (pg_current_wal_lsn) captured when the
+	// snapshot opens — the PG sibling of GTIDSet, set only by
+	// ConsistentTableChecksumPG (zero on the MySQL paths, which leave the
+	// anchor in GTIDSet). It carries the same lock-free-window caveat as
+	// GTIDSet: pg_current_wal_lsn is global state, not MVCC-filtered.
+	LSN uint64
 	// Columns is the ordered set of column names the digest was computed over
 	// (ordinal order, generated columns excluded). A consumer that recomputes a
 	// digest to compare (the verify capstone #634) must hash exactly this set in

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -242,15 +242,9 @@ func (s *Server) handleVerifyTrigger(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "this server has no source configured; set the source connection first")
 		return
 	}
-	// Live-source verify fingerprints the source with MySQL-only SQL. For a PG
-	// source, baseline-anchored verify (the default) is the supported path; a
-	// live-source request is refused with a clear message, not a misleading
-	// inconclusive (#1009). The engine backstops this in cmd/bintrail-console.
-	if mode == VerifyModeLiveSource && e.IsPostgres() {
-		writeJSONError(w, http.StatusBadRequest,
-			"live-source verify is not supported for PostgreSQL sources; use baseline-anchored (the default) instead")
-		return
-	}
+	// A PostgreSQL source is NOT refused here anymore: live-source verify has
+	// a PG-native checksum path since #1024 (verify.VerifyTablePG); the
+	// supervisor routes by the index's recorded flavor, not the registry field.
 
 	req := VerifyRequest{
 		ServerID: e.ID, ServerName: e.Name, Mode: mode, Tables: body.Tables,

--- a/internal/console/verify_trigger_test.go
+++ b/internal/console/verify_trigger_test.go
@@ -326,23 +326,27 @@ func addVerifyEntryPG(t *testing.T, srv *Server) string {
 	return e.ID
 }
 
-// TestVerifyTrigger_postgresRefusesLiveSource: live-source verify fingerprints
-// the source with MySQL-only SQL, so a PostgreSQL source is refused with a hard
-// 400 (deferred to #1024) — a clear message, never a misleading inconclusive,
-// and the controller is never triggered. A baseline destination is set so this
-// branch (not the earlier baseline gate) is what fires. No live PG needed.
-func TestVerifyTrigger_postgresRefusesLiveSource(t *testing.T) {
+// TestVerifyTrigger_postgresAcceptsLiveSource: live-source verify has a
+// PG-native checksum path since #1024, so a PostgreSQL entry with a source and
+// a baseline destination is ACCEPTED (this endpoint used to hard-400 it) and
+// the controller receives the request with the source DSN it needs — the
+// supervisor routes to the PG engine by the index's recorded flavor.
+func TestVerifyTrigger_postgresAcceptsLiveSource(t *testing.T) {
 	srv, ctrl := newVerifyTriggerServer(t)
 	id := addVerifyEntryPG(t, srv)
 	rec, body := doServersReq(t, srv, "POST", "/api/servers/"+id+"/verify", `{"mode":"live-source"}`)
-	if rec.Code != 400 {
-		t.Fatalf("PG live-source: code=%d, want 400 (body=%s)", rec.Code, body)
+	if rec.Code != 202 {
+		t.Fatalf("PG live-source: code=%d, want 202 (body=%s)", rec.Code, body)
 	}
-	if !strings.Contains(string(body), "not supported for PostgreSQL") {
-		t.Errorf("want the clear PG-refusal message, got: %s", body)
+	if len(ctrl.triggered) != 1 {
+		t.Fatalf("controller triggered %d times, want 1", len(ctrl.triggered))
 	}
-	if len(ctrl.triggered) != 0 {
-		t.Fatal("controller must never be triggered for a PG live-source request")
+	req := ctrl.triggered[0]
+	if req.Mode != VerifyModeLiveSource {
+		t.Errorf("mode = %q, want live-source", req.Mode)
+	}
+	if req.SourceDSN == "" {
+		t.Error("request must carry the source DSN for the live fingerprint")
 	}
 }
 

--- a/internal/pgverifysource/pgverifysource.go
+++ b/internal/pgverifysource/pgverifysource.go
@@ -29,19 +29,21 @@ import (
 	"github.com/dbtrail/dbtrail/internal/verify"
 )
 
-// Connect opens the live-source PostgreSQL connection with the capture
+// connectPinned opens the live-source PostgreSQL connection with the capture
 // plane's pinned render GUCs (TimeZone=UTC, DateStyle=ISO,
 // extra_float_digits=3, bytea_output=hex, IntervalStyle=postgres). The pin is
 // load-bearing, not a convenience: the reconstructed side's text (pgbaseline
 // COPY + pgoutput deltas) was rendered under exactly these GUCs, so a source
 // scanned without them (server-local TimeZone, default float digits) would
 // digest-differ on identical data — every timestamptz row a conclusive false
-// MISMATCH. Kept as the single entry point so no caller can forget the pin.
-func Connect(ctx context.Context, dsn string) (*pgx.Conn, error) {
+// MISMATCH. Unexported on purpose, like the checksum below: LiveSource is the
+// ONLY composition this package offers, so the pin invariant is structural —
+// no external caller can pair the checksum with an unpinned connection.
+func connectPinned(ctx context.Context, dsn string) (*pgx.Conn, error) {
 	return pgcapture.ConnectQueryPinned(ctx, dsn)
 }
 
-// LiveSource connects to dsn (pinned, via Connect) and returns the
+// LiveSource connects to dsn (pinned, via connectPinned) and returns the
 // verify.PGSourceChecksum a verify.PGLiveConfig needs, plus the close func
 // the caller must defer. This is the one-call wiring both consumers use
 // (cmd/bintrail-pg's cli.SetPGLiveVerifyConnect hook and consoleapp's
@@ -50,17 +52,17 @@ func Connect(ctx context.Context, dsn string) (*pgx.Conn, error) {
 // pgx.Conn is not concurrency-safe — which matches VerifyTablePG's
 // one-table-at-a-time loop.
 func LiveSource(ctx context.Context, dsn string) (verify.PGSourceChecksum, func() error, error) {
-	conn, err := Connect(ctx, dsn)
+	conn, err := connectPinned(ctx, dsn)
 	if err != nil {
 		return nil, nil, err
 	}
 	checksum := func(ctx context.Context, schema, table string, normalize func(raw []byte) []byte) (consistency.TableChecksum, error) {
-		return ConsistentTableChecksumPG(ctx, conn, schema, table, normalize)
+		return consistentTableChecksumPG(ctx, conn, schema, table, normalize)
 	}
 	return checksum, func() error { return conn.Close(context.Background()) }, nil
 }
 
-// ConsistentTableChecksumPG is the PostgreSQL sibling of
+// consistentTableChecksumPG is the PostgreSQL sibling of
 // consistency.ConsistentTableChecksumNormalized (#1024): a point-in-time,
 // order-independent fingerprint of a live PG source table, byte-comparable to
 // the digest internal/verify's reconstruct computes from a pgbaseline
@@ -70,7 +72,7 @@ func LiveSource(ctx context.Context, dsn string) (verify.PGSourceChecksum, func(
 // Why this needs almost no per-type canonicalization, where the MySQL scan
 // needed plenty: for a PostgreSQL source BOTH sides of the comparison already
 // speak the same rendering — PostgreSQL's own type output functions, run under
-// the render GUCs internal/pgcapture pins (see Connect). The baseline is
+// the render GUCs internal/pgcapture pins (see connectPinned). The baseline is
 // COPY ... (FORMAT text) under those GUCs (internal/pgbaseline), the deltas
 // are pgoutput text under those GUCs, and this scan reads the SAME output
 // functions under the SAME GUCs by forcing the wire format to text. The one
@@ -80,7 +82,7 @@ func LiveSource(ctx context.Context, dsn string) (verify.PGSourceChecksum, func(
 // and the text rendering comes from pgx.QueryResultFormats{TextFormatCode},
 // never from casts.
 //
-// conn MUST be connected with the pinned render GUCs (Connect) — an unpinned
+// conn MUST be connected with the pinned render GUCs (connectPinned) — an unpinned
 // session renders timestamptz in the server's zone and floats at default
 // precision, silently breaking byte-comparability. The connection is used
 // serially: a transaction is opened and committed within this call.
@@ -114,7 +116,7 @@ func LiveSource(ctx context.Context, dsn string) (verify.PGSourceChecksum, func(
 // never called for SQL NULL (nil raw bytes). VerifyTablePG passes its own
 // render normalizer through verify.PGSourceChecksum, so the two sides are
 // symmetric by construction.
-func ConsistentTableChecksumPG(ctx context.Context, conn *pgx.Conn, schema, table string, normalize func(raw []byte) []byte) (consistency.TableChecksum, error) {
+func consistentTableChecksumPG(ctx context.Context, conn *pgx.Conn, schema, table string, normalize func(raw []byte) []byte) (consistency.TableChecksum, error) {
 	res := consistency.TableChecksum{Schema: schema, Table: table}
 	if conn == nil {
 		return res, fmt.Errorf("pgverifysource: no PostgreSQL source connection")
@@ -210,7 +212,7 @@ func ConsistentTableChecksumPG(ctx context.Context, conn *pgx.Conn, schema, tabl
 
 // pgTableColumns returns the live, non-dropped, non-generated columns of
 // schema.table in attnum order — the same catalog contract as
-// internal/pgbaseline's loadColumns (see ConsistentTableChecksumPG's doc for
+// internal/pgbaseline's loadColumns (see consistentTableChecksumPG's doc for
 // why it is duplicated rather than imported, and why generated columns are
 // excluded).
 func pgTableColumns(ctx context.Context, conn *pgx.Conn, schema, table string) ([]string, error) {

--- a/internal/pgverifysource/pgverifysource.go
+++ b/internal/pgverifysource/pgverifysource.go
@@ -1,0 +1,242 @@
+// Package pgverifysource is the PostgreSQL live-source provider for
+// internal/verify (#1024): the PG-native table checksum plus the pinned
+// connection and the verify.PGSourceChecksum factory that wires it.
+//
+// It is a SEPARATE package — not part of internal/consistency — for a
+// dependency-boundary reason, not a stylistic one: it links the PostgreSQL
+// driver stack (jackc/pgx, pglogrepl, internal/pgcapture), which two guards
+// ban from the packages the core binary and the read layer link —
+// cliapp's TestCoreBinaryIsPostgresFree (#534: cmd/bintrail must stay
+// postgres-free; PG capture lives in cmd/bintrail-pg) and internal/event's
+// TestReadLayerDoesNotLinkGoMySQL (#528: the read stack, which reaches
+// internal/consistency via reconstruct → baseline, must link no capture
+// library). Putting this code in internal/consistency put pgx into both.
+// Only pgx-linking binaries import this package: cmd/bintrail-pg (via the
+// internal/cli seam, cli.SetPGLiveVerifyConnect) and consoleapp (the watch
+// daemon already links the PG capture stack).
+package pgverifysource
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbtrail/dbtrail/internal/consistency"
+	"github.com/dbtrail/dbtrail/internal/pgcapture"
+	"github.com/dbtrail/dbtrail/internal/verify"
+)
+
+// Connect opens the live-source PostgreSQL connection with the capture
+// plane's pinned render GUCs (TimeZone=UTC, DateStyle=ISO,
+// extra_float_digits=3, bytea_output=hex, IntervalStyle=postgres). The pin is
+// load-bearing, not a convenience: the reconstructed side's text (pgbaseline
+// COPY + pgoutput deltas) was rendered under exactly these GUCs, so a source
+// scanned without them (server-local TimeZone, default float digits) would
+// digest-differ on identical data — every timestamptz row a conclusive false
+// MISMATCH. Kept as the single entry point so no caller can forget the pin.
+func Connect(ctx context.Context, dsn string) (*pgx.Conn, error) {
+	return pgcapture.ConnectQueryPinned(ctx, dsn)
+}
+
+// LiveSource connects to dsn (pinned, via Connect) and returns the
+// verify.PGSourceChecksum a verify.PGLiveConfig needs, plus the close func
+// the caller must defer. This is the one-call wiring both consumers use
+// (cmd/bintrail-pg's cli.SetPGLiveVerifyConnect hook and consoleapp's
+// runLiveSourcePG), so the connect-pin-checksum composition cannot drift
+// between them. The returned checksum func uses the connection serially —
+// pgx.Conn is not concurrency-safe — which matches VerifyTablePG's
+// one-table-at-a-time loop.
+func LiveSource(ctx context.Context, dsn string) (verify.PGSourceChecksum, func() error, error) {
+	conn, err := Connect(ctx, dsn)
+	if err != nil {
+		return nil, nil, err
+	}
+	checksum := func(ctx context.Context, schema, table string, normalize func(raw []byte) []byte) (consistency.TableChecksum, error) {
+		return ConsistentTableChecksumPG(ctx, conn, schema, table, normalize)
+	}
+	return checksum, func() error { return conn.Close(context.Background()) }, nil
+}
+
+// ConsistentTableChecksumPG is the PostgreSQL sibling of
+// consistency.ConsistentTableChecksumNormalized (#1024): a point-in-time,
+// order-independent fingerprint of a live PG source table, byte-comparable to
+// the digest internal/verify's reconstruct computes from a pgbaseline
+// snapshot plus pgoutput deltas (it folds rows through the same
+// consistency.Hasher, so the digests share the version-tagged contract).
+//
+// Why this needs almost no per-type canonicalization, where the MySQL scan
+// needed plenty: for a PostgreSQL source BOTH sides of the comparison already
+// speak the same rendering — PostgreSQL's own type output functions, run under
+// the render GUCs internal/pgcapture pins (see Connect). The baseline is
+// COPY ... (FORMAT text) under those GUCs (internal/pgbaseline), the deltas
+// are pgoutput text under those GUCs, and this scan reads the SAME output
+// functions under the SAME GUCs by forcing the wire format to text. The one
+// trap this deliberately avoids: a `col::text` CAST is NOT the output function
+// — boolean::text renders 'true' while bool_out (what COPY, pgoutput, and a
+// text-format result all use) renders 't' — so the SELECT names bare columns
+// and the text rendering comes from pgx.QueryResultFormats{TextFormatCode},
+// never from casts.
+//
+// conn MUST be connected with the pinned render GUCs (Connect) — an unpinned
+// session renders timestamptz in the server's zone and floats at default
+// precision, silently breaking byte-comparability. The connection is used
+// serially: a transaction is opened and committed within this call.
+//
+// The whole computation runs inside one REPEATABLE READ, READ ONLY transaction
+// — PG's MVCC snapshot is the consistency anchor, the sibling of MySQL's
+// START TRANSACTION WITH CONSISTENT SNAPSHOT. The WAL anchor
+// (pg_current_wal_lsn) is captured by the transaction's FIRST statement, which
+// is also what materializes the snapshot, so the anchor and the data describe
+// the same instant modulo the lock-free window documented on
+// consistency.TableChecksum.GTIDSet (pg_current_wal_lsn is global, not
+// MVCC-filtered — exactly like @@gtid_executed). It errors on a standby
+// (pg_current_wal_lsn requires a primary), same as pgbaseline's own anchor
+// read.
+//
+// Column set: the live, non-dropped, NON-GENERATED columns in attnum order —
+// the same contract as internal/pgbaseline's loadColumns, duplicated here
+// rather than imported to keep this provider free of pgbaseline's Parquet
+// stack. Generated columns must stay out for the same reason they are out of
+// the baseline: pgoutput never streams them on PG 14–17, so the reconstructed
+// side cannot carry them and including them here would digest-differ on every
+// row.
+//
+// normalize, when non-nil, rewrites a scanned value's raw text bytes before
+// hashing — the same symmetric-normalization hook
+// consistency.ConsistentTableChecksumNormalized takes, minus the DATA_TYPE
+// parameter: metadata.WritePGSnapshot stores an EMPTY data_type for every PG
+// column, so the reconstruct side renders under dataType "" and the live side
+// must apply the identical policy; a type-keyed hook here would invite an
+// asymmetric normalization that can never trigger on the other side. It is
+// never called for SQL NULL (nil raw bytes). VerifyTablePG passes its own
+// render normalizer through verify.PGSourceChecksum, so the two sides are
+// symmetric by construction.
+func ConsistentTableChecksumPG(ctx context.Context, conn *pgx.Conn, schema, table string, normalize func(raw []byte) []byte) (consistency.TableChecksum, error) {
+	res := consistency.TableChecksum{Schema: schema, Table: table}
+	if conn == nil {
+		return res, fmt.Errorf("pgverifysource: no PostgreSQL source connection")
+	}
+
+	if _, err := conn.Exec(ctx, "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY"); err != nil {
+		return res, fmt.Errorf("begin repeatable read snapshot: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			// Read-only transaction; rollback is best-effort cleanup.
+			_, _ = conn.Exec(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	// First statement in the transaction: materializes the MVCC snapshot AND
+	// captures the WAL anchor at that same instant.
+	var lsnText string
+	if err := conn.QueryRow(ctx, "SELECT pg_current_wal_lsn()::text").Scan(&lsnText); err != nil {
+		return res, fmt.Errorf("read WAL anchor (pg_current_wal_lsn requires a primary): %w", err)
+	}
+	lsn, err := pglogrepl.ParseLSN(lsnText)
+	if err != nil {
+		return res, fmt.Errorf("parse WAL anchor %q: %w", lsnText, err)
+	}
+	res.LSN = uint64(lsn)
+
+	cols, err := pgTableColumns(ctx, conn, schema, table)
+	if err != nil {
+		return res, err
+	}
+	if len(cols) == 0 {
+		return res, fmt.Errorf("table %s.%s has no columns (does it exist?)", schema, table)
+	}
+	res.Columns = cols
+
+	selectList := make([]string, len(cols))
+	for i, c := range cols {
+		selectList[i] = pgx.Identifier{c}.Sanitize()
+	}
+	query := fmt.Sprintf("SELECT %s FROM %s",
+		strings.Join(selectList, ","), pgx.Identifier{schema, table}.Sanitize())
+
+	// A single format code applies to every result column (PostgreSQL Bind
+	// semantics) — the server renders each value through its type OUTPUT
+	// function, the exact bytes COPY text and pgoutput produce for the same
+	// stored value.
+	rows, err := conn.Query(ctx, query, pgx.QueryResultFormats{pgx.TextFormatCode})
+	if err != nil {
+		return res, fmt.Errorf("scan %s.%s: %w", schema, table, err)
+	}
+	defer rows.Close()
+
+	hasher := consistency.NewHasher()
+	values := make([][]byte, len(cols))
+	for rows.Next() {
+		raw := rows.RawValues()
+		if len(raw) != len(cols) {
+			return res, fmt.Errorf("scan %s.%s: row has %d values, want %d", schema, table, len(raw), len(cols))
+		}
+		for i, v := range raw {
+			// nil is SQL NULL; a non-nil empty slice is an empty value. Both
+			// raw and a pass-through normalize alias pgx's row buffer, which
+			// is reused on the NEXT rows.Next — safe only because AddBytes
+			// below hashes synchronously and copies every byte. Do not defer
+			// or buffer this (same aliasing contract as the MySQL scan).
+			switch {
+			case v == nil:
+				values[i] = nil
+			case normalize != nil:
+				values[i] = normalize(v)
+			default:
+				values[i] = v
+			}
+		}
+		hasher.AddBytes(values)
+	}
+	if err := rows.Err(); err != nil {
+		return res, fmt.Errorf("iterate rows of %s.%s: %w", schema, table, err)
+	}
+	rows.Close()
+
+	if _, err := conn.Exec(ctx, "COMMIT"); err != nil {
+		return res, fmt.Errorf("commit snapshot: %w", err)
+	}
+	committed = true
+
+	res.RowCount = hasher.Count()
+	res.Digest = hasher.Digest()
+	return res, nil
+}
+
+// pgTableColumns returns the live, non-dropped, non-generated columns of
+// schema.table in attnum order — the same catalog contract as
+// internal/pgbaseline's loadColumns (see ConsistentTableChecksumPG's doc for
+// why it is duplicated rather than imported, and why generated columns are
+// excluded).
+func pgTableColumns(ctx context.Context, conn *pgx.Conn, schema, table string) ([]string, error) {
+	rows, err := conn.Query(ctx, `
+		SELECT a.attname
+		FROM pg_attribute a
+		JOIN pg_class c ON c.oid = a.attrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = $1 AND c.relname = $2
+		  AND a.attnum > 0 AND NOT a.attisdropped AND a.attgenerated = ''
+		ORDER BY a.attnum`, schema, table)
+	if err != nil {
+		return nil, fmt.Errorf("introspect columns of %s.%s: %w", schema, table, err)
+	}
+	defer rows.Close()
+
+	var cols []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan column metadata of %s.%s: %w", schema, table, err)
+		}
+		cols = append(cols, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate column metadata of %s.%s: %w", schema, table, err)
+	}
+	return cols, nil
+}

--- a/internal/pgverifysource/pgverifysource_integration_test.go
+++ b/internal/pgverifysource/pgverifysource_integration_test.go
@@ -69,15 +69,15 @@ func TestConsistentTableChecksumPG_Integration(t *testing.T) {
 
 	// The scan connection MUST be the pinned one — that is the contract under
 	// test (TimeZone=UTC, DateStyle=ISO, bytea_output=hex, ...).
-	conn, err := Connect(ctx, baseDSN)
+	conn, err := connectPinned(ctx, baseDSN)
 	if err != nil {
 		t.Fatalf("pinned connect: %v", err)
 	}
 	t.Cleanup(func() { conn.Close(context.Background()) })
 
-	got, err := ConsistentTableChecksumPG(ctx, conn, "public", pgckTbl, nil)
+	got, err := consistentTableChecksumPG(ctx, conn, "public", pgckTbl, nil)
 	if err != nil {
-		t.Fatalf("ConsistentTableChecksumPG: %v", err)
+		t.Fatalf("consistentTableChecksumPG: %v", err)
 	}
 	if got.RowCount != 2 {
 		t.Errorf("RowCount = %d, want 2", got.RowCount)
@@ -115,9 +115,9 @@ func TestConsistentTableChecksumPG_Integration(t *testing.T) {
 	mustExec(fmt.Sprintf("CREATE TABLE %s %s", pgckTblRev, ddl))
 	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (2, false, NULL, NULL, NULL, '')", pgckTblRev))
 	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (1, true, '\\xdeadbeef', '2024-01-02 03:04:05+00', 12.30, 'café 日本語')", pgckTblRev))
-	rev, err := ConsistentTableChecksumPG(ctx, conn, "public", pgckTblRev, nil)
+	rev, err := consistentTableChecksumPG(ctx, conn, "public", pgckTblRev, nil)
 	if err != nil {
-		t.Fatalf("ConsistentTableChecksumPG (reversed): %v", err)
+		t.Fatalf("consistentTableChecksumPG (reversed): %v", err)
 	}
 	if rev.Digest != got.Digest {
 		t.Errorf("row order changed the digest: %s vs %s", rev.Digest, got.Digest)
@@ -125,11 +125,11 @@ func TestConsistentTableChecksumPG_Integration(t *testing.T) {
 
 	// The normalize hook must rewrite values before hashing (and only non-NULL
 	// ones — it would have panicked on nil above if misapplied).
-	bang, err := ConsistentTableChecksumPG(ctx, conn, "public", pgckTbl, func(raw []byte) []byte {
+	bang, err := consistentTableChecksumPG(ctx, conn, "public", pgckTbl, func(raw []byte) []byte {
 		return append(append([]byte{}, raw...), '!')
 	})
 	if err != nil {
-		t.Fatalf("ConsistentTableChecksumPG (hook): %v", err)
+		t.Fatalf("consistentTableChecksumPG (hook): %v", err)
 	}
 	if bang.Digest == got.Digest {
 		t.Error("normalize hook did not affect the digest")
@@ -139,9 +139,9 @@ func TestConsistentTableChecksumPG_Integration(t *testing.T) {
 	// loadColumns, so the live column set always matches the baseline's.
 	mustExec(fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY, n int, twice int GENERATED ALWAYS AS (n * 2) STORED)", pgckTblGen))
 	mustExec(fmt.Sprintf("INSERT INTO %s (id, n) VALUES (1, 21)", pgckTblGen))
-	gen, err := ConsistentTableChecksumPG(ctx, conn, "public", pgckTblGen, nil)
+	gen, err := consistentTableChecksumPG(ctx, conn, "public", pgckTblGen, nil)
 	if err != nil {
-		t.Fatalf("ConsistentTableChecksumPG (generated): %v", err)
+		t.Fatalf("consistentTableChecksumPG (generated): %v", err)
 	}
 	if len(gen.Columns) != 2 || gen.Columns[0] != "id" || gen.Columns[1] != "n" {
 		t.Errorf("Columns = %v, want [id n] (generated column excluded)", gen.Columns)
@@ -153,7 +153,7 @@ func TestConsistentTableChecksumPG_Integration(t *testing.T) {
 	}
 
 	// A missing table errors loudly, never a zero-row "match".
-	if _, err := ConsistentTableChecksumPG(ctx, conn, "public", "pgvs_ck_it_nope", nil); err == nil {
+	if _, err := consistentTableChecksumPG(ctx, conn, "public", "pgvs_ck_it_nope", nil); err == nil {
 		t.Error("want an error for a nonexistent table")
 	}
 }
@@ -163,11 +163,14 @@ func TestConsistentTableChecksumPG_Integration(t *testing.T) {
 // relation's schema snapshot and a PG stream checkpoint, and
 // verify.VerifyTablePG — wired through LiveSource, exactly as
 // cmd/bintrail-pg and the console daemon wire it — comparing the live source
-// against the reconstruction. The MATCH leg proves the live checksum and the
-// reconstruct digest agree byte-for-byte on identical data across the tricky
-// renderings (bool, numeric scale, multibyte, NULL vs empty); the two
-// MISMATCH legs prove a real divergence — an uncaptured in-place UPDATE,
-// then an uncaptured DELETE — is conclusively detected, not masked.
+// against the reconstruction. Four legs: MATCH proves the live checksum and
+// the reconstruct digest agree byte-for-byte on identical data across the
+// tricky renderings (bool, numeric scale, multibyte, NULL vs empty); an
+// UNCAPTURED in-place UPDATE is a conclusive content MISMATCH; indexing that
+// same UPDATE as a pgoutput-shaped delta event folds it onto the baseline and
+// restores MATCH (the delta half of the engine — the PK text-identity join
+// and the pgTextPK merge — running against real data); an uncaptured DELETE
+// is a conclusive row-count MISMATCH.
 //
 // Requires BOTH backends: a MySQL index (testutil.CreateTestDB) and a live
 // PostgreSQL (BINTRAIL_TEST_PG_DSN).
@@ -290,6 +293,27 @@ func TestVerifyTablePG_Integration(t *testing.T) {
 	}
 	if res.Status != verify.StatusMismatch || !strings.Contains(res.Detail, "content digest differs") {
 		t.Fatalf("status=%q detail=%q, want a content mismatch", res.Status, res.Detail)
+	}
+
+	// DELTA MATCH: index the same UPDATE as the capture daemon would store it
+	// — pgoutput text values in the row images, the raw text PK in pk_values —
+	// and the reconstruction must fold it onto the baseline and agree with the
+	// live table again. This is the delta half of the engine (time-bounded
+	// FetchMerged window, PK text-identity join, pgTextPK merge) against real
+	// data; without it a PK-spelling regression between the event and baseline
+	// sides (the #1155/#1158 bug class) would ship green and turn every
+	// captured write into a false MISMATCH.
+	testutil.InsertEvent(t, indexDB, "0/1000000", 100, 200,
+		time.Now().UTC().Format("2006-01-02 15:04:05"), nil,
+		"public", vpgTbl, 2 /*UPDATE*/, "1", nil,
+		[]byte(`{"id":"1","v":"café 日本語","ok":"t","num":"12.30"}`),
+		[]byte(`{"id":"1","v":"tampered","ok":"t","num":"12.30"}`))
+	res, err = verify.VerifyTablePG(ctx, cfg, "public", vpgTbl)
+	if err != nil {
+		t.Fatalf("VerifyTablePG (delta indexed): %v", err)
+	}
+	if res.Status != verify.StatusMatch {
+		t.Fatalf("status = %q (detail=%q), want match once the UPDATE is indexed — the delta fold or the PK join is broken", res.Status, res.Detail)
 	}
 
 	// MISMATCH (row count): an uncaptured DELETE is always conclusive.

--- a/internal/pgverifysource/pgverifysource_integration_test.go
+++ b/internal/pgverifysource/pgverifysource_integration_test.go
@@ -1,0 +1,313 @@
+//go:build integration
+
+package pgverifysource
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbtrail/dbtrail/internal/consistency"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/pgbaseline"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+	"github.com/dbtrail/dbtrail/internal/verify"
+)
+
+// Names are branch-unique: the PG server is shared with other test runs;
+// everything is dropped in t.Cleanup.
+const (
+	pgckTbl    = "pgvs_ck_it_1024"
+	pgckTblRev = "pgvs_ck_it_1024_rev"
+	pgckTblGen = "pgvs_ck_it_1024_gen"
+	vpgTbl     = "pgvs_verify_it_1024"
+	vpgPub     = "pgvs_verify_it_pub_1024"
+	vpgSlot    = "bintrail_pgvs_verify_it_1024"
+)
+
+// TestConsistentTableChecksumPG_Integration proves the PG live-scan render
+// contract against a real PostgreSQL: the digest equals a hand-built digest
+// over the EXPECTED pinned-GUC text renderings (bool 't' — the output-function
+// form a ::text cast would NOT produce — bytea \x hex, timestamptz in UTC ISO,
+// numeric with its declared scale, NULL distinct from empty string), it is
+// row-order independent, generated columns are excluded, and the normalize
+// hook rewrites values before hashing.
+func TestConsistentTableChecksumPG_Integration(t *testing.T) {
+	baseDSN := testutil.SkipIfNoPostgres(t)
+	ctx := context.Background()
+
+	setup, err := pgx.Connect(ctx, baseDSN)
+	if err != nil {
+		t.Fatalf("connect setup conn: %v", err)
+	}
+	t.Cleanup(func() { setup.Close(context.Background()) })
+
+	dropAll := func() {
+		bg := context.Background()
+		for _, tbl := range []string{pgckTbl, pgckTblRev, pgckTblGen} {
+			_, _ = setup.Exec(bg, fmt.Sprintf("DROP TABLE IF EXISTS %s", tbl))
+		}
+	}
+	dropAll()
+	t.Cleanup(dropAll)
+
+	mustExec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := setup.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+
+	ddl := `(id int PRIMARY KEY, ok bool, b bytea, ts timestamptz, num numeric(10,2), v text)`
+	mustExec(fmt.Sprintf("CREATE TABLE %s %s", pgckTbl, ddl))
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (1, true, '\\xdeadbeef', '2024-01-02 03:04:05+00', 12.30, 'café 日本語')", pgckTbl))
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (2, false, NULL, NULL, NULL, '')", pgckTbl))
+
+	// The scan connection MUST be the pinned one — that is the contract under
+	// test (TimeZone=UTC, DateStyle=ISO, bytea_output=hex, ...).
+	conn, err := Connect(ctx, baseDSN)
+	if err != nil {
+		t.Fatalf("pinned connect: %v", err)
+	}
+	t.Cleanup(func() { conn.Close(context.Background()) })
+
+	got, err := ConsistentTableChecksumPG(ctx, conn, "public", pgckTbl, nil)
+	if err != nil {
+		t.Fatalf("ConsistentTableChecksumPG: %v", err)
+	}
+	if got.RowCount != 2 {
+		t.Errorf("RowCount = %d, want 2", got.RowCount)
+	}
+	if got.LSN == 0 {
+		t.Error("LSN = 0, want a real WAL anchor")
+	}
+	wantCols := []string{"id", "ok", "b", "ts", "num", "v"}
+	if len(got.Columns) != len(wantCols) {
+		t.Fatalf("Columns = %v, want %v", got.Columns, wantCols)
+	}
+	for i, c := range wantCols {
+		if got.Columns[i] != c {
+			t.Fatalf("Columns = %v, want %v (attnum order)", got.Columns, wantCols)
+		}
+	}
+
+	// Hand-built expectation: the EXACT text the pinned output functions must
+	// produce. If any rendering drifts (e.g. an unpinned TimeZone leaking
+	// through, or a ::text cast turning 't' into 'true'), this digest differs.
+	want := consistency.NewHasher()
+	want.AddBytes([][]byte{
+		[]byte("1"), []byte("t"), []byte(`\xdeadbeef`),
+		[]byte("2024-01-02 03:04:05+00"), []byte("12.30"), []byte("café 日本語"),
+	})
+	want.AddBytes([][]byte{
+		[]byte("2"), []byte("f"), nil, nil, nil, []byte(""),
+	})
+	if got.Digest != want.Digest() {
+		t.Errorf("Digest = %s, want the hand-built pinned-GUC rendering digest %s", got.Digest, want.Digest())
+	}
+
+	// Order independence: same rows inserted in reverse order → same digest
+	// (the multiset fold, same property the MySQL checksum has).
+	mustExec(fmt.Sprintf("CREATE TABLE %s %s", pgckTblRev, ddl))
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (2, false, NULL, NULL, NULL, '')", pgckTblRev))
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (1, true, '\\xdeadbeef', '2024-01-02 03:04:05+00', 12.30, 'café 日本語')", pgckTblRev))
+	rev, err := ConsistentTableChecksumPG(ctx, conn, "public", pgckTblRev, nil)
+	if err != nil {
+		t.Fatalf("ConsistentTableChecksumPG (reversed): %v", err)
+	}
+	if rev.Digest != got.Digest {
+		t.Errorf("row order changed the digest: %s vs %s", rev.Digest, got.Digest)
+	}
+
+	// The normalize hook must rewrite values before hashing (and only non-NULL
+	// ones — it would have panicked on nil above if misapplied).
+	bang, err := ConsistentTableChecksumPG(ctx, conn, "public", pgckTbl, func(raw []byte) []byte {
+		return append(append([]byte{}, raw...), '!')
+	})
+	if err != nil {
+		t.Fatalf("ConsistentTableChecksumPG (hook): %v", err)
+	}
+	if bang.Digest == got.Digest {
+		t.Error("normalize hook did not affect the digest")
+	}
+
+	// STORED generated columns are excluded — same contract as pgbaseline's
+	// loadColumns, so the live column set always matches the baseline's.
+	mustExec(fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY, n int, twice int GENERATED ALWAYS AS (n * 2) STORED)", pgckTblGen))
+	mustExec(fmt.Sprintf("INSERT INTO %s (id, n) VALUES (1, 21)", pgckTblGen))
+	gen, err := ConsistentTableChecksumPG(ctx, conn, "public", pgckTblGen, nil)
+	if err != nil {
+		t.Fatalf("ConsistentTableChecksumPG (generated): %v", err)
+	}
+	if len(gen.Columns) != 2 || gen.Columns[0] != "id" || gen.Columns[1] != "n" {
+		t.Errorf("Columns = %v, want [id n] (generated column excluded)", gen.Columns)
+	}
+	wantGen := consistency.NewHasher()
+	wantGen.AddBytes([][]byte{[]byte("1"), []byte("21")})
+	if gen.Digest != wantGen.Digest() {
+		t.Errorf("generated-column digest = %s, want %s (hashed over id,n only)", gen.Digest, wantGen.Digest())
+	}
+
+	// A missing table errors loudly, never a zero-row "match".
+	if _, err := ConsistentTableChecksumPG(ctx, conn, "public", "pgvs_ck_it_nope", nil); err == nil {
+		t.Error("want an error for a nonexistent table")
+	}
+}
+
+// TestVerifyTablePG_Integration is the end-to-end parity proof for #1024:
+// a pgbaseline snapshot of a live PG table, an index seeded with the
+// relation's schema snapshot and a PG stream checkpoint, and
+// verify.VerifyTablePG — wired through LiveSource, exactly as
+// cmd/bintrail-pg and the console daemon wire it — comparing the live source
+// against the reconstruction. The MATCH leg proves the live checksum and the
+// reconstruct digest agree byte-for-byte on identical data across the tricky
+// renderings (bool, numeric scale, multibyte, NULL vs empty); the two
+// MISMATCH legs prove a real divergence — an uncaptured in-place UPDATE,
+// then an uncaptured DELETE — is conclusively detected, not masked.
+//
+// Requires BOTH backends: a MySQL index (testutil.CreateTestDB) and a live
+// PostgreSQL (BINTRAIL_TEST_PG_DSN).
+func TestVerifyTablePG_Integration(t *testing.T) {
+	baseDSN := testutil.SkipIfNoPostgres(t)
+	indexDB, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+	// The delta window (baseline snapshot → now) must be partition-covered or
+	// the planner's gap check reports the current hour as rotated-and-lost —
+	// same setup rule as every MySQL live-source verify test.
+	curHour := time.Now().UTC().Truncate(time.Hour)
+	testutil.SetupPartitionedTable(t, indexDB, dbName, []time.Time{curHour.Add(-time.Hour), curHour})
+	ctx := context.Background()
+
+	setup, err := pgx.Connect(ctx, baseDSN)
+	if err != nil {
+		t.Fatalf("connect setup conn: %v", err)
+	}
+	t.Cleanup(func() { setup.Close(context.Background()) })
+
+	dropAll := func() {
+		bg := context.Background()
+		_, _ = setup.Exec(bg, fmt.Sprintf("DROP PUBLICATION IF EXISTS %s", vpgPub))
+		_, _ = setup.Exec(bg, fmt.Sprintf("DROP TABLE IF EXISTS %s", vpgTbl))
+		_, _ = setup.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", vpgSlot)
+	}
+	dropAll()
+	t.Cleanup(dropAll)
+
+	mustExec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := setup.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+
+	mustExec(fmt.Sprintf(`CREATE TABLE %s (id int PRIMARY KEY, v text, ok bool, num numeric(10,2))`, vpgTbl))
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (1, 'café 日本語', true, 12.30)", vpgTbl))
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (2, '', false, NULL)", vpgTbl))
+	mustExec(fmt.Sprintf("INSERT INTO %s VALUES (3, NULL, NULL, 0.01)", vpgTbl))
+	mustExec(fmt.Sprintf("CREATE PUBLICATION %s FOR TABLE %s", vpgPub, vpgTbl))
+
+	outDir := t.TempDir()
+	if _, err := pgbaseline.Run(ctx, pgbaseline.Config{
+		QueryDSN:    baseDSN,
+		ReplDSN:     pgReplDSN(baseDSN),
+		SlotName:    vpgSlot,
+		Publication: vpgPub,
+		OutputDir:   outDir,
+	}); err != nil {
+		t.Fatalf("pgbaseline.Run: %v", err)
+	}
+
+	// Index side: the relation's schema snapshot (what the capture daemon
+	// writes on the first RelationMessage) ...
+	if _, err := metadata.WritePGSnapshot(ctx, indexDB, &metadata.PGRelationSchema{
+		Schema: "public", Table: vpgTbl,
+		Columns: []metadata.PGRelationColumn{
+			{Name: "id", Ordinal: 1, IsPK: true},
+			{Name: "v", Ordinal: 2},
+			{Name: "ok", Ordinal: 3},
+			{Name: "num", Ordinal: 4},
+		},
+	}); err != nil {
+		t.Fatalf("WritePGSnapshot: %v", err)
+	}
+	// ... and a PG stream checkpoint far past any real WAL position, so the
+	// coverage verdict takes its PROVEN branch (checkpoint >= anchor) and the
+	// run carries no coverage-unverified note.
+	if _, err := indexDB.ExecContext(ctx, `
+		INSERT INTO stream_state (id, mode, binlog_file, binlog_position, gtid_set, flavor, last_checkpoint, server_id)
+		VALUES (1, 'gtid', 'FFFFFFFF/FFFFFFFF', ?, 'FFFFFFFF/FFFFFFFF', 'postgres', UTC_TIMESTAMP(), 1)`,
+		uint64(1)<<62); err != nil {
+		t.Fatalf("seed stream_state: %v", err)
+	}
+
+	resolver, err := verify.ResolverFor(indexDB)
+	if err != nil {
+		t.Fatalf("ResolverFor: %v", err)
+	}
+	sourceChecksum, closeSource, err := LiveSource(ctx, baseDSN)
+	if err != nil {
+		t.Fatalf("LiveSource: %v", err)
+	}
+	t.Cleanup(func() { _ = closeSource() })
+
+	cfg := verify.PGLiveConfig{
+		SourceChecksum: sourceChecksum,
+		IndexDB:        indexDB,
+		Resolver:       resolver,
+		BaselineSource: outDir,
+		IndexDBName:    dbName,
+		NoArchive:      true,
+	}
+
+	// MATCH: live table == baseline, no deltas.
+	res, err := verify.VerifyTablePG(ctx, cfg, "public", vpgTbl)
+	if err != nil {
+		t.Fatalf("VerifyTablePG: %v", err)
+	}
+	if res.Status != verify.StatusMatch {
+		t.Fatalf("status = %q (detail=%q), want match", res.Status, res.Detail)
+	}
+	if res.SourceRows != 3 || res.ReconstructRows != 3 {
+		t.Errorf("rows src/recon = %d/%d, want 3/3", res.SourceRows, res.ReconstructRows)
+	}
+	if !strings.HasPrefix(res.Anchor, "LSN:") {
+		t.Errorf("Anchor = %q, want an LSN: label", res.Anchor)
+	}
+	if res.Detail != "" {
+		t.Errorf("Detail = %q, want empty on a proven-coverage match", res.Detail)
+	}
+
+	// MISMATCH (content): an in-place UPDATE the index never captured must
+	// surface as a conclusive content divergence at equal row count.
+	mustExec(fmt.Sprintf("UPDATE %s SET v = 'tampered' WHERE id = 1", vpgTbl))
+	res, err = verify.VerifyTablePG(ctx, cfg, "public", vpgTbl)
+	if err != nil {
+		t.Fatalf("VerifyTablePG (tampered): %v", err)
+	}
+	if res.Status != verify.StatusMismatch || !strings.Contains(res.Detail, "content digest differs") {
+		t.Fatalf("status=%q detail=%q, want a content mismatch", res.Status, res.Detail)
+	}
+
+	// MISMATCH (row count): an uncaptured DELETE is always conclusive.
+	mustExec(fmt.Sprintf("DELETE FROM %s WHERE id = 2", vpgTbl))
+	res, err = verify.VerifyTablePG(ctx, cfg, "public", vpgTbl)
+	if err != nil {
+		t.Fatalf("VerifyTablePG (deleted): %v", err)
+	}
+	if res.Status != verify.StatusMismatch || !strings.Contains(res.Detail, "row count differs") {
+		t.Fatalf("status=%q detail=%q, want a row-count mismatch", res.Status, res.Detail)
+	}
+}
+
+// pgReplDSN appends replication=database — same helper shape as the
+// pgbaseline integration test's replDSN (unexported there).
+func pgReplDSN(base string) string {
+	if strings.Contains(base, "?") {
+		return base + "&replication=database"
+	}
+	return base + "?replication=database"
+}

--- a/internal/verify/verify_pg.go
+++ b/internal/verify/verify_pg.go
@@ -1,0 +1,331 @@
+package verify
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/consistency"
+	"github.com/dbtrail/dbtrail/internal/duckdbutil"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+)
+
+// PGSourceChecksum fingerprints one live PostgreSQL table at a consistent
+// snapshot, applying normalize to every non-NULL scanned value — the seam
+// through which VerifyTablePG reaches the live source WITHOUT this package
+// linking the PostgreSQL driver stack. This package (and internal/cli, which
+// links it into the core binary) must stay pgx-free: cliapp's
+// TestCoreBinaryIsPostgresFree and internal/event's dep guard ban the PG
+// capture stack from the core binary and the read layer. The one
+// implementation is internal/pgverifysource (LiveSource), linked only by
+// pgx-carrying binaries: cmd/bintrail-pg via cli.SetPGLiveVerifyConnect, and
+// the console daemon directly.
+//
+// VerifyTablePG passes its own render normalizer as normalize, so an
+// implementation never chooses normalization policy — symmetry with the
+// reconstruct side stays by construction.
+type PGSourceChecksum func(ctx context.Context, schema, table string, normalize func(raw []byte) []byte) (consistency.TableChecksum, error)
+
+// PGLiveConfig wires the data sources live-source verify needs for a
+// PostgreSQL source (#1024) — the PG sibling of Config. SourceChecksum
+// replaces Config.SourceDB: the live fingerprint must run under the capture
+// plane's pinned render GUCs on a PG driver connection, both of which live
+// behind the PGSourceChecksum seam (internal/pgverifysource).
+type PGLiveConfig struct {
+	// SourceChecksum is the live-source fingerprint provider — wire it with
+	// internal/pgverifysource.LiveSource. VerifyTablePG calls it serially,
+	// one table at a time.
+	SourceChecksum PGSourceChecksum
+	IndexDB        *sql.DB
+	Resolver       *metadata.Resolver
+	BaselineSource string // local dir or s3:// prefix, passed to FindBaseline
+	IndexDBName    string
+	NoArchive      bool
+	ArchiveFetcher query.ArchiveFetcher
+	// DuckDBTuning is the resource budget for the baseline-merge DuckDB
+	// session the reconstruct step opens — see Config.DuckDBTuning.
+	DuckDBTuning duckdbutil.Tuning
+}
+
+// PGTargetTables returns the tables a PostgreSQL live-source (or
+// recover-inputs) run should cover: the explicit "schema.table" list when one
+// was given, else every table the resolver knows. It exists because the
+// MySQL-path fallback — SELECT ... WHERE snapshot_id = MAX(snapshot_id) —
+// silently returns ONE table on a PG index: WritePGSnapshot stores one
+// relation per snapshot_id, so the newest snapshot_id names the most recently
+// (re-)published relation, not the schema. The per-table resolver
+// (metadata.NewLatestPerTableResolver, chosen by ResolverFor) already folds
+// every relation's newest snapshot into one view; enumerate that.
+func PGTargetTables(resolver *metadata.Resolver, explicit []string) ([]query.SchemaTable, error) {
+	var out []query.SchemaTable
+	if len(explicit) > 0 {
+		for _, entry := range explicit {
+			schema, table, ok := strings.Cut(entry, ".")
+			if !ok || schema == "" || table == "" {
+				return nil, fmt.Errorf("invalid table filter %q (want schema.table)", entry)
+			}
+			out = append(out, query.SchemaTable{Schema: schema, Table: table})
+		}
+	} else {
+		for _, tm := range resolver.AllTables() {
+			out = append(out, query.SchemaTable{Schema: tm.Schema, Table: tm.Table})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Schema != out[j].Schema {
+			return out[i].Schema < out[j].Schema
+		}
+		return out[i].Table < out[j].Table
+	})
+	return out, nil
+}
+
+// pgNormalizeRenderedBytes is the live-scan normalization hook for a
+// PostgreSQL source — normalizeRenderedBytes under an EMPTY data type,
+// because that is exactly what the reconstruct side does:
+// metadata.WritePGSnapshot stores data_type="" for every PG column, so
+// renderCellNormalized on the recon side resolves to
+// normalizeRenderedBytes(b, ""). Both sides therefore apply the identical
+// policy (in practice: only the type-independent JSON-container
+// canonicalization; the MySQL zero-date/TIME/FLOAT rewrites are keyed on
+// MySQL DATA_TYPE tokens a PG snapshot never carries). Symmetry by
+// construction — see ConsistentTableChecksumNormalized's doc for why an
+// asymmetric normalization trades one false mismatch for another.
+func pgNormalizeRenderedBytes(raw []byte) []byte {
+	return normalizeRenderedBytes(raw, "")
+}
+
+// VerifyTablePG verifies one table of a PostgreSQL source in live-source mode
+// (#1024): fingerprint the live source at a REPEATABLE READ snapshot
+// (consistency.ConsistentTableChecksumPG), reconstruct the table to that same
+// point from baseline + indexed deltas, render both sides to PostgreSQL's own
+// text form, and compare — the PG sibling of VerifyTable. Differences from
+// the MySQL path, each anchored to an existing PG-path decision:
+//
+//   - No PK-type gate: PG stores every PK column as raw text on BOTH the
+//     baseline (COPY text) and delta (pgoutput text) sides, so the match is
+//     string-identity — same bypass as VerifyBaselinePair's pg branch.
+//   - The delta window is time-bounded ONLY (no SincePos/UntilPos): PG events
+//     carry a non-monotonic "X/Y" LSN in binlog_file that the
+//     length-lexicographic position filter cannot bound correctly — the same
+//     "PG never sets a position bound" invariant baselineFetchOptions keeps
+//     (#1022 is the deferred numeric-LSN refinement).
+//   - Coverage is checked against the stream's LSN checkpoint
+//     (indexCoversPG), which can PROVE coverage but not always disprove it —
+//     see pgCoverageVerdict for the honest degradation.
+//
+// The T0→T1 alignment caveat of VerifyTable applies identically: writes
+// committed between the snapshot opening and the reconstruct's Until surface
+// as a (safe, conclusive) mismatch — run against a quiescent source,
+// off-peak.
+func VerifyTablePG(ctx context.Context, cfg PGLiveConfig, schema, table string) (TableResult, error) {
+	res := TableResult{Schema: schema, Table: table}
+
+	tm, err := cfg.Resolver.Resolve(schema, table)
+	if err != nil {
+		return res, fmt.Errorf("resolve %s.%s: %w", schema, table, err)
+	}
+	pkCols := tm.PKColumnMetas()
+	if len(pkCols) == 0 {
+		return inconclusive(res, "table has no primary key"), nil
+	}
+
+	// 1. Live source fingerprint at a consistent snapshot, normalized with the
+	// same policy the reconstruct render applies (see pgNormalizeRenderedBytes).
+	if cfg.SourceChecksum == nil {
+		return res, fmt.Errorf("source checksum %s.%s: no PostgreSQL source checksum wired (see PGSourceChecksum — internal/pgverifysource.LiveSource provides it)", schema, table)
+	}
+	src, err := cfg.SourceChecksum(ctx, schema, table, pgNormalizeRenderedBytes)
+	if err != nil {
+		return res, fmt.Errorf("source checksum %s.%s: %w", schema, table, err)
+	}
+	res.SourceDigest = src.Digest
+	res.SourceRows = src.RowCount
+	res.Anchor = fmt.Sprintf("LSN:%d", src.LSN) // same label form as anchorLabel's pg branch
+	asOf := time.Now().UTC()
+
+	// 2. Coverage: has the index durably absorbed everything the snapshot
+	// reflects? Inconclusive when provably not (or when events were
+	// permanently lost); a note when it cannot be proven either way.
+	covered, coverageNote := indexCoversPG(ctx, cfg.IndexDB, src.LSN)
+	if !covered {
+		return inconclusive(res, coverageNote), nil
+	}
+
+	// 3. Find the baseline at-or-before asOf — identical to the MySQL path.
+	baselinePath, snapshotTime, _, err := reconstruct.FindBaseline(ctx, cfg.BaselineSource, schema, table, asOf)
+	if err != nil {
+		if isNoBaseline(err) {
+			return inconclusive(res, "no baseline at-or-before the snapshot; reconstruct would omit never-touched rows"), nil
+		}
+		return res, fmt.Errorf("find baseline %s.%s: %w", schema, table, err)
+	}
+
+	// 4. Latest event per PK in (baseline, asOf]. Time bounds only — no
+	// SincePos/UntilPos on a PG window (see the function doc).
+	engine := query.New(cfg.IndexDB)
+	rows, _, err := query.FetchMerged(ctx, cfg.IndexDB, engine, query.FetchMergedOptions{
+		Opts: query.Options{
+			Schema:     schema,
+			Table:      table,
+			Since:      &snapshotTime,
+			Until:      &asOf,
+			LimitPerPK: 1,
+		},
+		DBName:         cfg.IndexDBName,
+		NoArchive:      cfg.NoArchive,
+		ArchiveFetcher: cfg.ArchiveFetcher,
+	})
+	if err != nil {
+		var gap *query.GapError
+		if errors.As(err, &gap) {
+			return inconclusive(res, "coverage gap in the reconstruction window: "+gap.Error()), nil
+		}
+		return res, fmt.Errorf("fetch changes %s.%s: %w", schema, table, err)
+	}
+	// Same event-normalization passes as VerifyBaselinePair's pg branch runs —
+	// both are structurally no-ops while WritePGSnapshot stores empty
+	// data_type, and keeping the calls identical means the two PG verify
+	// modes cannot drift if that ever changes.
+	reconstruct.MapEventEnumLabels(cfg.IndexDB, cfg.Resolver, schema, table, rows)
+	binariesTyped := reconstruct.DecodeEventBinaries(cfg.IndexDB, schema, table, rows)
+	changes := make(map[string]*query.ResultRow, len(rows))
+	for i := range rows {
+		changes[rows[i].PKValues] = &rows[i]
+	}
+
+	// 5. Hash exactly the column set the live scan hashed, in its order —
+	// same rule as VerifyTable step 5. The PG live scan and pgbaseline share
+	// one column contract (live, non-dropped, non-generated, attnum order),
+	// so a name missing from the index snapshot means the capture daemon has
+	// not (re-)published this relation since the column appeared.
+	colByName := make(map[string]metadata.ColumnMeta, len(tm.Columns))
+	for _, c := range tm.Columns {
+		colByName[c.Name] = c
+	}
+	orderedCols := make([]metadata.ColumnMeta, 0, len(src.Columns))
+	for _, name := range src.Columns {
+		cm, ok := colByName[name]
+		if !ok {
+			return inconclusive(res, fmt.Sprintf("source column %q is absent from the index schema snapshot (the capture daemon snapshots a relation when it first streams it); stream an event for this table so the relation is re-published", name)), nil
+		}
+		orderedCols = append(orderedCols, cm)
+	}
+	// Deferred-representation gate — mirrored from VerifyBaselinePair for the
+	// same no-drift reason as the normalization passes above: with empty PG
+	// data types isDeferredType never fires, so this is constant-off today.
+	deferredCol, deferredRepr := deferredReprUnresolved(orderedCols, changes, binariesTyped)
+	var deferredDetail string
+	if deferredRepr {
+		deferredDetail = deferredReprDetail(deferredCol)
+	}
+
+	// 6. Reconstruct to asOf and hash in the source's text form. pgTextPK=true:
+	// the PK join is text-identity, the MySQL canonicalizer must not run.
+	reconDigest, reconCount, emitErr := reconstructDigest(ctx, baselinePath, schema, table, pkCols, changes, rows, orderedCols, true, renderCellNormalized, cfg.DuckDBTuning)
+	if emitErr != nil {
+		return res, fmt.Errorf("reconstruct %s.%s: %w", schema, table, emitErr)
+	}
+	res.ReconstructDigest = reconDigest
+	res.ReconstructRows = reconCount
+	if coverageNote != "" {
+		res.Detail = coverageNote
+	}
+
+	// 7. Compare — the same pure core as every other verify mode.
+	status, detail := classify(res.SourceDigest, res.SourceRows, res.ReconstructDigest, res.ReconstructRows, deferredDetail)
+	res.Status = status
+	if detail != "" {
+		res.Detail = detail // a real reason overrides the coverage note
+	}
+	return res, nil
+}
+
+// indexCoversPG reads the stream checkpoint and applies pgCoverageVerdict —
+// the PG sibling of indexCovers. Read errors degrade to not-covered with the
+// error as the reason (inconclusive, never a false mismatch), matching the
+// MySQL path's handling.
+func indexCoversPG(ctx context.Context, indexDB *sql.DB, anchorLSN uint64) (bool, string) {
+	var (
+		flavor    sql.NullString
+		pos       sql.NullInt64
+		gapLostAt sql.NullTime
+		gapDetail sql.NullString
+	)
+	err := indexDB.QueryRowContext(ctx,
+		"SELECT flavor, binlog_position, gap_lost_at, gap_lost_detail FROM stream_state WHERE id = 1").
+		Scan(&flavor, &pos, &gapLostAt, &gapDetail)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, "index has no stream state yet (daemon not running or never checkpointed)"
+	}
+	if err != nil {
+		return false, "could not read index coverage: " + err.Error()
+	}
+	var checkpoint uint64
+	if pos.Valid && pos.Int64 > 0 {
+		checkpoint = uint64(pos.Int64)
+	}
+	return pgCoverageVerdict(flavor.String, checkpoint, anchorLSN, gapLostAt.Valid, gapDetail.String)
+}
+
+// pgCoverageVerdict is the pure coverage decision for a PostgreSQL source —
+// separated from the stream_state read (indexCoversPG) so the verdict grid is
+// unit-testable, the same fetch/verdict split as internal/doctor's object-lock
+// check.
+//
+// PostgreSQL has no GTID-set containment: the only durable index cursor is
+// the stream's checkpoint — the last commit LSN it has durably indexed
+// (saveCheckpointPG) — while the snapshot anchor (pg_current_wal_lsn) also
+// advances with WAL the capture can never see as events: commits in OTHER
+// databases of the cluster, and non-transactional activity (autovacuum,
+// checkpoints). So the grid is deliberately asymmetric:
+//
+//   - checkpoint >= anchor PROVES coverage (everything the snapshot reflects
+//     committed at-or-before the anchor, and the index has durably absorbed
+//     commits past it) → covered, no note.
+//   - checkpoint < anchor proves NOTHING: the distance may be entirely
+//     unindexable WAL. Refusing here would make verify permanently
+//     inconclusive on any shared or merely non-idle cluster (cry-wolf), so it
+//     proceeds with a "coverage unverified" note — the same documented
+//     trade-off as the MySQL path on a GTID-off source, where a genuinely
+//     behind index surfaces as a (conclusive, investigable) mismatch rather
+//     than being silently masked.
+//
+// Hard stops stay hard: a stamped permanent loss (gap_lost_at) means events
+// in the window may be gone — inconclusive, never a false mismatch — and a
+// missing/foreign-flavor/zero checkpoint means no PG stream has ever
+// checkpointed here, so there is nothing to assume "caught up".
+func pgCoverageVerdict(flavor string, checkpointLSN, anchorLSN uint64, gapLost bool, gapDetail string) (bool, string) {
+	if flavor != flavorPostgres {
+		return false, fmt.Sprintf("index stream state has flavor %q, not a PostgreSQL capture; check that this index belongs to the PostgreSQL source being verified", flavor)
+	}
+	if gapLost {
+		detail := strings.TrimSpace(gapDetail)
+		if detail == "" {
+			detail = "no detail recorded"
+		}
+		return false, "the capture stream recorded a permanent event loss (" + detail + "); events in the comparison window may be missing, so a content difference would not be conclusive"
+	}
+	if checkpointLSN == 0 {
+		return false, "index has no LSN checkpoint yet (the PostgreSQL stream has not committed a checkpoint against this index)"
+	}
+	if checkpointLSN >= anchorLSN {
+		return true, ""
+	}
+	return true, fmt.Sprintf(
+		"coverage unverified (index checkpoint %s is behind the snapshot anchor %s, but WAL from other databases and non-transactional activity advances the anchor without producing indexable events, so containment cannot be proven): assuming the capture daemon is caught up",
+		formatLSN(checkpointLSN), formatLSN(anchorLSN))
+}
+
+// formatLSN renders a WAL position in PostgreSQL's canonical X/Y form —
+// byte-identical to pglogrepl.LSN.String(), reimplemented locally because
+// this package must not link the PG driver stack (see PGSourceChecksum).
+func formatLSN(lsn uint64) string {
+	return fmt.Sprintf("%X/%X", uint32(lsn>>32), uint32(lsn))
+}

--- a/internal/verify/verify_pg.go
+++ b/internal/verify/verify_pg.go
@@ -145,26 +145,38 @@ func VerifyTablePG(ctx context.Context, cfg PGLiveConfig, schema, table string) 
 	if err != nil {
 		return res, fmt.Errorf("source checksum %s.%s: %w", schema, table, err)
 	}
+	// A zero anchor would make the coverage verdict below vacuously "proven"
+	// (any nonzero checkpoint >= 0). The one shipped implementation errors
+	// before it can return LSN 0, so this guard enforces the seam's contract
+	// rather than papering over a live bug — turning a convention into an
+	// invariant instead of a silent pass.
+	if src.LSN == 0 {
+		return inconclusive(res, "source checksum carried no WAL anchor; cannot check index coverage"), nil
+	}
 	res.SourceDigest = src.Digest
 	res.SourceRows = src.RowCount
 	res.Anchor = fmt.Sprintf("LSN:%d", src.LSN) // same label form as anchorLabel's pg branch
 	asOf := time.Now().UTC()
 
-	// 2. Coverage: has the index durably absorbed everything the snapshot
-	// reflects? Inconclusive when provably not (or when events were
-	// permanently lost); a note when it cannot be proven either way.
-	covered, coverageNote := indexCoversPG(ctx, cfg.IndexDB, src.LSN)
-	if !covered {
-		return inconclusive(res, coverageNote), nil
-	}
-
-	// 3. Find the baseline at-or-before asOf — identical to the MySQL path.
+	// 2. Find the baseline at-or-before asOf — identical to the MySQL path.
+	// Found BEFORE the coverage check (the MySQL path's opposite order)
+	// because the PG gap_lost verdict is scoped to the comparison window,
+	// whose start is this baseline's snapshot time.
 	baselinePath, snapshotTime, _, err := reconstruct.FindBaseline(ctx, cfg.BaselineSource, schema, table, asOf)
 	if err != nil {
 		if isNoBaseline(err) {
 			return inconclusive(res, "no baseline at-or-before the snapshot; reconstruct would omit never-touched rows"), nil
 		}
 		return res, fmt.Errorf("find baseline %s.%s: %w", schema, table, err)
+	}
+
+	// 3. Coverage: has the index durably absorbed everything the snapshot
+	// reflects? Inconclusive when provably not (or when events were
+	// permanently lost inside the window); a note when it cannot be proven
+	// either way.
+	covered, coverageNote := indexCoversPG(ctx, cfg.IndexDB, src.LSN, snapshotTime)
+	if !covered {
+		return inconclusive(res, coverageNote), nil
 	}
 
 	// 4. Latest event per PK in (baseline, asOf]. Time bounds only — no
@@ -238,11 +250,22 @@ func VerifyTablePG(ctx context.Context, cfg PGLiveConfig, schema, table string) 
 		res.Detail = coverageNote
 	}
 
-	// 7. Compare — the same pure core as every other verify mode.
+	// 7. Compare — the same pure core as every other verify mode. Unlike the
+	// MySQL sibling (where the GTID-off coverage note is a rare corner), the
+	// coverage-unverified note is the ROUTINE state on PG (checkpoint <
+	// anchor on any non-idle cluster), and index lag is a common CAUSE of a
+	// reported divergence — so the note is APPENDED to a non-empty verdict
+	// detail, never dropped: a "row count differs" whose real cause is a
+	// lagging daemon must carry the one clue that explains it.
 	status, detail := classify(res.SourceDigest, res.SourceRows, res.ReconstructDigest, res.ReconstructRows, deferredDetail)
 	res.Status = status
-	if detail != "" {
-		res.Detail = detail // a real reason overrides the coverage note
+	switch {
+	case detail == "":
+		// StatusMatch: res.Detail already carries the coverage note (or "").
+	case coverageNote != "":
+		res.Detail = detail + " (note: " + coverageNote + ")"
+	default:
+		res.Detail = detail
 	}
 	return res, nil
 }
@@ -251,7 +274,15 @@ func VerifyTablePG(ctx context.Context, cfg PGLiveConfig, schema, table string) 
 // the PG sibling of indexCovers. Read errors degrade to not-covered with the
 // error as the reason (inconclusive, never a false mismatch), matching the
 // MySQL path's handling.
-func indexCoversPG(ctx context.Context, indexDB *sql.DB, anchorLSN uint64) (bool, string) {
+//
+// windowStart scopes the gap_lost stamp to the comparison window: a loss
+// stamped BEFORE the baseline's snapshot time is outside the window — the
+// baseline is a fresh dump of the source, so it re-covers whatever the gap
+// lost — and must not degrade the verdict, or one historical gap would make
+// this index permanently unverifiable no matter how many clean baselines
+// follow. Same window-scoping convention as `verify --check recover` ("a
+// stamped gap_lost_at inside the window degrades to inconclusive").
+func indexCoversPG(ctx context.Context, indexDB *sql.DB, anchorLSN uint64, windowStart time.Time) (bool, string) {
 	var (
 		flavor    sql.NullString
 		pos       sql.NullInt64
@@ -271,7 +302,14 @@ func indexCoversPG(ctx context.Context, indexDB *sql.DB, anchorLSN uint64) (bool
 	if pos.Valid && pos.Int64 > 0 {
 		checkpoint = uint64(pos.Int64)
 	}
-	return pgCoverageVerdict(flavor.String, checkpoint, anchorLSN, gapLostAt.Valid, gapDetail.String)
+	return pgCoverageVerdict(flavor.String, checkpoint, anchorLSN, gapLostInWindow(gapLostAt, windowStart), gapDetail.String)
+}
+
+// gapLostInWindow reports whether a stamped permanent loss falls inside the
+// comparison window (at-or-after its start). Pure — see indexCoversPG for why
+// a pre-window loss must not degrade the verdict.
+func gapLostInWindow(gapLostAt sql.NullTime, windowStart time.Time) bool {
+	return gapLostAt.Valid && !gapLostAt.Time.Before(windowStart)
 }
 
 // pgCoverageVerdict is the pure coverage decision for a PostgreSQL source —
@@ -310,7 +348,7 @@ func pgCoverageVerdict(flavor string, checkpointLSN, anchorLSN uint64, gapLost b
 		if detail == "" {
 			detail = "no detail recorded"
 		}
-		return false, "the capture stream recorded a permanent event loss (" + detail + "); events in the comparison window may be missing, so a content difference would not be conclusive"
+		return false, "the capture stream recorded a permanent event loss inside the comparison window (" + detail + "); events the reconstruction needs may be missing, so a content difference would not be conclusive"
 	}
 	if checkpointLSN == 0 {
 		return false, "index has no LSN checkpoint yet (the PostgreSQL stream has not committed a checkpoint against this index)"

--- a/internal/verify/verify_pg_test.go
+++ b/internal/verify/verify_pg_test.go
@@ -3,8 +3,10 @@ package verify
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dbtrail/dbtrail/internal/metadata"
 )
@@ -58,6 +60,30 @@ func TestPGCoverageVerdict(t *testing.T) {
 				t.Errorf("note = %q, want it to contain %q", note, tc.wantInNote)
 			}
 		})
+	}
+}
+
+// TestGapLostInWindow pins the window scoping of the gap_lost stamp: a loss
+// stamped BEFORE the baseline's snapshot time is outside the comparison
+// window (the baseline is a fresh dump — it re-covers whatever the gap lost)
+// and must NOT degrade the verdict, or one historical gap would make the
+// index permanently unverifiable no matter how many clean baselines follow.
+func TestGapLostInWindow(t *testing.T) {
+	windowStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		gap  sql.NullTime
+		want bool
+	}{
+		{"no stamp", sql.NullTime{}, false},
+		{"loss before the window (pre-baseline)", sql.NullTime{Valid: true, Time: windowStart.Add(-time.Hour)}, false},
+		{"loss exactly at window start", sql.NullTime{Valid: true, Time: windowStart}, true},
+		{"loss inside the window", sql.NullTime{Valid: true, Time: windowStart.Add(time.Hour)}, true},
+	}
+	for _, tc := range cases {
+		if got := gapLostInWindow(tc.gap, windowStart); got != tc.want {
+			t.Errorf("%s: gapLostInWindow = %v, want %v", tc.name, got, tc.want)
+		}
 	}
 }
 

--- a/internal/verify/verify_pg_test.go
+++ b/internal/verify/verify_pg_test.go
@@ -1,0 +1,180 @@
+package verify
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/metadata"
+)
+
+// TestPGCoverageVerdict pins the pure coverage grid for a PostgreSQL source —
+// especially its two load-bearing asymmetries: checkpoint >= anchor PROVES
+// coverage (no note), while checkpoint < anchor proves nothing and must
+// degrade to a covered-with-note (never a permanent inconclusive: WAL from
+// other databases advances the anchor without producing indexable events), and
+// a stamped permanent loss is a hard stop (inconclusive beats a possible false
+// mismatch).
+func TestPGCoverageVerdict(t *testing.T) {
+	cases := []struct {
+		name          string
+		flavor        string
+		checkpoint    uint64
+		anchor        uint64
+		gapLost       bool
+		gapDetail     string
+		wantCovered   bool
+		wantInNote    string
+		wantEmptyNote bool
+	}{
+		{name: "wrong flavor", flavor: "mysql", checkpoint: 100, anchor: 50,
+			wantCovered: false, wantInNote: "not a PostgreSQL capture"},
+		{name: "empty flavor", flavor: "", checkpoint: 100, anchor: 50,
+			wantCovered: false, wantInNote: "not a PostgreSQL capture"},
+		{name: "gap lost", flavor: "postgres", checkpoint: 100, anchor: 50, gapLost: true, gapDetail: "slot invalidated",
+			wantCovered: false, wantInNote: "slot invalidated"},
+		{name: "gap lost without detail", flavor: "postgres", checkpoint: 100, anchor: 50, gapLost: true,
+			wantCovered: false, wantInNote: "no detail recorded"},
+		{name: "no checkpoint yet", flavor: "postgres", checkpoint: 0, anchor: 50,
+			wantCovered: false, wantInNote: "no LSN checkpoint"},
+		{name: "checkpoint proves coverage", flavor: "postgres", checkpoint: 100, anchor: 100,
+			wantCovered: true, wantEmptyNote: true},
+		{name: "checkpoint past anchor", flavor: "postgres", checkpoint: 200, anchor: 100,
+			wantCovered: true, wantEmptyNote: true},
+		{name: "checkpoint behind anchor is unprovable, not blocking", flavor: "postgres", checkpoint: 50, anchor: 100,
+			wantCovered: true, wantInNote: "coverage unverified"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			covered, note := pgCoverageVerdict(tc.flavor, tc.checkpoint, tc.anchor, tc.gapLost, tc.gapDetail)
+			if covered != tc.wantCovered {
+				t.Fatalf("covered = %v, want %v (note=%q)", covered, tc.wantCovered, note)
+			}
+			if tc.wantEmptyNote && note != "" {
+				t.Errorf("want no note on proven coverage, got %q", note)
+			}
+			if tc.wantInNote != "" && !strings.Contains(note, tc.wantInNote) {
+				t.Errorf("note = %q, want it to contain %q", note, tc.wantInNote)
+			}
+		})
+	}
+}
+
+// TestVerifyTablePG_noPK: same PK-required gate as every other verify mode.
+func TestVerifyTablePG_noPK(t *testing.T) {
+	resolver := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"app.orders": {Schema: "app", Table: "orders", Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, DataType: ""},
+		}},
+	})
+	res, err := VerifyTablePG(context.Background(), PGLiveConfig{Resolver: resolver}, "app", "orders")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != StatusInconclusive || !strings.Contains(res.Detail, "no primary key") {
+		t.Fatalf("status=%q detail=%q, want inconclusive/no primary key", res.Status, res.Detail)
+	}
+}
+
+// TestVerifyTablePG_bypassesPKTypeGate: a PG snapshot's empty DATA_TYPE must
+// NOT trip the MySQL PK-type gate (PG PKs are text-identity on both sides —
+// the same bypass VerifyBaselinePair's pg branch has). With the gate bypassed
+// and no source checksum wired, the next step (the live fingerprint) is what
+// fails — proving the call got PAST the gate.
+func TestVerifyTablePG_bypassesPKTypeGate(t *testing.T) {
+	res, err := VerifyTablePG(context.Background(), PGLiveConfig{Resolver: pgResolver()}, "app", "orders")
+	if err == nil {
+		t.Fatalf("want the source-checksum error (no source checksum wired), got status %q", res.Status)
+	}
+	if !strings.Contains(err.Error(), "no PostgreSQL source checksum wired") {
+		t.Fatalf("error = %v, want the no-source-checksum error", err)
+	}
+	if strings.Contains(err.Error(), "unsupported by the baseline canonicalizer") {
+		t.Fatalf("the MySQL PK-type gate must not run on the PG path: %v", err)
+	}
+}
+
+// TestPGTargetTables covers the explicit filter (parse + sort), the invalid
+// entry error, and the resolver enumeration that replaces the MySQL path's
+// MAX(snapshot_id) query (which on a PG index — one relation per snapshot_id —
+// silently names a single table).
+func TestPGTargetTables(t *testing.T) {
+	resolver := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"app.orders": {Schema: "app", Table: "orders"},
+		"app.items":  {Schema: "app", Table: "items"},
+		"crm.leads":  {Schema: "crm", Table: "leads"},
+	})
+
+	t.Run("resolver enumeration, sorted", func(t *testing.T) {
+		got, err := PGTargetTables(resolver, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []string{"app.items", "app.orders", "crm.leads"}
+		if len(got) != len(want) {
+			t.Fatalf("got %d tables, want %d", len(got), len(want))
+		}
+		for i, st := range got {
+			if st.Schema+"."+st.Table != want[i] {
+				t.Errorf("tables[%d] = %s.%s, want %s", i, st.Schema, st.Table, want[i])
+			}
+		}
+	})
+
+	t.Run("explicit filter wins, sorted", func(t *testing.T) {
+		got, err := PGTargetTables(resolver, []string{"crm.leads", "app.orders"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 2 || got[0].Schema != "app" || got[1].Schema != "crm" {
+			t.Fatalf("got %v, want app.orders then crm.leads", got)
+		}
+	})
+
+	t.Run("invalid entry", func(t *testing.T) {
+		if _, err := PGTargetTables(resolver, []string{"nodot"}); err == nil {
+			t.Fatal("want an error for a filter entry without schema.table form")
+		}
+	})
+}
+
+// TestPGNormalizeSymmetry is the wiring guarantee behind the whole PG
+// live-source comparison: for any text value, the live-scan hook
+// (pgNormalizeRenderedBytes, applied to the source's raw text) must produce
+// exactly what the reconstruct side produces for the same text
+// (renderCellNormalized over a string value under a PG snapshot's EMPTY
+// DataType — metadata.WritePGSnapshot stores "" for every PG column). If
+// these two ever diverge, identical data digests differently and every row
+// becomes a false MISMATCH.
+func TestPGNormalizeSymmetry(t *testing.T) {
+	emptyTypeCol := metadata.ColumnMeta{DataType: ""}
+	values := []string{
+		"plain text",
+		"42",
+		"3.14",
+		"t",                             // bool output-function form
+		"\\x6465616462656566",           // bytea under bytea_output=hex
+		"2024-01-02 03:04:05.123456+00", // timestamptz under TimeZone=UTC, DateStyle=ISO
+		`{"b":2,"a":1}`,                 // JSON container: canonicalized on BOTH sides
+		`{"a": 1, "b": 2}`,              // jsonb output spacing: canonicalized the same way
+		"0000-00-00 00:00:00",           // MySQL zero-date sentinel text: must NOT be nulled under an empty type
+		"",                              // empty string stays an empty (non-NULL) value
+		"weird\tescapes\nand café 日本語",  // multibyte + control chars pass through
+	}
+	for _, v := range values {
+		live := pgNormalizeRenderedBytes([]byte(v))
+		recon := renderCellNormalized(v, emptyTypeCol)
+		if !bytes.Equal(live, recon) {
+			t.Errorf("normalization diverged for %q: live=%q recon=%q", v, live, recon)
+		}
+		if live == nil {
+			t.Errorf("normalization must never turn a non-NULL value into NULL (value %q)", v)
+		}
+	}
+	// The two JSON spellings of the same document must canonicalize to the
+	// same bytes — that IS the representation gap the hook exists to close.
+	if !bytes.Equal(pgNormalizeRenderedBytes([]byte(`{"b":2,"a":1}`)), pgNormalizeRenderedBytes([]byte(`{"a": 1, "b": 2}`))) {
+		t.Error("equivalent JSON containers must canonicalize identically")
+	}
+}


### PR DESCRIPTION
closes #1024

## Summary
- **`internal/pgverifysource` (new)**: `ConsistentTableChecksumPG` — the PG-native sibling of `consistency.ConsistentTableChecksumNormalized`. One `REPEATABLE READ, READ ONLY` transaction; `pg_current_wal_lsn()` captured by the snapshot-materializing first statement; attnum-ordered non-generated columns (pgbaseline's exact column contract); values read in **protocol text format** (`pgx.QueryResultFormats{TextFormatCode}` — never `::text` casts: `boolean::text` is `'true'`, `bool_out`/pgoutput/COPY emit `'t'`) on a connection pinned to the capture plane's render GUCs; rows folded through the shared `consistency.Hasher` so digests share the version-tagged contract. It is a separate package because it links pgx, which `TestCoreBinaryIsPostgresFree` (#534) and the read-layer dep guard (#528) ban from the core binary and the read stack.
- **`verify.VerifyTablePG` (pgx-free)**: mirror of `VerifyTable` with the PG-path decisions already ratified elsewhere — no PK-type gate (text identity, as in `VerifyBaselinePair`'s pg branch), time-bounded delta window (the "PG never sets a position bound" invariant), `pgTextPK` reconstruct. Normalization is symmetric by construction: both sides normalize under the empty `data_type` `WritePGSnapshot` stores (`pgNormalizeRenderedBytes` ≡ `renderCellNormalized` on strings — pinned by a unit test).
- **Coverage verdict** (`pgCoverageVerdict`, pure + unit-tested grid): `checkpoint >= anchor` **proves** coverage; behind-anchor proceeds with a `coverage unverified` note — WAL from other databases and non-transactional activity advances the anchor without producing indexable events, so blocking there would be permanently-inconclusive cry-wolf; the same documented trade-off as a GTID-off MySQL source. `gap_lost`, missing stream state, and a zero checkpoint stay hard inconclusive (never a false mismatch).
- **Wiring**: the CLI routes by index flavor through a new seam (`cli.SetPGLiveVerifyConnect`) that only `bintrail-pg` fills — the core `bintrail` binary refuses with a pointer to `bintrail-pg` and stays postgres-free. The console API-boundary refusal and the engine backstop are removed; the supervisor routes to the PG loop by the index's recorded flavor (the daemon already links the PG stack). PG target tables come from the resolver, not the `MAX(snapshot_id)` query (a PG index stores one relation per snapshot_id — that query silently names a single table).
- **Docs**: `verify.md` gains per-source notes (PG live-source semantics, coverage caveat, `LSN:` anchors); the stale `postgres.md`/`verify.md` claims that predated baseline-anchored PG verify (#1022/PR #1023) are corrected — full-table `reconstruct` remains out of scope, `verify` is not bound by that limit.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`, full sweep) — including the previously-broken dep guards `TestCoreBinaryIsPostgresFree` and `TestReadLayerDoesNotLinkGoMySQL`
- [x] `go vet ./...` and `go vet -tags integration ./...` clean
- [x] Integration (MySQL 8.4 @13306 + PostgreSQL 16 @15432, `-race`): `TestConsistentTableChecksumPG_Integration` — digest equals a **hand-built** digest of the expected pinned-GUC renderings (`t`, `\x` hex bytea, UTC timestamptz, numeric scale, NULL≠empty), row-order independence, generated-column exclusion
- [x] Integration end-to-end: `TestVerifyTablePG_Integration` — pgbaseline snapshot + seeded index → **match** on identical data (proven-coverage branch, no note), then conclusive **mismatch** for an uncaptured UPDATE (content) and DELETE (row count)
- [x] Full `-tags integration` suites for `internal/verify`, `internal/consistency`, `internal/console`, `consoleapp`, `internal/cli` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
