### PR TITLE
baseline: find the VALUES keyword at statement level, not by substring

### DIFF
--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -438,6 +438,104 @@ func TestReadSQLRow(t *testing.T) {
 	}
 }
 
+// TestReadSQLRowIdentifierEmbeddedSpace pins #502: a backtick-quoted table or
+// column identifier with an embedded space (`Allowed Values`, `sensor values`)
+// contains the substring " VALUES" before the real keyword. The pre-fix naive
+// substring search sliced mid-identifier — silently dropping the first row of
+// a multi-line INSERT, or rejecting a single-line file as truncated. The
+// VALUES finder must skip quoted identifiers and match only the keyword.
+func TestReadSQLRowIdentifierEmbeddedSpace(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+		want [][]string
+	}{
+		{
+			// Multi-line (mydumper native layout): pre-fix this returned rows
+			// (2,b),(3,c) — the first row lost with a clean exit.
+			name: "column with embedded space, multi-line",
+			sql:  "INSERT INTO `settings` (`id`,`Allowed Values`) VALUES(1,'a')\n,(2,'b')\n,(3,'c');\n",
+			want: [][]string{{"1", "a"}, {"2", "b"}, {"3", "c"}},
+		},
+		{
+			name: "table with embedded space, multi-line",
+			sql:  "INSERT INTO `sensor values` VALUES(1)\n,(2)\n,(3);\n",
+			want: [][]string{{"1"}, {"2"}, {"3"}},
+		},
+		{
+			// Single-line (mysqldump extended-insert): pre-fix this errored as
+			// "unterminated INSERT statement" and produced zero rows.
+			name: "column with embedded space, single-line",
+			sql:  "INSERT INTO `config` (`k`,`Default Values`) VALUES (1,'x'),(2,'y'),(3,'z');\n",
+			want: [][]string{{"1", "x"}, {"2", "y"}, {"3", "z"}},
+		},
+		{
+			// A doubled backtick is MySQL's escape for a literal backtick INSIDE
+			// a quoted identifier — the skip must not treat it as the closer.
+			name: "escaped backtick inside identifier",
+			sql:  "INSERT INTO `a``b values` VALUES(7,'q');\n",
+			want: [][]string{{"7", "q"}},
+		},
+		{
+			name: "REPLACE with embedded-space column",
+			sql:  "REPLACE INTO `settings` (`id`,`Allowed Values`) VALUES(9,'r');\n",
+			want: [][]string{{"9", "r"}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "shop.t.00000.sql")
+			if err := os.WriteFile(path, []byte(tc.sql), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			var rows [][]string
+			if err := ReadSQLFile(path, func(values []string, nulls []bool) error {
+				rows = append(rows, append([]string(nil), values...))
+				return nil
+			}); err != nil {
+				t.Fatalf("ReadSQLFile: %v", err)
+			}
+			if len(rows) != len(tc.want) {
+				t.Fatalf("got %d rows %v, want %d", len(rows), rows, len(tc.want))
+			}
+			for i := range tc.want {
+				for j := range tc.want[i] {
+					if rows[i][j] != tc.want[i][j] {
+						t.Errorf("row %d col %d = %q, want %q", i, j, rows[i][j], tc.want[i][j])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestFindValuesKeyword(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want int // -1 = not found; otherwise the offset of 'V'
+	}{
+		{"plain", "INSERT INTO `t` VALUES(1)", 16},
+		{"lowercase keyword", "insert into `t` values(1)", 16},
+		{"no space before paren", "INSERT INTO `t` (`a`) VALUES(1)", 22},
+		{"embedded-space identifier skipped", "INSERT INTO `sensor values` VALUES(1)", 28},
+		{"escaped backtick inside identifier", "INSERT INTO `a``b values` VALUES(1)", 26},
+		{"suffix of longer word ignored", "INSERT INTO NVALUES VALUES(1)", 20},
+		{"prefix of longer word ignored", "INSERT INTO VALUESX VALUES(1)", 20},
+		{"dollar-joined word ignored", "INSERT INTO a$VALUES VALUES(1)", 21},
+		{"no keyword", "INSERT INTO `t` (`a`,`b`)", -1},
+		{"unterminated backtick reads to end", "INSERT INTO `sensor values", -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := findValuesKeyword(tc.in); got != tc.want {
+				t.Errorf("findValuesKeyword(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestReadSQLRowEscaping(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/baseline/reader_sql.go
+++ b/internal/baseline/reader_sql.go
@@ -95,7 +95,7 @@ func readSQLLine(path string, lineNum int, line string, inStatement *bool, fn fu
 			return nil
 		}
 		// Find VALUES keyword (after any column list).
-		valIdx := strings.Index(upper, " VALUES")
+		valIdx := findValuesKeyword(trimmed)
 		if valIdx < 0 {
 			// The line opens an INSERT/REPLACE but carries no VALUES clause.
 			// In a complete mydumper/mysqldump data file every INSERT/REPLACE
@@ -110,7 +110,7 @@ func readSQLLine(path string, lineNum int, line string, inStatement *bool, fn fu
 				"— dump file may be truncated or in an unsupported layout: %q",
 				path, lineNum, truncateForError(trimmed))
 		}
-		fragment = strings.TrimSpace(trimmed[valIdx+7:])
+		fragment = strings.TrimSpace(trimmed[valIdx+len("VALUES"):])
 	}
 
 	terminated, err := parseSQLTuples(fragment, fn)
@@ -119,6 +119,58 @@ func readSQLLine(path string, lineNum int, line string, inStatement *bool, fn fu
 	}
 	*inStatement = !terminated
 	return nil
+}
+
+// findValuesKeyword returns the byte offset of the statement-level VALUES
+// keyword in an INSERT/REPLACE line, or -1 when there is none.
+//
+// A naive substring search for " VALUES" (the pre-#502 code) returns the FIRST
+// occurrence, which can land INSIDE a backtick-quoted identifier with an
+// embedded space (`Allowed Values`, `sensor values`): slicing there starts the
+// tuple parser mid-identifier, which silently drops the first row of a
+// multi-line INSERT or rejects a single-line file as "truncated". So scan at
+// statement level: backtick-quoted identifiers are skipped whole (a doubled
+// backtick is MySQL's escape for a literal one inside), and VALUES matches
+// only as a standalone word. Everything before the real keyword is
+// identifiers, keywords, and the (col, …) list — dumps quote every identifier,
+// and VALUES is a reserved word, so an unquoted statement-level match is
+// always the keyword. An unterminated backtick (a line truncated
+// mid-identifier) runs to end-of-line and reports "no VALUES", which routes
+// into the loud truncated-dump error at the call site.
+func findValuesKeyword(s string) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '`' {
+			for i++; i < len(s); i++ {
+				if s[i] == '`' {
+					if i+1 < len(s) && s[i+1] == '`' {
+						i++ // `` — escaped backtick, still inside the identifier
+						continue
+					}
+					break // closing backtick; the outer i++ steps past it
+				}
+			}
+			continue
+		}
+		if !hasPrefixFold(s[i:], "VALUES") {
+			continue
+		}
+		// Word boundaries on both sides, so a suffix ("NVALUES") or prefix
+		// ("VALUESX") of a longer unquoted token never matches.
+		if i > 0 && isWordByte(s[i-1]) {
+			continue
+		}
+		if i+len("VALUES") < len(s) && isWordByte(s[i+len("VALUES")]) {
+			continue
+		}
+		return i
+	}
+	return -1
+}
+
+// isWordByte reports whether c can be part of an unquoted MySQL identifier
+// (the word-boundary test for findValuesKeyword; '$' is legal in identifiers).
+func isWordByte(c byte) bool {
+	return isIdentByte(c) || c == '$'
 }
 
 // truncateForError caps a line excerpt used in an error message so a long


### PR DESCRIPTION
## What

`ReadSQLFile` located the `VALUES` keyword with `strings.Index(upper, " VALUES")` — the first occurrence, which can land **inside a backtick-quoted identifier with an embedded space** (`` `Allowed Values` ``, `` `sensor values` ``). Slicing there started the tuple parser mid-identifier:

- multi-line (mydumper native layout): the first row of the statement was **silently dropped** (clean exit, short count),
- single-line (mysqldump extended-insert): the whole file was rejected as `unterminated INSERT statement (missing ';')` with zero rows.

`findValuesKeyword` scans at statement level instead: backtick-quoted identifiers are skipped whole (`` `` `` is MySQL's escape for a literal backtick inside), and `VALUES` matches only as a standalone word (boundary check on both sides; `$` counts as an identifier byte). Dumps quote every identifier and `VALUES` is a reserved word, so an unquoted statement-level match is always the keyword. A line truncated mid-identifier (unterminated backtick) reads to end-of-line and reports "no VALUES", routing into the existing loud truncated-dump error — truncation still fails closed.

## Testing

- `TestReadSQLRowIdentifierEmbeddedSpace`: the three repros from the issue (verbatim inputs) + escaped-backtick identifier + REPLACE variant, through real files and `ReadSQLFile`.
- `TestFindValuesKeyword`: word-boundary and quoting edges (`NVALUES`/`VALUESX`/`a$VALUES` never match; unterminated backtick → -1).
- **Mutation-verified**: reverting to the naive `strings.Index` makes the new tests fail with the exact issue symptoms (silent 2-of-3 rows / `unexpected token '`'`); `go test ./internal/baseline/` full package green with the fix.

Closes #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
