### PR TITLE
ci: boot-test the demo image on both arches before tagging and signing

### DIFF
--- a/.github/workflows/demo-image.yml
+++ b/.github/workflows/demo-image.yml
@@ -15,9 +15,11 @@
 # runner (the `smoke` job, reusing demo/image/smoke-test.sh) before
 # `merge` tags and cosign-signs the manifest list. The build proves the
 # image compiles; the demo's real failure modes are runtime-only
-# (Percona apt drift, entrypoint ordering, ProxySQL handshake), so a
-# tag must not exist until the container has answered the acceptance
-# time-travel query on both arches.
+# (Percona apt drift, entrypoint ordering, ProxySQL handshake), so the
+# GHCR image tag must not exist until the container has answered the
+# acceptance time-travel query on both arches. (The v* GIT tag triggers
+# this workflow, so it necessarily already exists — what the gate
+# withholds is the image tag and the signature.)
 #
 # NOTE: like ghcr.io/dbtrail/bintrail, the bintrail-demo package is
 # created PRIVATE on first push and needs a one-time manual flip to
@@ -56,6 +58,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Keep in sync with the `smoke` job's matrix: `merge` publishes
+        # EVERY digest artifact (pattern: digests-*), but only the
+        # platforms listed THERE get boot-tested — an arch added here
+        # alone would ship unsmoked.
         include:
           - platform: linux/amd64
             runner: ubuntu-22.04
@@ -130,16 +136,24 @@ jobs:
   # to testing the final index: `imagetools create` in `merge` only
   # assembles pointers to these same digests. Gating BEFORE merge is
   # strictly stronger than the issue's "fail before cosign-signing":
-  # on a boot failure the version tag is never created at all.
+  # on a boot failure the version IMAGE tag (:X.Y.Z / :latest) is never
+  # created at all.
   smoke:
     runs-on: ${{ matrix.runner }}
     needs: build
+    # smoke-test.sh self-bounds at ~6 min, but the ghcr pull and the
+    # docker execs are unbounded — without this, a hung pull presents
+    # as "stuck" for the 6h default while gating the publish.
+    timeout-minutes: 15
     permissions:
       contents: read # checkout: smoke-test.sh + the demo/image/ files its static guards grep
       packages: read # pull the per-arch image by digest from ghcr.io
     strategy:
       fail-fast: false
       matrix:
+        # Keep in sync with the `build` job's matrix — an arch built but
+        # not listed here would be published by `merge` without ever
+        # having booted.
         include:
           - platform: linux/amd64
             runner: ubuntu-22.04

--- a/.github/workflows/demo-image.yml
+++ b/.github/workflows/demo-image.yml
@@ -11,6 +11,14 @@
 # Manual runs take an explicit existing tag (workflow_dispatch input) so
 # a dispatch can never publish an unversioned branch build.
 #
+# Publish gate (#971): each arch's pushed digest is BOOTED on its native
+# runner (the `smoke` job, reusing demo/image/smoke-test.sh) before
+# `merge` tags and cosign-signs the manifest list. The build proves the
+# image compiles; the demo's real failure modes are runtime-only
+# (Percona apt drift, entrypoint ordering, ProxySQL handshake), so a
+# tag must not exist until the container has answered the acceptance
+# time-travel query on both arches.
+#
 # NOTE: like ghcr.io/dbtrail/bintrail, the bintrail-demo package is
 # created PRIVATE on first push and needs a one-time manual flip to
 # public before anonymous `docker run` works (see docs/docker.md).
@@ -114,9 +122,81 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # Boot-test each arch's pushed digest on its NATIVE runner before
+  # anything is tagged or signed (#971). Reuses demo/image/smoke-test.sh
+  # (SKIP_BUILD=1 + IMAGE=<ref>@<digest>) instead of re-encoding the
+  # readiness/time-travel checks in YAML — a second copy of the same
+  # check is how guards rot. Testing the per-arch digests is equivalent
+  # to testing the final index: `imagetools create` in `merge` only
+  # assembles pointers to these same digests. Gating BEFORE merge is
+  # strictly stronger than the issue's "fail before cosign-signing":
+  # on a boot failure the version tag is never created at all.
+  smoke:
+    runs-on: ${{ matrix.runner }}
+    needs: build
+    permissions:
+      contents: read # checkout: smoke-test.sh + the demo/image/ files its static guards grep
+      packages: read # pull the per-arch image by digest from ghcr.io
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-22.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Prepare platform slug
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          # Same tree the build legs used (see the build job's checkout).
+          ref: ${{ inputs.tag || github.ref }}
+
+      # This leg's digest travels as the artifact's FILENAME (see the
+      # build job's "Export digest"). download-artifact fails loudly if
+      # the named artifact is missing.
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests
+
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Boot the pushed digest and run the smoke test
+        run: |
+          set -euo pipefail
+          # failglob: an empty digests dir aborts here (same guard as the
+          # merge job) instead of smoking a bogus ref.
+          shopt -s failglob
+          files=("${{ runner.temp }}/digests"/*)
+          [[ ${#files[@]} -eq 1 ]] || { echo "expected exactly one digest file, got ${#files[@]}: ${files[*]}"; exit 1; }
+          DIGEST="sha256:$(basename "${files[0]}")"
+          [[ "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo "unexpected digest: '$DIGEST'"; exit 1; }
+          # smoke-test.sh drives its acceptance queries with the mysql
+          # client; not every runner image ships it (arm in particular).
+          command -v mysql >/dev/null || {
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq mysql-client
+          }
+          # SKIP_BUILD=1 runs the EXACT bytes the build leg pushed —
+          # `docker run` pulls the digest ref on its own. The script
+          # boots the container, waits for the stack, checks the
+          # telemetry guard, and asserts all three time-travel forms.
+          SKIP_BUILD=1 IMAGE="${IMAGE}@${DIGEST}" demo/image/smoke-test.sh
+
   merge:
     runs-on: ubuntu-22.04
-    needs: build
+    # smoke: no tag, no signature, unless both arches booted and served
+    # the acceptance query (#971).
+    needs: [build, smoke]
     permissions:
       packages: write # push the merged manifest list to ghcr.io
       id-token: write # cosign keyless signing via GitHub OIDC

--- a/demo/image/smoke-test.sh
+++ b/demo/image/smoke-test.sh
@@ -95,11 +95,15 @@ log "bintrail processes: ${TOTAL:-0}, of them with DO_NOT_TRACK=1: ${GUARDED:-0}
 [ "${TOTAL:-0}" = "${GUARDED:-0}" ] \
     || { log "FAIL: $((TOTAL - GUARDED)) bintrail process(es) missing DO_NOT_TRACK=1"; exit 1; }
 
-LIVE=$(mysql_demo "SELECT status, total FROM orders WHERE id = 1")
+# `|| true` on the substitutions below: a client/shim ERROR becomes an
+# empty string so the labeled [ -n ] assertion reports it (same idiom
+# as BARE/HINT) — without it, errexit kills the script with zero
+# diagnostics, which matters now that CI gates publishing on this.
+LIVE=$(mysql_demo "SELECT status, total FROM orders WHERE id = 1" || true)
 log "live row:        ${LIVE:-<empty>}"
 [ -n "$LIVE" ] || { log "FAIL: live row missing"; exit 1; }
 
-PAST=$(mysql_demo "SELECT status, total FROM _flashback.orders AS OF '1 minute ago' WHERE id = 1")
+PAST=$(mysql_demo "SELECT status, total FROM _flashback.orders AS OF '1 minute ago' WHERE id = 1" || true)
 log "row 1 minute ago (virtual): ${PAST:-<empty>}"
 
 # The bare tagline form (#385): time-travel on the REAL table name —

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -90,6 +90,10 @@ docker run --rm -p 6033:6033 bintrail-demo
 `demo/image/smoke-test.sh` builds, boots, and asserts the acceptance flow
 (time-travel returns a previous `orders id=1` state distinct from the live
 row). It needs Docker and ~3 minutes; it is not part of `go test ./...`.
+CI runs this same script against each architecture's pushed image before
+a release tag is published or signed (the `smoke` job in
+`.github/workflows/demo-image.yml`), so a published demo image is one
+that has actually booted.
 
 ## Troubleshooting
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -91,7 +91,7 @@ docker run --rm -p 6033:6033 bintrail-demo
 (time-travel returns a previous `orders id=1` state distinct from the live
 row). It needs Docker and ~3 minutes; it is not part of `go test ./...`.
 CI runs this same script against each architecture's pushed image before
-a release tag is published or signed (the `smoke` job in
+the demo image is tagged and signed in GHCR (the `smoke` job in
 `.github/workflows/demo-image.yml`), so a published demo image is one
 that has actually booted.
 


### PR DESCRIPTION
closes #971

## Summary
- `demo-image.yml` published and cosign-signed the evaluation image without ever booting it; its real failure modes are runtime-only (Percona apt drift, entrypoint ordering, ProxySQL handshake) — exactly the class that shipped broken in #605.
- New `smoke` job between `build` and `merge`: each arch's pushed digest is booted on its **native** runner, reusing the existing `demo/image/smoke-test.sh` (`SKIP_BUILD=1 IMAGE=<ref>@<digest>`) instead of re-encoding readiness/time-travel checks in YAML. The script waits for the stack, checks the telemetry guard, and asserts all three time-travel forms.
- `merge` now `needs: [build, smoke]` — on a boot failure the version tag is never created, which is strictly stronger than the issue's "fail before cosign-signing". Testing the per-arch digests is equivalent to testing the final index: `imagetools create` only assembles pointers to these same digests.
- `docs/demo.md`: notes that CI runs the same smoke script per arch before a tag is published or signed.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `actionlint` clean on the edited workflow
- [ ] Next `v*` tag (or a `workflow_dispatch` on an existing tag) exercises the smoke legs for real

🤖 Generated with [Claude Code](https://claude.com/claude-code)
