### PR TITLE
cli: name the archive-reconcile remedy in the GapError hint for recover/reconstruct

### DIFF
--- a/internal/cli/reconstruct.go
+++ b/internal/cli/reconstruct.go
@@ -443,7 +443,10 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 		// (query.GapError, query.SourceEmptyError) stay command-neutral.
 		var gapErr *query.GapError
 		if errors.As(err, &gapErr) {
-			return fmt.Errorf("%w; pass --allow-gaps to proceed with an incomplete reconstruction", err)
+			// The rebuilt-index case (archive_state empty, hours rotated out of
+			// MySQL) also lands here; name the non-lossy remedy before the
+			// lossy one (#961).
+			return fmt.Errorf("%w; if the index was rebuilt and archives exist in storage, run `bintrail archive reconcile --repair --archive-s3 s3://...` (or --archive-dir) to repopulate archive_state and retry, or pass --allow-gaps to proceed with an incomplete reconstruction", err)
 		}
 		var emptyErr *query.SourceEmptyError
 		if errors.As(err, &emptyErr) {

--- a/internal/cli/reconstruct.go
+++ b/internal/cli/reconstruct.go
@@ -446,7 +446,7 @@ func runReconstruct(cmd *cobra.Command, args []string) error {
 			// The rebuilt-index case (archive_state empty, hours rotated out of
 			// MySQL) also lands here; name the non-lossy remedy before the
 			// lossy one (#961).
-			return fmt.Errorf("%w; if the index was rebuilt and archives exist in storage, run `bintrail archive reconcile --repair --archive-s3 s3://...` (or --archive-dir) to repopulate archive_state and retry, or pass --allow-gaps to proceed with an incomplete reconstruction", err)
+			return fmt.Errorf("%w; gap detection reads archive_state, so a rebuilt index reports already-archived hours as gaps too — if archives exist in storage, run `bintrail archive reconcile --repair --index-dsn ... --archive-s3 s3://...` (or --archive-dir) to repopulate archive_state and retry, or pass --allow-gaps to proceed with an incomplete reconstruction", err)
 		}
 		var emptyErr *query.SourceEmptyError
 		if errors.As(err, &emptyErr) {

--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -353,7 +353,7 @@ func runRecover(cmd *cobra.Command, args []string) error {
 			// The rebuilt-index case (archive_state empty, hours rotated out of
 			// MySQL) also lands here; name the non-lossy remedy before the
 			// lossy one (#961).
-			return fmt.Errorf("%w; if the index was rebuilt and archives exist in storage, run `bintrail archive reconcile --repair --archive-s3 s3://...` (or --archive-dir) to repopulate archive_state and retry, or pass --allow-gaps to proceed with a possibly incomplete recovery", err)
+			return fmt.Errorf("%w; gap detection reads archive_state, so a rebuilt index reports already-archived hours as gaps too — if archives exist in storage, run `bintrail archive reconcile --repair --index-dsn ... --archive-s3 s3://...` (or --archive-dir) to repopulate archive_state and retry, or pass --allow-gaps to proceed with a possibly incomplete recovery", err)
 		}
 		var emptyErr *query.SourceEmptyError
 		if errors.As(err, &emptyErr) {

--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -350,7 +350,10 @@ func runRecover(cmd *cobra.Command, args []string) error {
 		// (query.GapError, query.SourceEmptyError) stay command-neutral.
 		var gapErr *query.GapError
 		if errors.As(err, &gapErr) {
-			return fmt.Errorf("%w; pass --allow-gaps to proceed with a possibly incomplete recovery", err)
+			// The rebuilt-index case (archive_state empty, hours rotated out of
+			// MySQL) also lands here; name the non-lossy remedy before the
+			// lossy one (#961).
+			return fmt.Errorf("%w; if the index was rebuilt and archives exist in storage, run `bintrail archive reconcile --repair --archive-s3 s3://...` (or --archive-dir) to repopulate archive_state and retry, or pass --allow-gaps to proceed with a possibly incomplete recovery", err)
 		}
 		var emptyErr *query.SourceEmptyError
 		if errors.As(err, &emptyErr) {


### PR DESCRIPTION
closes #961

## Summary
- The rebuilt-index scenario (`archive_state` empty, hours rotated out of MySQL) surfaces as a planner `*query.GapError`, and the CLI hint on that branch only suggested `--allow-gaps` — a possibly incomplete result — when full coverage was one `archive reconcile --repair` away.
- Extends the two mute `GapError` messages (`internal/cli/recover.go`, single-row `internal/cli/reconstruct.go`) to name the non-lossy remedy first: `bintrail archive reconcile --repair --archive-s3 s3://...` (or `--archive-dir`), then retry; `--allow-gaps` stays as the fallback.
- Wording matches the pattern the `SourceEmptyError` branches already use in both files.

## Scope notes (per the 2026-08-02 grooming comment)
- `GapError.Error()` stays command-neutral in `internal/query` — remediation lives at the CLI layer only.
- The `query` command has no `GapError` branch (nothing to change there).
- Full-table reconstruct handles gaps via `cfg.AllowGaps` inside `ReconstructTables` — no CLI `GapError` branch to touch.
- No docs change needed: `docs/index-recovery.md` already documents the reconcile step for a rebuilt index.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `go vet ./...`, `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)