### PR TITLE
console-e2e: cover the primary read workflows over a real fixture

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -63,6 +63,7 @@ let TOKEN = "";
 let currentServer = "";       // X-Bintrail-Server target ("" = backend default)
 let defaultServerId = "";
 let serverGen = 0;            // bumped on every server switch (staleness guard)
+let viewGen = 0;              // bumped on every route render (staleness guard)
 let capsCache = {};           // last /api/capabilities for the selected server
 let extViews = [];            // extension views advertised for the selected server (embedding builds)
 let lastSQL = "";             // last generated undo SQL (for copy/download)
@@ -641,6 +642,12 @@ function renderRoute() {
   // the page must release the daemon's single-query latch.
   closeDatePicker();
   abortSQLRun();
+  // Route-level staleness: the full-view async renderers (overview / status /
+  // storage) fetch before painting, so navigating away while their fetches are
+  // in flight would let the OLD view's completion clear and repaint over the
+  // new one (nav highlighting one route, content showing another). serverGen
+  // only covers server switches; this covers same-server navigation.
+  viewGen++;
   const route = routeFromLocation();
   setActiveNav(route);
   cursorIdx = -1;
@@ -753,7 +760,7 @@ function covCard(c) {
 }
 
 async function renderOverview() {
-  const gen = serverGen;
+  const gen = serverGen, vgen = viewGen;
   viewLoading();
   try {
     const [status, eventsData, coverage] = await Promise.all([
@@ -764,10 +771,10 @@ async function renderOverview() {
       // indistinguishable from a console without the feature.
       api("/api/coverage").catch((err) => { console.error("coverage fetch failed", err); return { continuity: "unavailable" }; }),
     ]);
-    if (gen !== serverGen) return;
+    if (gen !== serverGen || vgen !== viewGen) return;
     buildOverview(status, eventsData, coverage); // render INSIDE the try: a throw here shows an error, never a stuck "Loading…"
   } catch (err) {
-    if (gen !== serverGen) return;
+    if (gen !== serverGen || vgen !== viewGen) return;
     const v = VIEW(); clear(v); v.append(pageHead("Overview", null)); renderError(v, err);
   }
 }
@@ -1735,12 +1742,12 @@ function renderTimeline(container, data) {
 // ── Status ─────────────────────────────────────────────────────────────────
 
 async function renderStatus() {
-  const gen = serverGen;
+  const gen = serverGen, vgen = viewGen;
   viewLoading();
   let data;
   try { data = await api("/api/status"); }
-  catch (err) { if (gen !== serverGen) return; const v = VIEW(); clear(v); v.append(pageHead("Status", null)); renderError(v, err); return; }
-  if (gen !== serverGen) return;
+  catch (err) { if (gen !== serverGen || vgen !== viewGen) return; const v = VIEW(); clear(v); v.append(pageHead("Status", null)); renderError(v, err); return; }
+  if (gen !== serverGen || vgen !== viewGen) return;
   updateSideMeta(data);
 
   const v = VIEW(); clear(v);
@@ -1980,7 +1987,7 @@ async function renderStorage() {
   // Gated like Time-travel: a direct URL / Back with the capability off must
   // REWRITE the URL (replaceState) before re-dispatching — see renderTimetravel.
   if (!capsCache.monitor) { history.replaceState({}, "", "/overview"); renderRoute(); return; }
-  const gen = serverGen;
+  const gen = serverGen, vgen = viewGen;
   viewLoading();
   // Each fetch degrades independently: a panel renders its own failure note
   // instead of one error wiping the whole page. (A 401 inside api() raises the
@@ -1993,7 +2000,7 @@ async function renderStorage() {
     api("/api/baselines").catch(asErr),
     api("/api/telemetry").catch(asErr),
   ]);
-  if (gen !== serverGen) return;
+  if (gen !== serverGen || vgen !== viewGen) return;
   // Same guard as renderOverview: a throw inside the build must show an
   // error, never leave the "Loading…" skeleton up forever.
   try {

--- a/test/console-e2e/README.md
+++ b/test/console-e2e/README.md
@@ -23,10 +23,15 @@ make console-e2e
 PW_CHANNEL=chrome make console-e2e
 ```
 
-`run.sh` builds `bintrail-console`, creates a throwaway index database, launches
-a source-less `watch` daemon, seeds a monitored source whose per-source index
-is intentionally **not** provisioned (the lifecycle state that exercises the
-guards), drives the scenarios, and tears everything down.
+`run.sh` builds `bintrail-console` and `bintrail`, creates a throwaway index
+database, provisions it with the production schema (`bintrail init`) plus a
+seeded read fixture — row events, a cascade fixture, and a baseline snapshot
+produced by the real `bintrail baseline` converter over a hand-written
+mydumper-format dump — launches a source-less `watch` daemon (with
+`--baseline-dir` and the baseline-trigger opt-in), seeds a monitored source
+whose per-source index is intentionally **not** provisioned (the lifecycle
+state that exercises the guards), drives the scenarios, and tears everything
+down.
 
 ## What each scenario guards
 
@@ -39,6 +44,13 @@ guards), drives the scenarios, and tears everything down.
 | form: advanced expanded for a BYO-index entry | the other `byoIndex` arm — a no-source entry must show its index fields |
 | form: source fields visible | the monitor form rendering for a source entry |
 | error: real 1049 reaches the frontend + empty state (×4) | the actual backend 1049 (from the unprovisioned default server) must surface as an actionable empty state, not a raw wall — and `scrubDSNError` must preserve the index db name |
+| events: render + redaction (×6) | the primary read workflow over REAL indexed rows (#970): rows render, the diff expands, and the seeded `query_text`/`query_hash` canary never reaches the DOM while `connection_id` passes through (#701 D1) |
+| export: JSON/CSV blobs (×6) | the real download buttons, blobs captured at `URL.createObjectURL`: query_text-free, connection_id kept, CSV header in lockstep with `EVENT_CSV_COLUMNS` |
+| recover: submit renders SQL (×3) | Recover actually submits and paints the reversal SQL panel — scenario 6 only checks the form DOM exists |
+| cascade: banner + counts (×3) | the `cascade_detected` positive-half rendering (#619) — the banner block whose missing `)` once broke the whole SPA |
+| timetravel (×6) | the reconstruct gate + baseline+deltas over a real fixture baseline (#970): event fold, baseline-only row, deleted row |
+| overview: window honesty (×2) | `buildOverview` window line uses the fetched window's own bounds, never `status.coverage` (#679/#686) |
+| storage: Create-baseline gates (×5) | the button's double-gate (#686): live enabled arm, destination-missing arm, capability-off arm; the fixture snapshot listed |
 | no uncaught JS errors | any thrown error over the whole drive |
 
 Adding a scenario: append an `ok(...)`/`bad(...)` block in `console_e2e.mjs`.

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -18,6 +18,16 @@ const URL = process.env.CONSOLE_URL || "http://127.0.0.1:8090";
 const TOKEN = process.env.CONSOLE_TOKEN || "";
 const CHANNEL = process.env.PW_CHANNEL || undefined; // undefined → bundled chromium
 const ART = process.env.E2E_ARTIFACT_DIR || "/tmp";
+// Read-fixture coordinates (seeded by run.sh into the boot index; see the
+// fixture block there). FIX is the seeded schema; TT_AT is a timestamp just
+// after the last seeded event, inside the hour whose partition exists — using
+// the default `at` (now) would race the top-of-hour partition boundary.
+const FIX = process.env.E2E_FIX_SCHEMA || "e2eshop";
+const TT_AT = process.env.E2E_TT_AT || "";
+// The query_text canary run.sh embeds in the seeded UPDATE event. query_text /
+// query_hash are captured index data but NEVER cross the DTO layer (#699);
+// this string appearing anywhere in the page or an export is a leak.
+const CANARY = "e2e-canary-query-text";
 
 const results = [];
 const ok = (name) => results.push({ name, pass: true });
@@ -575,6 +585,279 @@ try {
   csv.plain === "hello" && csv.number === "42" ? ok("csv: benign values pass through untouched") : bad("csv: benign values pass through untouched", JSON.stringify([csv.plain, csv.number]));
   csv.quoted === '"a,""b"' ? ok("csv: existing quoting logic unchanged") : bad("csv: existing quoting logic unchanged", JSON.stringify(csv.quoted));
   csv.objFormula === '"{""id"":1}"' ? ok("csv: JSON object cells are not prefixed") : bad("csv: JSON object cells are not prefixed", JSON.stringify(csv.objFormula));
+
+  // ── Scenarios 12-15: the primary READ workflows over REAL indexed data ─────
+  // (#970/#686/#619). Everything below runs against the "byo-idx" server from
+  // scenario 5 — its index is the boot db run.sh provisioned with `bintrail
+  // init`, seeded events, and a real `bintrail baseline` snapshot (which the
+  // daemon-level --baseline-dir exposes to every server, making this one
+  // Time-travel-capable).
+  await page.evaluate(async (id) => { await switchServer(id); }, byoId);
+
+  // Scenario 12 — Events renders real rows, and the redaction contract holds
+  // end-to-end (#970): query_text/query_hash are captured index data that must
+  // NEVER reach the browser (#699 — the canary is IN the seeded UPDATE row),
+  // while connection_id must PASS THROUGH (#701 D1 un-gated it; asserting
+  // absence here would pin the stale pre-#701 contract).
+  await page.evaluate(() => navigate("events"));
+  await page.waitForSelector("#ev-rows .ev-row", { timeout: 10000 });
+  const evr = await page.evaluate(({ FIX, CANARY }) => {
+    const rows = Array.from(document.querySelectorAll("#ev-rows .ev-row"));
+    const updRow = rows.find((r) => r.textContent.includes(FIX + ".orders") && r.textContent.includes("UPDATE"));
+    let diffText = "";
+    if (updRow) {
+      updRow.click(); // expands and lazy-renders the before/after diff
+      diffText = updRow.nextElementSibling ? updRow.nextElementSibling.textContent : "";
+    }
+    const upd = lastEvents.find((e) => e.event_type === "UPDATE" && e.schema_name === FIX && e.table_name === "orders") || {};
+    return {
+      rowCount: rows.length,
+      updFound: !!updRow,
+      diffText,
+      domCanary: document.body.textContent.includes(CANARY),
+      leakedKeys: lastEvents.filter((e) => ("query_text" in e) || ("query_hash" in e)).length,
+      connId: upd.connection_id,
+    };
+  }, { FIX, CANARY });
+  evr.rowCount === 6 ? ok("events: all 6 seeded events render") : bad("events: all 6 seeded events render", `rowCount=${evr.rowCount}`);
+  evr.updFound ? ok("events: the seeded orders UPDATE row renders") : bad("events: the seeded orders UPDATE row renders", "row not found");
+  (/shipped/.test(evr.diffText) && /new/.test(evr.diffText))
+    ? ok("events: expanding a row shows the before/after diff")
+    : bad("events: expanding a row shows the before/after diff", `diffText=${evr.diffText.slice(0, 120)}`);
+  !evr.domCanary ? ok("events: query_text never reaches the DOM") : bad("events: query_text never reaches the DOM", "canary found in page text");
+  evr.leakedKeys === 0 ? ok("events: no query_text/query_hash keys in the wire events") : bad("events: no query_text/query_hash keys in the wire events", `${evr.leakedKeys} event(s) carry them`);
+  evr.connId === 777 ? ok("events: connection_id passes through (#701 D1)") : bad("events: connection_id passes through (#701 D1)", `connection_id=${JSON.stringify(evr.connId)}`);
+
+  // Scenario 12b — the export path (#970): drive the REAL JSON/CSV buttons and
+  // capture the blobs downloadBlob mints. Export is over the on-screen
+  // redacted DTOs — so it must stay query_text-free WITH connection_id, and
+  // the CSV header must stay in lockstep with EVENT_CSV_COLUMNS.
+  const exp = await page.evaluate(async (CANARY) => {
+    const btns = Array.from(document.querySelectorAll(".result-bar button"));
+    const jsonBtn = btns.find((b) => b.textContent.trim() === "JSON");
+    const csvBtn = btns.find((b) => b.textContent.trim() === "CSV");
+    const blobs = [];
+    const orig = URL.createObjectURL;
+    URL.createObjectURL = (b) => { blobs.push(b); return orig.call(URL, b); };
+    jsonBtn.click();
+    csvBtn.click();
+    URL.createObjectURL = orig;
+    const [jsonText, csvText] = await Promise.all(blobs.map((b) => b.text()));
+    const arr = JSON.parse(jsonText);
+    const header = csvText.split("\r\n")[0];
+    return {
+      n: arr.length,
+      jsonLeak: arr.filter((e) => ("query_text" in e) || ("query_hash" in e)).length,
+      jsonConn: arr.every((e) => "connection_id" in e),
+      jsonCanary: jsonText.includes(CANARY),
+      headerLockstep: header === EVENT_CSV_COLUMNS.join(","),
+      headerConn: header.split(",").includes("connection_id"),
+      headerLeak: /query_text|query_hash/.test(header),
+      csvCanary: csvText.includes(CANARY),
+      csvConnVal: csvText.split("\r\n").some((l) => l.split(",").includes("777")),
+    };
+  }, CANARY);
+  exp.n === 6 ? ok("export: JSON blob carries the full rendered page") : bad("export: JSON blob carries the full rendered page", `n=${exp.n}`);
+  (exp.jsonLeak === 0 && !exp.jsonCanary) ? ok("export: JSON blob is query_text/query_hash-free") : bad("export: JSON blob is query_text/query_hash-free", `leak=${exp.jsonLeak} canary=${exp.jsonCanary}`);
+  exp.jsonConn ? ok("export: JSON blob keeps connection_id") : bad("export: JSON blob keeps connection_id", "some entry lacks the key");
+  exp.headerLockstep ? ok("export: CSV header in lockstep with EVENT_CSV_COLUMNS") : bad("export: CSV header in lockstep with EVENT_CSV_COLUMNS", "header drifted");
+  (exp.headerConn && !exp.headerLeak) ? ok("export: CSV columns include connection_id, never query_text") : bad("export: CSV columns include connection_id, never query_text", `conn=${exp.headerConn} leak=${exp.headerLeak}`);
+  (!exp.csvCanary && exp.csvConnVal) ? ok("export: CSV rows redacted but carry the connection_id value") : bad("export: CSV rows redacted but carry the connection_id value", `canary=${exp.csvCanary} conn777=${exp.csvConnVal}`);
+
+  // Scenario 13 — Recover actually SUBMITS and renders the reversal SQL
+  // (#970). Scenario 6 above only checks the form's DOM exists.
+  await page.evaluate(() => navigate("recover"));
+  await page.waitForSelector("#recover-form", { timeout: 8000 });
+  await page.waitForFunction((FIX) => {
+    const f = document.getElementById("recover-form");
+    return f && Array.from(f.elements.schema.options).some((o) => o.value === FIX);
+  }, FIX, { timeout: 8000 });
+  await page.evaluate((FIX) => {
+    const f = document.getElementById("recover-form");
+    f.elements.schema.value = FIX;
+    f.elements.table.value = "orders";
+    f.elements.pk.value = "1";
+    f.requestSubmit();
+  }, FIX);
+  await page.waitForSelector("#recover-out #sql-panel", { timeout: 8000 });
+  const rec = await page.evaluate(() => ({
+    sql: (document.querySelector("#recover-out #sql-panel .code") || {}).textContent || "",
+    meta: (document.querySelector("#recover-out #sql-panel .lbl") || {}).textContent || "",
+    cascadeBanner: !!document.querySelector("#recover-out .ctx-banner"),
+  }));
+  (/UPDATE/.test(rec.sql) && rec.sql.includes("'new'"))
+    ? ok("recover: submit renders the reversal SQL")
+    : bad("recover: submit renders the reversal SQL", `sql=${rec.sql.slice(0, 160)}`);
+  /1 statement\(s\) from 1 event\(s\)/.test(rec.meta)
+    ? ok("recover: meta line reports statement/event counts")
+    : bad("recover: meta line reports statement/event counts", rec.meta);
+  !rec.cascadeBanner ? ok("recover: a plain undo shows no CASCADE banner") : bad("recover: a plain undo shows no CASCADE banner", "banner rendered for a non-parent target");
+
+  // Scenario 13b — the cascade-detected banner (#619): the seeded parent DELETE
+  // has two child INSERTs behind an ON DELETE CASCADE fk_constraints row, so
+  // /api/recover auto-detects and the positive-half rendering (banner + counts
+  // meta) must run. During #617 a missing ')' in this exact block broke the
+  // whole SPA and only a manual boot probe caught it — this is that guard.
+  await page.evaluate(() => {
+    const f = document.getElementById("recover-form");
+    f.elements.table.value = "parent";
+    f.elements.pk.value = "";
+    f.requestSubmit();
+  });
+  await page.waitForFunction(() => {
+    const b = document.querySelector("#recover-out .ctx-banner .badge");
+    return b && b.textContent === "CASCADE";
+  }, { timeout: 8000 });
+  const cas = await page.evaluate(() => ({
+    banner: (document.querySelector("#recover-out .ctx-banner") || {}).textContent || "",
+    sql: (document.querySelector("#recover-out #sql-panel .code") || {}).textContent || "",
+    meta: (document.querySelector("#recover-out #sql-panel .lbl") || {}).textContent || "",
+  }));
+  cas.banner.includes("restores 2 related row(s)")
+    ? ok("cascade: banner counts the repaired child rows")
+    : bad("cascade: banner counts the repaired child rows", cas.banner);
+  (cas.meta.includes("2 cascade child row(s)") && cas.meta.includes("0 SET NULL restore(s)"))
+    ? ok("cascade: meta line carries the cascade-aware counts")
+    : bad("cascade: meta line carries the cascade-aware counts", cas.meta);
+  (/INSERT INTO/.test(cas.sql) && cas.sql.includes("child") && cas.sql.includes("10") && cas.sql.includes("11"))
+    ? ok("cascade: script re-inserts both cascade-deleted children")
+    : bad("cascade: script re-inserts both cascade-deleted children", cas.sql.slice(0, 200));
+
+  // Scenario 14 — Time-travel over the fixture baseline (#970). First pin the
+  // gate itself: this server must report reconstruct (a baseline is
+  // configured), and a server WITHOUT it must be rerouted off /timetravel.
+  const ttGate = await page.evaluate(() => {
+    const had = !!capsCache.reconstruct;
+    capsCache.reconstruct = false;
+    navigate("timetravel");
+    const rerouted = location.pathname === "/overview";
+    capsCache.reconstruct = had;
+    return { had, rerouted };
+  });
+  ttGate.had ? ok("timetravel: a baseline-configured server reports the reconstruct capability") : bad("timetravel: a baseline-configured server reports the reconstruct capability", "capsCache.reconstruct falsy on byo-idx");
+  ttGate.rerouted ? ok("timetravel: gated-off navigation reroutes to overview") : bad("timetravel: gated-off navigation reroutes to overview", "landed on /timetravel without the capability");
+
+  await page.evaluate(() => navigate("timetravel"));
+  await page.waitForSelector("#tt-form", { timeout: 8000 });
+  await page.waitForFunction((FIX) => {
+    const f = document.getElementById("tt-form");
+    return f && Array.from(f.elements.schema.options).some((o) => o.value === FIX);
+  }, FIX, { timeout: 8000 });
+  // pk=1: baseline row (status new) + a later UPDATE (status shipped) — the
+  // event fold half. email only ever existed in the baseline's full row image.
+  await page.evaluate(async ({ FIX, TT_AT }) => {
+    const f = document.getElementById("tt-form");
+    f.elements.schema.value = FIX;
+    await loadTables(f);
+    f.elements.table.value = "orders";
+    f.elements.pk.value = "1";
+    if (TT_AT) f.elements.at.value = TT_AT;
+    f.requestSubmit();
+  }, { FIX, TT_AT });
+  await page.waitForSelector("#tt-out .statetable", { timeout: 10000 });
+  const tt1 = await page.evaluate(() => {
+    const cells = {};
+    document.querySelectorAll("#tt-out .statetable tr").forEach((tr) => {
+      cells[tr.querySelector("th").textContent] = tr.querySelector("td").textContent;
+    });
+    return { cells, meta: (document.querySelector("#tt-out .meta-line") || {}).textContent || "" };
+  });
+  (tt1.cells.status === "shipped" && tt1.cells.email === "a@example.com")
+    ? ok("timetravel: reconstructed row folds the event over the baseline")
+    : bad("timetravel: reconstructed row folds the event over the baseline", JSON.stringify(tt1.cells));
+  /baseline /.test(tt1.meta) ? ok("timetravel: meta line names the baseline anchor") : bad("timetravel: meta line names the baseline anchor", tt1.meta);
+
+  // pk=4: exists ONLY in the baseline (no events) — a binlog-only reconstruct
+  // cannot resolve it, so this pins the baseline half of baseline+deltas.
+  await page.evaluate(() => { const f = document.getElementById("tt-form"); f.elements.pk.value = "4"; f.requestSubmit(); });
+  await page.waitForFunction(() => /d@example\.com/.test((document.getElementById("tt-out") || {}).textContent || ""), { timeout: 10000 });
+  const tt4 = await page.evaluate(() => {
+    const cells = {};
+    document.querySelectorAll("#tt-out .statetable tr").forEach((tr) => {
+      cells[tr.querySelector("th").textContent] = tr.querySelector("td").textContent;
+    });
+    return cells;
+  });
+  (tt4.status === "new" && tt4.email === "d@example.com")
+    ? ok("timetravel: a never-touched row resolves from the baseline alone")
+    : bad("timetravel: a never-touched row resolves from the baseline alone", JSON.stringify(tt4));
+
+  // pk=2: in the baseline, then DELETEd — must render the deleted note, not an
+  // empty table and not the stale baseline value.
+  await page.evaluate(() => { const f = document.getElementById("tt-form"); f.elements.pk.value = "2"; f.requestSubmit(); });
+  await page.waitForFunction(() => !!document.querySelector("#tt-out .deleted-note"), { timeout: 10000 });
+  const tt2 = await page.evaluate(() => (document.querySelector("#tt-out .deleted-note") || {}).textContent || "");
+  /Row was deleted/.test(tt2)
+    ? ok("timetravel: a deleted row renders the deleted note")
+    : bad("timetravel: a deleted row renders the deleted note", tt2);
+
+  // Scenario 15 — Overview window honesty (#686): fixture-drive the REAL
+  // buildOverview with a status.coverage spanning far more history than the
+  // fetched events window, and assert the window line uses the window's OWN
+  // bounds (#679/#684) — a reintroduced status.coverage fallback fails here
+  // and nowhere else (the Go suite never renders app.js).
+  const ov = await page.evaluate(() => {
+    const mkev = (ts, type, pk) => ({ event_timestamp: ts, schema_name: "ovfix", table_name: "t", event_type: type, pk_values: pk, changed_columns: [] });
+    const events = [mkev("2026-03-01 10:30:00", "DELETE", "9"), mkev("2026-03-01 10:00:00", "INSERT", "8")];
+    const status = { coverage: { oldest: "2020-01-01 00:00:00", newest: "2026-06-30 00:00:00", total_events: 123456 } };
+    buildOverview(status, { events }, null);
+    return {
+      win: (document.querySelector(".ov-coverage") || {}).textContent || "",
+      sub: (document.querySelector(".page-sub") || {}).textContent || "",
+    };
+  });
+  (ov.win.includes("2026-03-01 10:00:00") && ov.win.includes("2026-03-01 10:30:00") && !ov.win.includes("2020-01-01"))
+    ? ok("overview: window line uses the fetched window's own bounds")
+    : bad("overview: window line uses the fetched window's own bounds", ov.win);
+  (ov.sub.includes("1 delete(s)") && ov.sub.includes("2 event(s)"))
+    ? ok("overview: subhead counts come from the fetched window")
+    : bad("overview: subhead counts come from the fetched window", ov.sub);
+
+  // Scenario 15b — Storage page live (#686): with the daemon opted in
+  // (BINTRAIL_CONSOLE_BASELINE_TRIGGER=1) and this server baseline-configured,
+  // the Create-baseline button must render enabled, and the fixture snapshot
+  // (1 table, anchored at binlog.000001:50) must be listed.
+  await page.evaluate(() => navigate("storage"));
+  await page.waitForFunction(() => Array.from(document.querySelectorAll(".stg-row")).some((r) => r.textContent.includes("binlog.000001:50")), { timeout: 10000 });
+  const stg = await page.evaluate(() => {
+    const heads = Array.from(document.querySelectorAll(".ov-panel-head"));
+    const bHead = heads.find((h) => /Baseline snapshots/.test(h.textContent));
+    const btn = bHead ? Array.from(bHead.querySelectorAll("button")).find((b) => b.textContent === "Create baseline") : null;
+    const row = Array.from(document.querySelectorAll(".stg-row")).find((r) => r.textContent.includes("binlog.000001:50"));
+    return { capOn: !!capsCache.baseline_trigger, btnPresent: !!btn, btnEnabled: btn ? !btn.disabled : false, rowText: row ? row.textContent : "" };
+  });
+  stg.capOn ? ok("storage: baseline_trigger capability reaches the frontend") : bad("storage: baseline_trigger capability reaches the frontend", "capsCache.baseline_trigger falsy");
+  (stg.btnPresent && stg.btnEnabled) ? ok("storage: Create-baseline button renders enabled when both gates pass") : bad("storage: Create-baseline button renders enabled when both gates pass", `present=${stg.btnPresent} enabled=${stg.btnEnabled}`);
+  stg.rowText.includes("1 table(s)") ? ok("storage: the fixture snapshot is listed with its table count") : bad("storage: the fixture snapshot is listed with its table count", stg.rowText);
+
+  // Scenario 15c — the button's other gate arms, fixture-driven through the
+  // REAL baselinesPanel (destination-missing can't exist live once the daemon
+  // sets a default --baseline-dir): no destination → no button + the setup
+  // empty state; capability off → no button even with a destination.
+  const gates = await page.evaluate(() => {
+    const servers = [{ id: "srv-fix", name: "fixture" }];
+    const keepCur = currentServer;
+    currentServer = "srv-fix";
+    const cfgOff = baselinesPanel({ configured: false }, servers);
+    const keepCap = capsCache.baseline_trigger;
+    capsCache.baseline_trigger = false;
+    const capOff = baselinesPanel({ configured: true, source: "/tmp/baselines", snapshots: [] }, servers);
+    capsCache.baseline_trigger = keepCap;
+    currentServer = keepCur;
+    const hasBtn = (n) => Array.from(n.querySelectorAll("button")).some((b) => b.textContent === "Create baseline");
+    return {
+      cfgOffBtn: hasBtn(cfgOff),
+      cfgOffEmpty: /No baselines configured/.test(cfgOff.textContent),
+      capOffBtn: hasBtn(capOff),
+      capOffEmpty: /no snapshots found/.test(capOff.textContent),
+    };
+  });
+  (!gates.cfgOffBtn && gates.cfgOffEmpty)
+    ? ok("storage: no baseline destination → no button, setup empty state")
+    : bad("storage: no baseline destination → no button, setup empty state", JSON.stringify(gates));
+  (!gates.capOffBtn && gates.capOffEmpty)
+    ? ok("storage: baseline_trigger off → no button even with a destination")
+    : bad("storage: baseline_trigger off → no button even with a destination", JSON.stringify(gates));
 
   // No uncaught JS errors over the whole run.
   jsErrors.length === 0 ? ok("no uncaught JS errors") : bad("no uncaught JS errors", JSON.stringify(jsErrors));

--- a/test/console-e2e/run.sh
+++ b/test/console-e2e/run.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
-# Orchestrates the console frontend E2E: build the binary, point it at the
+# Orchestrates the console frontend E2E: build the binaries, point them at the
 # shared test MySQL, launch a source-less `watch` daemon, seed a monitored
 # source whose per-source index is intentionally NOT provisioned (the
 # lifecycle state that exercises the regression guards), then drive headless
 # Chrome (console_e2e.mjs). Tears everything down on exit.
+#
+# The boot index ($IDX_DB) is additionally provisioned as a REAL read fixture
+# (#970/#686/#619): `bintrail init` creates the production schema, seeded row
+# events + a cascade fixture land in real hourly partitions, and a baseline
+# snapshot is produced by the real `bintrail baseline` converter over a
+# hand-written mydumper-format dump. The scenarios reach it through the
+# "byo-idx" registry server; the daemon-level --baseline-dir makes that server
+# reconstruct-capable (Time-travel).
 #
 # Usage:  test/console-e2e/run.sh
 # Env:
@@ -21,7 +29,10 @@ MYSQL_CONTAINER="${MYSQL_CONTAINER:-bintrail-test-mysql}"
 PORT="${E2E_PORT:-8090}"
 TOKEN="${E2E_TOKEN:-e2e-console-token}"
 IDX_DB="bintrail_e2e_idx"
+FIX_SCHEMA="e2eshop"
 SERVERS_FILE="$(mktemp -t console-e2e-servers.XXXXXX.yaml)"
+DUMP_DIR="$(mktemp -d -t console-e2e-dump.XXXXXX)"
+BASELINE_ROOT="$(mktemp -d -t console-e2e-baseline.XXXXXX)"
 export E2E_ARTIFACT_DIR="${E2E_ARTIFACT_DIR:-${RUNNER_TEMP:-/tmp}}"
 
 mysql_exec() { docker exec -i "$MYSQL_CONTAINER" mysql -uroot -ptestroot "$@" 2>/dev/null; }
@@ -31,6 +42,7 @@ cleanup() {
   [ -n "$DAEMON_PID" ] && kill "$DAEMON_PID" 2>/dev/null || true
   mysql_exec -e "DROP DATABASE IF EXISTS $IDX_DB;" >/dev/null 2>&1 || true
   rm -f "$SERVERS_FILE" 2>/dev/null || true
+  rm -rf "$DUMP_DIR" "$BASELINE_ROOT" 2>/dev/null || true
 }
 trap cleanup EXIT
 
@@ -41,15 +53,89 @@ if [ -z "$CONSOLE_BIN" ]; then
   (cd "$ROOT" && go build -o "$CONSOLE_BIN" ./cmd/bintrail-console)
 fi
 
+echo "==> build bintrail (fixture provisioning: init + baseline conversion)"
+CLI_BIN="$ROOT/bintrail"
+(cd "$ROOT" && go build -o "$CLI_BIN" ./cmd/bintrail)
+
 echo "==> fresh index database $IDX_DB"
 mysql_exec -e "DROP DATABASE IF EXISTS $IDX_DB; CREATE DATABASE $IDX_DB;"
 
+# Fixture timestamps, anchored in the PREVIOUS UTC hour so the whole event
+# window (baseline anchor -> reconstruct `at`) lives inside one hour whose
+# partition exists — the planner classifies hours without a named partition as
+# gaps (p_future doesn't count), and a gap 422s the strict Time-travel path.
+# Computed with node (already required by this harness) because BSD and GNU
+# `date` disagree on relative-time flags.
+IFS='|' read -r P_HOUR H_HOUR H_NEXT PN_P PN_H TS_SNAP TS_INS TS_UPD TS_DEL TT_AT <<EOF
+$(node -e '
+const H = new Date(); H.setUTCMinutes(0, 0, 0);
+const P = new Date(H.getTime() - 3600e3), N = new Date(H.getTime() + 3600e3);
+const f = (d) => d.toISOString().slice(0, 19).replace("T", " ");
+const pn = (d) => "p_" + d.toISOString().slice(0, 13).replace(/[-T]/g, "");
+const m = (min) => f(new Date(P.getTime() + min * 60e3));
+console.log([f(P), f(H), f(N), pn(P), pn(H), m(5), m(10), m(20), m(30), m(35)].join("|"));')
+EOF
+
+echo "==> provision the boot index with the production schema (bintrail init)"
+"$CLI_BIN" init --index-dsn "${BASE_DSN}/${IDX_DB}" --partitions 4 >/dev/null
+
+# init partitions forward from the current hour; the fixture events live in the
+# PREVIOUS hour, so split the first partition to give that hour a named one.
+mysql_exec "$IDX_DB" -e "ALTER TABLE binlog_events REORGANIZE PARTITION $PN_H INTO (
+  PARTITION $PN_P VALUES LESS THAN (TO_SECONDS('$H_HOUR')),
+  PARTITION $PN_H VALUES LESS THAN (TO_SECONDS('$H_NEXT')));"
+
+echo "==> seed row events + cascade fixture into $IDX_DB"
+# Mirrors internal/console's seedCascadeConsole plus an orders lifecycle. The
+# UPDATE carries query_text/query_hash (a canary the frontend must NEVER see —
+# they are redacted at the DTO layer) and connection_id=777 (which MUST pass
+# through since #701 D1). The cascade child deletes are deliberately NOT
+# indexed — that blind spot is what /api/recover's cascade synthesis repairs.
+mysql_exec "$IDX_DB" <<SQL
+INSERT INTO schema_snapshots (snapshot_id, snapshot_time, schema_name, table_name, column_name, ordinal_position, column_key, data_type, is_nullable) VALUES
+  (1,'$P_HOUR','$FIX_SCHEMA','orders','id',1,'PRI','int','NO'),
+  (1,'$P_HOUR','$FIX_SCHEMA','orders','status',2,'','varchar','YES'),
+  (1,'$P_HOUR','$FIX_SCHEMA','orders','email',3,'','varchar','YES'),
+  (1,'$P_HOUR','$FIX_SCHEMA','parent','id',1,'PRI','int','NO'),
+  (1,'$P_HOUR','$FIX_SCHEMA','child','id',1,'PRI','int','NO'),
+  (1,'$P_HOUR','$FIX_SCHEMA','child','pid',2,'','int','YES');
+INSERT INTO binlog_events (binlog_file, start_pos, end_pos, event_timestamp, connection_id, schema_name, table_name, event_type, pk_values, changed_columns, row_before, row_after, query_text, query_hash) VALUES
+  ('binlog.000001',100,200,'$TS_INS',NULL,'$FIX_SCHEMA','orders',1,'3',NULL,NULL,'{"id":3,"status":"new","email":"c@example.com"}',NULL,NULL),
+  ('binlog.000001',200,300,'$TS_UPD',777,'$FIX_SCHEMA','orders',2,'1','["status"]','{"id":1,"status":"new","email":"a@example.com"}','{"id":1,"status":"shipped","email":"a@example.com"}','UPDATE orders SET status = ''shipped'' /* e2e-canary-query-text */',SHA2('e2e-canary-query-text',256)),
+  ('binlog.000001',300,400,'$TS_DEL',NULL,'$FIX_SCHEMA','orders',3,'2',NULL,'{"id":2,"status":"new","email":"b@example.com"}',NULL,NULL,NULL),
+  ('binlog.000001',400,500,'$TS_INS',NULL,'$FIX_SCHEMA','child',1,'10',NULL,NULL,'{"id":10,"pid":1}',NULL,NULL),
+  ('binlog.000001',500,600,'$TS_INS',NULL,'$FIX_SCHEMA','child',1,'11',NULL,NULL,'{"id":11,"pid":1}',NULL,NULL),
+  ('binlog.000001',600,700,'$TS_UPD',NULL,'$FIX_SCHEMA','parent',3,'1',NULL,'{"id":1}',NULL,NULL,NULL);
+INSERT INTO fk_constraints (snapshot_id, constraint_name, schema_name, table_name, column_name, ordinal_position, referenced_schema_name, referenced_table_name, referenced_column_name, delete_rule, update_rule) VALUES
+  (1,'fk_child_parent','$FIX_SCHEMA','child','pid',1,'$FIX_SCHEMA','parent','id','CASCADE','RESTRICT');
+SQL
+
+echo "==> build a baseline snapshot (real 'bintrail baseline' over a mydumper-format dump)"
+# Baseline rows 1 and 2 predate the events above (anchor binlog.000001:50 at
+# TS_SNAP); row 4 is never touched by any event — Time-travel resolving it
+# proves the baseline half of baseline+deltas, not just the event fold.
+# The tab before Log:/Pos: is load-bearing (ParseMetadata cuts "\tLog: ").
+printf 'Started dump at: %s\nSHOW MASTER STATUS:\n\tLog: binlog.000001\n\tPos: 50\nFinished dump at: %s\n' "$TS_SNAP" "$TS_SNAP" > "$DUMP_DIR/metadata"
+cat > "$DUMP_DIR/$FIX_SCHEMA.orders-schema.sql" <<'SQL'
+CREATE TABLE `orders` (
+  `id` int NOT NULL,
+  `status` varchar(32) DEFAULT NULL,
+  `email` varchar(128) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL
+cat > "$DUMP_DIR/$FIX_SCHEMA.orders.00000.sql" <<'SQL'
+INSERT INTO `orders` VALUES (1,"new","a@example.com"),(2,"new","b@example.com"),(4,"new","d@example.com");
+SQL
+"$CLI_BIN" baseline --input "$DUMP_DIR" --output "$BASELINE_ROOT" >/dev/null
+
 echo "==> launch source-less watch daemon on :$PORT"
-BINTRAIL_CONSOLE_TOKEN="$TOKEN" "$CONSOLE_BIN" watch \
+BINTRAIL_CONSOLE_TOKEN="$TOKEN" BINTRAIL_CONSOLE_BASELINE_TRIGGER=1 "$CONSOLE_BIN" watch \
   --index-dsn "${BASE_DSN}/${IDX_DB}" \
   --console-listen "127.0.0.1:$PORT" \
   --console-token "$TOKEN" \
   --console-servers-file "$SERVERS_FILE" \
+  --baseline-dir "$BASELINE_ROOT" \
   --console-allow-setup >"$E2E_ARTIFACT_DIR/console-e2e-daemon.log" 2>&1 &
 DAEMON_PID=$!
 
@@ -77,4 +163,5 @@ fi
 
 echo "==> drive headless Chrome"
 cd "$HERE"
-CONSOLE_URL="http://127.0.0.1:$PORT" CONSOLE_TOKEN="$TOKEN" node console_e2e.mjs
+CONSOLE_URL="http://127.0.0.1:$PORT" CONSOLE_TOKEN="$TOKEN" \
+  E2E_FIX_SCHEMA="$FIX_SCHEMA" E2E_TT_AT="$TT_AT" node console_e2e.mjs


### PR DESCRIPTION
## What

The console e2e harness only ever exercised broken-state renders and pure fixture-driven functions. This PR gives the workflows the console exists for their first browser coverage, per the grooming note on #970 (one PR, one fixture/daemon for #970 + #686 + #619):

- **run.sh** provisions the boot index as a real read fixture: `bintrail init` (production schema), seeded row events + cascade fixture in **real hourly partitions** (the previous hour's partition is split out of init's first one — the planner classifies unnamed hours as gaps, and a gap 422s strict reconstruct), and a baseline snapshot produced by the **real `bintrail baseline` converter** over a hand-written mydumper-format dump. The daemon gains `--baseline-dir` + `BINTRAIL_CONSOLE_BASELINE_TRIGGER=1`.
- **Events + export (#970)**: rows render, the diff expands, and the seeded `query_text`/`query_hash` canary never reaches the DOM or the JSON/CSV blobs (captured at `URL.createObjectURL` off the real buttons) — while `connection_id` **passes through**, per #701 D1 (the issue's original "assert connection_id absent" is the stale pre-#701 contract). CSV header pinned in lockstep with `EVENT_CSV_COLUMNS`.
- **Recover (#970) + cascade banner (#619)**: a real submit renders the reversal SQL; the cascade fixture drives `cascade_detected` and the banner/counts meta — the block whose missing `)` once broke the whole SPA with only a manual boot probe to catch it.
- **Time-travel (#970)**: capability gate both ways, event-over-baseline fold, a baseline-only row (pins the baseline half of baseline+deltas), and a deleted row. `at` is pinned inside the partitioned hour so the scenario never races the top-of-hour boundary.
- **Overview + Storage (#686)**: window line uses the fetched window's own bounds (never `status.coverage`), and the Create-baseline button's three gate arms.

## Frontend bug found and fixed

Driving Events right after a server switch exposed a real bug invisible to the Go suite: `renderOverview`/`renderStatus`/`renderStorage` guard their async completion only on `serverGen`, so navigating to another route mid-fetch let the OLD view clear and repaint over the new one (nav highlighting Events, content showing Overview — screenshot from the failing run confirmed it). Fixed with a `viewGen` bumped in `renderRoute`, mirrored into those three guards. The new Events scenario is the regression guard: it fails without the fix.

## Testing

- `make console-e2e`: 109/109 (78 existing + 31 new assertions)
- `go test ./internal/console/`: ok

Closes #970. Closes #686. Closes #619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
