### PR TITLE
baseline: exclude system-versioning period columns from the parsed schema

### DIFF
--- a/internal/baseline/generated_column_test.go
+++ b/internal/baseline/generated_column_test.go
@@ -120,18 +120,20 @@ func TestParseSchemaExcludesSystemVersioningPeriodColumns(t *testing.T) {
 	}
 }
 
-// TestParseSchemaSystemVersioningPeriodColumnVariants covers the two edges of
-// rowPeriodRe: trailing attributes after the period clause (MariaDB allows
-// INVISIBLE on explicit period columns) must still be excluded, and a plain
-// column that merely SHARES the conventional row_start/row_end NAME — with no
-// GENERATED clause — must be kept: its values ARE in the dump, and dropping it
-// would shift every later column's positional slot (the #767 corruption class).
+// TestParseSchemaSystemVersioningPeriodColumnVariants covers the edges of
+// rowPeriodRe: trailing attributes after the period clause (verified on
+// MariaDB 11.4 — SHOW CREATE TABLE emits INVISIBLE right after the period
+// clause) and a lowercase hand-rolled spelling must still be excluded, and a
+// plain column that merely SHARES the conventional row_start/row_end NAME —
+// with no GENERATED clause — must be kept: its values ARE in the dump, and
+// dropping it would shift every later column's positional slot (the #767
+// corruption class).
 func TestParseSchemaSystemVersioningPeriodColumnVariants(t *testing.T) {
 	const schema = "CREATE TABLE `t` (\n" +
 		"  `id` int(11) NOT NULL,\n" +
 		"  `row_start` timestamp(6) NOT NULL DEFAULT current_timestamp(6),\n" +
 		"  `rs` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,\n" +
-		"  `re` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,\n" +
+		"  `re` timestamp(6) generated always as row end,\n" +
 		"  `val` varchar(20) DEFAULT NULL,\n" +
 		"  PRIMARY KEY (`id`,`re`)\n" +
 		") ENGINE=InnoDB WITH SYSTEM VERSIONING;\n"

--- a/internal/baseline/generated_column_test.go
+++ b/internal/baseline/generated_column_test.go
@@ -85,6 +85,73 @@ func TestParseSchemaExcludesGeneratedColumnMariaDBForm(t *testing.T) {
 	}
 }
 
+// TestParseSchemaExcludesSystemVersioningPeriodColumns pins the issue #863
+// fix: a MariaDB system-versioned table's EXPLICIT temporal period columns use
+// a parenthesis-free defining clause ("GENERATED ALWAYS AS ROW START|END")
+// that generatedRe cannot see, yet mydumper excludes their values from the
+// INSERT column-list and VALUES tuples exactly like STORED/VIRTUAL generated
+// columns (verified against a real mydumper dump of MariaDB 11.4 — see
+// rowPeriodRe's comment). The schema text below is the verbatim shape that
+// dump produced. Before the fix, ParseSchema kept row_start/row_end and the
+// #861 arity check refused the whole table.
+func TestParseSchemaExcludesSystemVersioningPeriodColumns(t *testing.T) {
+	const schema = "CREATE TABLE `sv_explicit` (\n" +
+		"  `id` int(11) NOT NULL,\n" +
+		"  `val` varchar(20) DEFAULT NULL,\n" +
+		"  `row_start` timestamp(6) GENERATED ALWAYS AS ROW START,\n" +
+		"  `row_end` timestamp(6) GENERATED ALWAYS AS ROW END,\n" +
+		"  PRIMARY KEY (`id`,`row_end`),\n" +
+		"  PERIOD FOR SYSTEM_TIME (`row_start`, `row_end`)\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 WITH SYSTEM VERSIONING;\n"
+
+	cols, err := ParseSchemaText(schema)
+	if err != nil {
+		t.Fatalf("ParseSchemaText: %v", err)
+	}
+	wantNames := []string{"id", "val"}
+	if len(cols) != len(wantNames) {
+		t.Fatalf("got %d columns %v, want %d (%v) — period columns must be excluded",
+			len(cols), colNames(cols), len(wantNames), wantNames)
+	}
+	for i, name := range wantNames {
+		if cols[i].Name != name {
+			t.Errorf("col[%d].Name = %q, want %q", i, cols[i].Name, name)
+		}
+	}
+}
+
+// TestParseSchemaSystemVersioningPeriodColumnVariants covers the two edges of
+// rowPeriodRe: trailing attributes after the period clause (MariaDB allows
+// INVISIBLE on explicit period columns) must still be excluded, and a plain
+// column that merely SHARES the conventional row_start/row_end NAME — with no
+// GENERATED clause — must be kept: its values ARE in the dump, and dropping it
+// would shift every later column's positional slot (the #767 corruption class).
+func TestParseSchemaSystemVersioningPeriodColumnVariants(t *testing.T) {
+	const schema = "CREATE TABLE `t` (\n" +
+		"  `id` int(11) NOT NULL,\n" +
+		"  `row_start` timestamp(6) NOT NULL DEFAULT current_timestamp(6),\n" +
+		"  `rs` timestamp(6) GENERATED ALWAYS AS ROW START INVISIBLE,\n" +
+		"  `re` timestamp(6) GENERATED ALWAYS AS ROW END INVISIBLE,\n" +
+		"  `val` varchar(20) DEFAULT NULL,\n" +
+		"  PRIMARY KEY (`id`,`re`)\n" +
+		") ENGINE=InnoDB WITH SYSTEM VERSIONING;\n"
+
+	cols, err := ParseSchemaText(schema)
+	if err != nil {
+		t.Fatalf("ParseSchemaText: %v", err)
+	}
+	wantNames := []string{"id", "row_start", "val"}
+	if len(cols) != len(wantNames) {
+		t.Fatalf("got %d columns %v, want %d (%v) — INVISIBLE period columns excluded, plain row_start kept",
+			len(cols), colNames(cols), len(wantNames), wantNames)
+	}
+	for i, name := range wantNames {
+		if cols[i].Name != name {
+			t.Errorf("col[%d].Name = %q, want %q", i, cols[i].Name, name)
+		}
+	}
+}
+
 func colNames(cols []Column) []string {
 	names := make([]string, len(cols))
 	for i, c := range cols {

--- a/internal/baseline/schema.go
+++ b/internal/baseline/schema.go
@@ -95,8 +95,8 @@ var generatedRe = regexp.MustCompile(`(?i)\bAS\s*\(.*\)\s*(?:VIRTUAL|STORED|PERS
 //	`row_start` timestamp(6) GENERATED ALWAYS AS ROW START,
 //	`row_end`   timestamp(6) GENERATED ALWAYS AS ROW END,
 //
-// Verified against a real dump (issue #863, mydumper/mydumper:latest vs
-// MariaDB 11.4, same flags bintrail passes incl. --complete-insert): mydumper
+// Verified against a real dump (issue #863, mydumper v1.0.3-1 vs MariaDB
+// 11.4, same flags bintrail passes incl. --complete-insert): mydumper
 // emits these columns in the -schema.sql exactly as above but EXCLUDES their
 // values from the INSERT column-list and VALUES tuples, the same treatment
 // STORED/VIRTUAL generated columns get — so ParseSchema must drop them from
@@ -110,7 +110,15 @@ var generatedRe = regexp.MustCompile(`(?i)\bAS\s*\(.*\)\s*(?:VIRTUAL|STORED|PERS
 // trade-off as generatedRe: the failure mode is the loud arity check, never
 // silent corruption. internal/consistency/checksum.go needs no sibling change —
 // its tableColumns already excludes these via GENERATION_EXPRESSION, which
-// MariaDB fills with the literal "ROW START"/"ROW END".
+// MariaDB fills with the literal "ROW START"/"ROW END" (verified live).
+//
+// Known scope limit (#1266): MariaDB extends the table's PRIMARY KEY with the
+// ROW END column, and the schema snapshot keeps it (PKColumnMetas selects on
+// IsPK only), so FULL-TABLE reconstruct — and verify, which reconstructs —
+// still refuse such a table loudly at the PK-canonicalization step
+// (MissingPKColumnError: the baseline no longer carries the column). The
+// baseline itself, single-row reconstruct with --pk-columns, and the query
+// paths all work.
 var rowPeriodRe = regexp.MustCompile(`(?i)\bGENERATED\s+ALWAYS\s+AS\s+ROW\s+(?:START|END)\b`)
 
 // ParseSchema reads a mydumper <db>.<table>-schema.sql file and returns the

--- a/internal/baseline/schema.go
+++ b/internal/baseline/schema.go
@@ -88,6 +88,31 @@ var colRe = regexp.MustCompile("^\\s+`([^`]+)`\\s+(\\w+)(?:\\s*\\([^)]*\\))?\\s*
 // loud on a column-count mismatch — never silent corruption.
 var generatedRe = regexp.MustCompile(`(?i)\bAS\s*\(.*\)\s*(?:VIRTUAL|STORED|PERSISTENT)\b`)
 
+// rowPeriodRe matches a MariaDB system-versioned table's explicit temporal
+// period columns, whose defining clause is parenthesis-free and therefore
+// invisible to generatedRe:
+//
+//	`row_start` timestamp(6) GENERATED ALWAYS AS ROW START,
+//	`row_end`   timestamp(6) GENERATED ALWAYS AS ROW END,
+//
+// Verified against a real dump (issue #863, mydumper/mydumper:latest vs
+// MariaDB 11.4, same flags bintrail passes incl. --complete-insert): mydumper
+// emits these columns in the -schema.sql exactly as above but EXCLUDES their
+// values from the INSERT column-list and VALUES tuples, the same treatment
+// STORED/VIRTUAL generated columns get — so ParseSchema must drop them from
+// the positional column list too, or the #861 arity check refuses the whole
+// table. IMPLICIT period columns (a table created WITH SYSTEM VERSIONING
+// without declaring them) are invisible and appear in neither the schema nor
+// the data files, so only the explicit form needs handling. The regex is
+// anchored on the full "GENERATED ALWAYS AS ROW START|END" phrase and tolerates
+// trailing attributes (e.g. INVISIBLE); a plain column merely NAMED row_start
+// has no such clause and is kept. Same accepted COMMENT-false-positive
+// trade-off as generatedRe: the failure mode is the loud arity check, never
+// silent corruption. internal/consistency/checksum.go needs no sibling change —
+// its tableColumns already excludes these via GENERATION_EXPRESSION, which
+// MariaDB fills with the literal "ROW START"/"ROW END".
+var rowPeriodRe = regexp.MustCompile(`(?i)\bGENERATED\s+ALWAYS\s+AS\s+ROW\s+(?:START|END)\b`)
+
 // ParseSchema reads a mydumper <db>.<table>-schema.sql file and returns the
 // ordered list of columns with their Parquet type mappings.
 func ParseSchema(path string) ([]Column, error) {
@@ -136,9 +161,10 @@ func parseSchemaFrom(r io.Reader) ([]Column, error) {
 		if m == nil {
 			continue
 		}
-		if generatedRe.MatchString(line) {
-			// STORED/VIRTUAL generated column — mydumper never dumps its value,
-			// so it must not occupy a slot in the positional column list either.
+		if generatedRe.MatchString(line) || rowPeriodRe.MatchString(line) {
+			// STORED/VIRTUAL generated column, or a system-versioning period
+			// column (#863) — mydumper never dumps its value, so it must not
+			// occupy a slot in the positional column list either.
 			continue
 		}
 		name := m[1]


### PR DESCRIPTION
closes #863

## Summary
- MariaDB system-versioned tables' explicit temporal period columns (`row_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START`, …) use a parenthesis-free defining clause that `generatedRe` cannot match, so `ParseSchema` kept them in the positional column list and the #861 arity check refused the whole table (loud, but the table could not be baselined at all).
- **Empirical prerequisite from the issue, now confirmed**: a real mydumper run (mydumper v1.0.3-1 vs MariaDB 11.4, same flags bintrail passes incl. `--complete-insert`) lists these columns in the `-schema.sql` but excludes their values from the INSERT column-list and VALUES tuples — the exact treatment STORED/VIRTUAL generated columns get. Implicit period columns (table created `WITH SYSTEM VERSIONING` without declaring them) appear in neither schema nor data files, so only the explicit form needs handling.
- Fix: sibling regex `rowPeriodRe` (`GENERATED ALWAYS AS ROW START|END`, trailing attributes like `INVISIBLE` tolerated — verified live that MariaDB 11.4 emits that attribute) checked alongside `generatedRe` in `parseSchemaFrom`. Same accepted COMMENT-false-positive trade-off as `generatedRe`: worst case is the loud arity check, never silent corruption.
- No sibling change needed in `internal/consistency/checksum.go`: `tableColumns` filters by `GENERATION_EXPRESSION`, which MariaDB fills with the literal `ROW START`/`ROW END` for these columns (verified live).

## Known scope limit (follow-up: #1266)
MariaDB extends the versioned table's PRIMARY KEY with the `ROW END` column, and the schema snapshot keeps it, so **full-table** reconstruct — and `verify`, which reconstructs — still refuse such tables loudly at PK canonicalization (`MissingPKColumnError`). Confirmed end-to-end; the baseline itself, single-row reconstruct with `--pk-columns`, and the query paths all work, so this PR is a strict improvement. Documented in `rowPeriodRe`'s comment.

## Test plan
- [x] New `TestParseSchemaExcludesSystemVersioningPeriodColumns` pins the verbatim real-dump schema shape → only `id`,`val` remain
- [x] New `TestParseSchemaSystemVersioningPeriodColumnVariants` covers the `INVISIBLE` attribute, a lowercase hand-rolled clause (pins `(?i)`), and pins that a plain column merely *named* `row_start` (no GENERATED clause) is **kept**
- [x] Mutation-checked: reverting the `parseSchemaFrom` condition makes the new tests fail
- [x] End-to-end against the real artifact: `bintrail baseline` over the actual mydumper dump of the system-versioned tables converts (2 tables); resulting Parquet schema is `id`,`val` only with correct current-state values; single-row reconstruct returns the right row
- [x] `go test ./... -count=1` green (51 packages), `go test -race` on `internal/baseline`, `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
