### PR TITLE
reconstruct/verify: refuse generated PK members up front (MariaDB system versioning)

### DIFF
--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -537,6 +537,14 @@ The resolver is loaded best-effort in the `recover` command — a failure logs a
 
 Generated columns (`STORED` or `VIRTUAL`) are computed by MySQL and cannot be set explicitly, so the generated script skips them in `INSERT`/`UPDATE` SET clauses — the script won't fail trying to assign a value MySQL owns.
 
+### System-versioned tables (MariaDB)
+
+MariaDB silently extends a system-versioned table's `PRIMARY KEY` with its `ROW END` period column (`PRIMARY KEY (id, row_end)`), and that column is generated — baselines never carry its values, and the binlog records history rows and versioned `DELETE`s under the same surviving key. Rendering such a table as a whole would risk emitting history rows as live data, so bintrail refuses instead:
+
+- **Full-table `reconstruct`** (baseline merge and binlog-only fallback alike) and the shim's **full-table `_flashback`/`_snapshot`** views refuse with an error naming the generated PK column.
+- **`verify`** reports the table as `inconclusive` — a permanent property of the table's shape, not a failure. A run scoped only to such tables still exits non-zero (nothing was proven).
+- **Still available**: `query` and `recover` are not gated, and single-row `reconstruct` works with an explicit column list, e.g. `--pk 1 --pk-columns id`.
+
 ### Column type encodings (BLOB/TEXT, GEOMETRY, VECTOR)
 
 Columns that MySQL delivers as raw bytes are stored base64-encoded in the index, so `recover` decodes them back to a loadable literal using the column type from the schema snapshot:

--- a/internal/baseline/schema.go
+++ b/internal/baseline/schema.go
@@ -115,10 +115,13 @@ var generatedRe = regexp.MustCompile(`(?i)\bAS\s*\(.*\)\s*(?:VIRTUAL|STORED|PERS
 // Known scope limit (#1266): MariaDB extends the table's PRIMARY KEY with the
 // ROW END column, and the schema snapshot keeps it (PKColumnMetas selects on
 // IsPK only), so FULL-TABLE reconstruct — and verify, which reconstructs —
-// still refuse such a table loudly at the PK-canonicalization step
-// (MissingPKColumnError: the baseline no longer carries the column). The
-// baseline itself, single-row reconstruct with --pk-columns, and the query
-// paths all work.
+// refuse such a table UP FRONT (reconstruct.GeneratedPKColumn gates both
+// full-table paths; verify reports it inconclusive rather than error).
+// Excluding the column from the join key instead would corrupt silently —
+// the binlog carries history rows and versioned deletes under the same
+// remaining key; see GeneratedPKColumn's comment for the MariaDB 11.4
+// evidence. The baseline itself, single-row reconstruct with --pk-columns,
+// and the query paths all work.
 var rowPeriodRe = regexp.MustCompile(`(?i)\bGENERATED\s+ALWAYS\s+AS\s+ROW\s+(?:START|END)\b`)
 
 // ParseSchema reads a mydumper <db>.<table>-schema.sql file and returns the

--- a/internal/cascadebaseline/provider.go
+++ b/internal/cascadebaseline/provider.go
@@ -91,6 +91,16 @@ func (p *Provider) BaselineChildren(ctx context.Context, schema, table, fkCol, p
 	if err != nil {
 		return cascade.BaselineLookup{}, false, fmt.Errorf("resolve %s.%s for baseline: %w", schema, table, err)
 	}
+	// A generated PK member — the MariaDB system-versioning shape (#1266) —
+	// cannot canonicalize against a baseline that omits the column; without
+	// this gate every row below dies with MissingPKColumnError and its
+	// misleading "run `bintrail snapshot` to refresh" remediation, which no
+	// re-snapshot can ever satisfy. Fail loud with the real cause instead,
+	// same stance as the fkFilterSafe refusal below.
+	if c, found := reconstruct.GeneratedPKColumn(tm.PKColumnMetas()); found {
+		return cascade.BaselineLookup{}, false, fmt.Errorf("baseline scan of %s.%s: %s",
+			schema, table, reconstruct.GeneratedPKGateReason(c, "the cascade baseline fallback"))
+	}
 	// The FK filter binds parentPK as a STRING against the baseline column.
 	// DuckDB coerces it exactly for integer/string FK columns, but for
 	// DATETIME/DECIMAL/DATE the string form may not match the stored value and

--- a/internal/cascadebaseline/provider_generatedpk_1266_test.go
+++ b/internal/cascadebaseline/provider_generatedpk_1266_test.go
@@ -1,0 +1,43 @@
+package cascadebaseline
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+)
+
+// TestProvider_generatedPKRefusesWithRealCause wires the #1266 gate through
+// the real BaselineChildren path: a system-versioned child table (PK silently
+// extended with the STORED GENERATED row_end period column) must fail loud
+// with the versioning-aware cause, never reach per-row canonicalization and
+// its misleading "run `bintrail snapshot` to refresh" remediation. The find
+// func returns a nonexistent path on purpose: metadata read is best-effort
+// (warn only), and the gate fires before ReadBaselineRows would die on the
+// path — so deleting the gate flips this test's error to the file-open one.
+func TestProvider_generatedPKRefusesWithRealCause(t *testing.T) {
+	find := func(ctx context.Context, schema, table string, at time.Time) (string, time.Time, reconstruct.StaleWarning, error) {
+		return "/nonexistent/baseline.parquet", time.Now().Add(-time.Hour), reconstruct.StaleWarning{}, nil
+	}
+	resolver := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"shop.child": {Schema: "shop", Table: "child", Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+			{Name: "pid", OrdinalPosition: 2, DataType: "int"},
+			{Name: "row_end", OrdinalPosition: 4, IsPK: true, DataType: "timestamp", ColumnType: "timestamp(6)", IsGenerated: true},
+		}},
+	})
+
+	_, _, err := New(find, resolver).BaselineChildren(context.Background(), "shop", "child", "pid", "1", time.Now(), 100)
+	if err == nil {
+		t.Fatal("expected the generated-PK refusal, got nil")
+	}
+	if !strings.Contains(err.Error(), "generated column") || !strings.Contains(err.Error(), `"row_end"`) {
+		t.Fatalf("want the generated-PK cause naming row_end, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "not in baseline row") {
+		t.Fatalf("must refuse before per-row canonicalization, not with MissingPKColumnError: %v", err)
+	}
+}

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -829,6 +829,9 @@ func ReconstructTable(
 	// so every probe row would die with MissingPKColumnError deep in the
 	// merge. Refuse up front with the versioning-aware message instead; see
 	// GeneratedPKColumn for why a reduced join key is NOT the fix.
+	// Deliberately AFTER the type loop: an empty DataType must keep winning
+	// the #1009 wrong-path verdict (PG-shaped snapshot on the MySQL path),
+	// which only the type gate discriminates.
 	if pkCol, ok := GeneratedPKColumn(pkCols); ok {
 		return nil, fullTableGeneratedPKRefusal(schema, table, pkCol)
 	}
@@ -1708,7 +1711,8 @@ func reconstructBinlogOnly(
 	if err != nil {
 		return nil, fmt.Errorf("resolve schema for %s.%s: %w; run `bintrail snapshot` to refresh", schema, table, err)
 	}
-	if len(tm.PKColumnMetas()) == 0 {
+	pkCols := tm.PKColumnMetas()
+	if len(pkCols) == 0 {
 		return nil, fmt.Errorf("%s.%s has no primary key in the loaded snapshot; full-table reconstruct requires a PK", schema, table)
 	}
 	// Same generated-PK gate as the baseline path (#1266), and this path is
@@ -1716,7 +1720,7 @@ func reconstructBinlogOnly(
 	// versioned table's history-row inserts fold under their own full
 	// pk_values and would be emitted as duplicate live rows (the output
 	// column list excludes generated columns, so nothing distinguishes them).
-	if pkCol, ok := GeneratedPKColumn(tm.PKColumnMetas()); ok {
+	if pkCol, ok := GeneratedPKColumn(pkCols); ok {
 		return nil, fullTableGeneratedPKRefusal(schema, table, pkCol)
 	}
 
@@ -1748,7 +1752,7 @@ func reconstructBinlogOnly(
 		Resolver: resolver,
 		Schema:   schema,
 		Table:    table,
-		PKCols:   tm.PKColumnMetas(),
+		PKCols:   pkCols,
 		Opts: query.Options{
 			Schema: schema,
 			Table:  table,
@@ -1794,7 +1798,7 @@ func reconstructBinlogOnly(
 	}
 
 	rep.BinlogOnly = true
-	if err := writeBinlogOnlyChanges(cfg.OutputDir, schema, table, tm.PKColumnMetas(), colNames, cfg.ChunkSize, createSQL, changes, rep); err != nil {
+	if err := writeBinlogOnlyChanges(cfg.OutputDir, schema, table, pkCols, colNames, cfg.ChunkSize, createSQL, changes, rep); err != nil {
 		return nil, err
 	}
 	rep.Duration = time.Since(start)

--- a/internal/reconstruct/fulltable.go
+++ b/internal/reconstruct/fulltable.go
@@ -824,6 +824,14 @@ func ReconstructTable(
 			return nil, fullTablePKTypeRefusal(schema, table, pkCol)
 		}
 	}
+	// A generated column inside the PK — the MariaDB system-versioning shape
+	// (#1266) — can never canonicalize: the baseline omits generated columns,
+	// so every probe row would die with MissingPKColumnError deep in the
+	// merge. Refuse up front with the versioning-aware message instead; see
+	// GeneratedPKColumn for why a reduced join key is NOT the fix.
+	if pkCol, ok := GeneratedPKColumn(pkCols); ok {
+		return nil, fullTableGeneratedPKRefusal(schema, table, pkCol)
+	}
 
 	// For DATETIME/TIMESTAMP PK columns, warn loudly if the column_type
 	// metadata is missing — the canonicalizer will fall back to a
@@ -1702,6 +1710,14 @@ func reconstructBinlogOnly(
 	}
 	if len(tm.PKColumnMetas()) == 0 {
 		return nil, fmt.Errorf("%s.%s has no primary key in the loaded snapshot; full-table reconstruct requires a PK", schema, table)
+	}
+	// Same generated-PK gate as the baseline path (#1266), and this path is
+	// MORE exposed, not less: with no baseline probe to fail loudly, a
+	// versioned table's history-row inserts fold under their own full
+	// pk_values and would be emitted as duplicate live rows (the output
+	// column list excludes generated columns, so nothing distinguishes them).
+	if pkCol, ok := GeneratedPKColumn(tm.PKColumnMetas()); ok {
+		return nil, fullTableGeneratedPKRefusal(schema, table, pkCol)
 	}
 
 	// Generated columns can't be set explicitly in an INSERT, so exclude them

--- a/internal/reconstruct/fulltable_generatedpk_1266_test.go
+++ b/internal/reconstruct/fulltable_generatedpk_1266_test.go
@@ -78,3 +78,31 @@ func TestReconstructTable_generatedPKRefusal_binlogOnlyPath(t *testing.T) {
 		t.Fatalf("want the generated-PK refusal naming row_end, got: %v", err)
 	}
 }
+
+// TestReconstructTable_emptyDataTypeKeepsWrongPathVerdict pins the gate
+// ORDERING the in-code comment claims: a PK member with an empty DataType —
+// the PG snapshot shape (#1009) — must keep winning the wrong-path verdict
+// even when it is ALSO marked generated. Swapping the generated gate above the
+// SupportedPKType loop would mask it with a MariaDB-shaped message; before
+// this test, that ordering was prose, not a guard.
+func TestReconstructTable_emptyDataTypeKeepsWrongPathVerdict(t *testing.T) {
+	dir := writeGateBaseline(t, "svdb", "orders", map[string]string{
+		baseline.MetaKeyCreateTableSQL: "CREATE TABLE `orders` (`id` int NOT NULL)",
+	})
+	cfg := FullTableConfig{BaselineSrc: dir, At: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)}
+	resolver := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"svdb.orders": {Schema: "svdb", Table: "orders", Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "", IsGenerated: true},
+		}},
+	})
+	_, err := ReconstructTable(context.Background(), cfg, "svdb", "orders", nil, nil, nil, resolver, "")
+	if err == nil {
+		t.Fatal("expected the PG wrong-path refusal, got nil")
+	}
+	if strings.Contains(err.Error(), "generated column") {
+		t.Fatalf("empty DataType must win the #1009 wrong-path verdict, got the generated-PK message: %v", err)
+	}
+	if !strings.Contains(err.Error(), "PostgreSQL") {
+		t.Fatalf("want the PG wrong-path verdict, got: %v", err)
+	}
+}

--- a/internal/reconstruct/fulltable_generatedpk_1266_test.go
+++ b/internal/reconstruct/fulltable_generatedpk_1266_test.go
@@ -1,0 +1,80 @@
+package reconstruct
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+)
+
+// svResolver1266 stubs the MariaDB system-versioning PK shape #1266 reports:
+// the PRIMARY KEY silently extended with the STORED GENERATED ROW END period
+// column (`PRIMARY KEY (id, row_end)`, observed on MariaDB 11.4).
+func svResolver1266() *metadata.Resolver {
+	return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"svdb.orders": {Schema: "svdb", Table: "orders", Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+			{Name: "val", OrdinalPosition: 2, DataType: "varchar"},
+			{Name: "row_end", OrdinalPosition: 4, IsPK: true, DataType: "timestamp", ColumnType: "timestamp(6)", IsGenerated: true},
+		}},
+	})
+}
+
+func TestGeneratedPKColumn(t *testing.T) {
+	tm, err := svResolver1266().Resolve("svdb", "orders")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	c, ok := GeneratedPKColumn(tm.PKColumnMetas())
+	if !ok || c.Name != "row_end" {
+		t.Fatalf("GeneratedPKColumn = (%q, %v), want (row_end, true)", c.Name, ok)
+	}
+	if _, ok := GeneratedPKColumn([]metadata.ColumnMeta{{Name: "id", IsPK: true}}); ok {
+		t.Fatal("GeneratedPKColumn on a plain PK must report false")
+	}
+}
+
+// TestReconstructTable_generatedPKRefusal_baselinePath wires the gate through
+// the REAL baseline-merge path: a baseline snapshot exists and carries
+// CreateTableSQL, so execution reaches the PK gates, where the generated
+// row_end member must refuse up front — with the versioning-aware message,
+// never the deep per-row MissingPKColumnError the issue reproduced. The gate
+// fires before any DB access, so db/engine stay nil (mutation guard: deleting
+// the gate makes this test die on the nil DB in CheckDestructiveDDL).
+func TestReconstructTable_generatedPKRefusal_baselinePath(t *testing.T) {
+	dir := writeGateBaseline(t, "svdb", "orders", map[string]string{
+		baseline.MetaKeyCreateTableSQL: "CREATE TABLE `orders` (`id` int NOT NULL, PRIMARY KEY (`id`,`row_end`))",
+	})
+	cfg := FullTableConfig{BaselineSrc: dir, At: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)}
+
+	_, err := ReconstructTable(context.Background(), cfg, "svdb", "orders", nil, nil, nil, svResolver1266(), "")
+	if err == nil {
+		t.Fatal("expected the generated-PK refusal, got nil")
+	}
+	if !strings.Contains(err.Error(), `"row_end"`) || !strings.Contains(err.Error(), "generated column") {
+		t.Fatalf("want the generated-PK refusal naming row_end, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "not in baseline row") {
+		t.Fatalf("must refuse up front, not with the deep MissingPKColumnError: %v", err)
+	}
+}
+
+// TestReconstructTable_generatedPKRefusal_binlogOnlyPath wires the sibling gate
+// through the binlog-only fallback (no baseline found, mydumper output): the
+// refusal must fire before the event fold — this path has no baseline probe to
+// fail loudly, so without the gate a versioned table's history-row inserts
+// would be emitted as duplicate live rows.
+func TestReconstructTable_generatedPKRefusal_binlogOnlyPath(t *testing.T) {
+	cfg := FullTableConfig{BaselineSrc: t.TempDir(), At: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)}
+
+	_, err := ReconstructTable(context.Background(), cfg, "svdb", "orders", nil, nil, nil, svResolver1266(), "")
+	if err == nil {
+		t.Fatal("expected the generated-PK refusal, got nil")
+	}
+	if !strings.Contains(err.Error(), `"row_end"`) || !strings.Contains(err.Error(), "generated column") {
+		t.Fatalf("want the generated-PK refusal naming row_end, got: %v", err)
+	}
+}

--- a/internal/reconstruct/pkgatereason.go
+++ b/internal/reconstruct/pkgatereason.go
@@ -79,12 +79,12 @@ func GeneratedPKColumn(pkCols []metadata.ColumnMeta) (metadata.ColumnMeta, bool)
 // names in the text: console and wire surfaces emit it too.
 func GeneratedPKGateReason(c metadata.ColumnMeta, surface string) string {
 	return fmt.Sprintf(
-		"primary-key column %q is a generated column — the MariaDB system-versioning shape, which extends a versioned "+
-			"table's PK with its ROW END period column — and baselines deliberately omit generated columns, so %s cannot "+
-			"build the baseline-side PK join key for this table; dropping the column from the key instead would corrupt "+
-			"silently, because the binlog carries history rows (as inserts) and versioned deletes (as row_end updates) "+
-			"under the same remaining key; single-row reconstruct with an explicit PK column list, query, and recover "+
-			"are unaffected", c.Name, surface)
+		"primary-key column %q is a generated column — most commonly the MariaDB system-versioning shape, which extends "+
+			"a versioned table's PK with its ROW END period column — and baselines deliberately omit generated columns, "+
+			"so %s cannot build the baseline-side PK join key for this table; dropping the column from the key instead "+
+			"would corrupt silently, because a versioned table's binlog carries history rows (as inserts) and versioned "+
+			"deletes (as row_end updates) under the same remaining key; query and recover are unaffected, and the CLI's "+
+			"single-row reconstruct with an explicit PK column list also works", c.Name, surface)
 }
 
 // fullTableGeneratedPKRefusal is the error both full-table reconstruct paths

--- a/internal/reconstruct/pkgatereason.go
+++ b/internal/reconstruct/pkgatereason.go
@@ -40,7 +40,9 @@ func PKTypeGateReason(c metadata.ColumnMeta, surface, action string) string {
 }
 
 // GeneratedPKColumn returns the first primary-key member that is a STORED/
-// VIRTUAL generated column, in ordinal order, and whether one exists (#1266).
+// VIRTUAL generated column, in input order, and whether one exists (#1266).
+// Callers pass PKColumnMetas(), which preserves ordinal order — the ordering
+// guarantee is the input's, not this function's.
 //
 // The shape this detects in practice is MariaDB system versioning: MariaDB
 // silently extends a versioned table's PRIMARY KEY with its ROW END period
@@ -83,7 +85,7 @@ func GeneratedPKGateReason(c metadata.ColumnMeta, surface string) string {
 			"a versioned table's PK with its ROW END period column — and baselines deliberately omit generated columns, "+
 			"so %s cannot build the baseline-side PK join key for this table; dropping the column from the key instead "+
 			"would corrupt silently, because a versioned table's binlog carries history rows (as inserts) and versioned "+
-			"deletes (as row_end updates) under the same remaining key; query and recover are unaffected, and the CLI's "+
+			"deletes (as row_end updates) under the same remaining key; query and recover are not gated, and the CLI's "+
 			"single-row reconstruct with an explicit PK column list also works", c.Name, surface)
 }
 

--- a/internal/reconstruct/pkgatereason.go
+++ b/internal/reconstruct/pkgatereason.go
@@ -39,6 +39,62 @@ func PKTypeGateReason(c metadata.ColumnMeta, surface, action string) string {
 	return fmt.Sprintf("primary-key column %q has type %q unsupported by the baseline canonicalizer", c.Name, c.DataType)
 }
 
+// GeneratedPKColumn returns the first primary-key member that is a STORED/
+// VIRTUAL generated column, in ordinal order, and whether one exists (#1266).
+//
+// The shape this detects in practice is MariaDB system versioning: MariaDB
+// silently extends a versioned table's PRIMARY KEY with its ROW END period
+// column (`PRIMARY KEY (id, row_end)`, observed on 11.4 for both visible and
+// INVISIBLE explicit period columns) and marks that column STORED GENERATED in
+// information_schema, which is how it reaches the snapshot's is_generated
+// flag. An ordinary STORED generated column inside a PK trips this too, on
+// purpose: in both cases the baseline deliberately omits the column's values
+// (mydumper never dumps generated columns), so no baseline-side PK join key
+// can be built and the merge would die deep in the probe with
+// MissingPKColumnError on every row.
+//
+// Why the gates that call this REFUSE instead of dropping the column from the
+// join key (the fix direction #1266 first suggested): the binlog does NOT
+// carry only current-state rows for a versioned table. Verified against
+// MariaDB 11.4: an UPDATE logs the current-row update PLUS a Write_rows for
+// the history row (same remaining key, row_end = now), and a DELETE logs no
+// Delete_rows at all — it is an Update_rows tombstone (row_end sentinel →
+// now). Under a reduced key the history insert would overwrite the current
+// row in the last-write-wins change map, orphan history rows would be emitted
+// as duplicate live rows, and tombstoned deletes would resurrect — silent
+// corruption where today's refusal is loud. Supporting these tables takes
+// versioning-aware fold semantics, not a smaller key.
+func GeneratedPKColumn(pkCols []metadata.ColumnMeta) (metadata.ColumnMeta, bool) {
+	for _, c := range pkCols {
+		if c.IsGenerated {
+			return c, true
+		}
+	}
+	return metadata.ColumnMeta{}, false
+}
+
+// GeneratedPKGateReason renders the refusal/inconclusive detail for a primary
+// key that contains a generated column (see GeneratedPKColumn). surface names
+// the feature speaking ("verify", "full-table reconstruct", ...). No CLI flag
+// names in the text: console and wire surfaces emit it too.
+func GeneratedPKGateReason(c metadata.ColumnMeta, surface string) string {
+	return fmt.Sprintf(
+		"primary-key column %q is a generated column — the MariaDB system-versioning shape, which extends a versioned "+
+			"table's PK with its ROW END period column — and baselines deliberately omit generated columns, so %s cannot "+
+			"build the baseline-side PK join key for this table; dropping the column from the key instead would corrupt "+
+			"silently, because the binlog carries history rows (as inserts) and versioned deletes (as row_end updates) "+
+			"under the same remaining key; single-row reconstruct with an explicit PK column list, query, and recover "+
+			"are unaffected", c.Name, surface)
+}
+
+// fullTableGeneratedPKRefusal is the error both full-table reconstruct paths
+// (baseline merge and binlog-only fallback) return when the PK contains a
+// generated column, so the two cannot drift.
+func fullTableGeneratedPKRefusal(schema, table string, pkCol metadata.ColumnMeta) error {
+	return fmt.Errorf("full-table reconstruct: %s.%s: %s", schema, table,
+		GeneratedPKGateReason(pkCol, "full-table reconstruct"))
+}
+
 // fullTablePKTypeRefusal is the error ReconstructTable's PK-type gate returns
 // for a column supportedPKType rejected. An empty DataType gets the honest
 // wrong-path verdict (see PKTypeGateReason): the gate sits after the recorded

--- a/internal/shim/fulltable_generatedpk_1266_test.go
+++ b/internal/shim/fulltable_generatedpk_1266_test.go
@@ -1,0 +1,89 @@
+package shim
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/metadata"
+)
+
+// svShimResolver stubs the MariaDB system-versioning PK shape (#1266): the PK
+// silently extended with the STORED GENERATED ROW END period column.
+func svShimResolver() func() (*metadata.Resolver, error) {
+	return func() (*metadata.Resolver, error) {
+		return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+			"app.orders": {Schema: "app", Table: "orders", PKColumns: []string{"id", "row_end"},
+				Columns: []metadata.ColumnMeta{
+					{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+					{Name: "val", OrdinalPosition: 2, DataType: "varchar"},
+					{Name: "row_end", OrdinalPosition: 4, IsPK: true, DataType: "timestamp", ColumnType: "timestamp(6)", IsGenerated: true},
+				}},
+		}), nil
+	}
+}
+
+func assertGeneratedPKWireError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("versioned-PK full-table view must refuse, got nil")
+	}
+	var myErr *gomysql.MyError
+	if !errors.As(err, &myErr) {
+		t.Fatalf("error = %T %v, want *mysql.MyError", err, err)
+	}
+	if myErr.Code != gomysql.ER_NO_PARTITION_FOR_GIVEN_VALUE {
+		t.Errorf("wire code = %d, want %d (ER_NO_PARTITION_FOR_GIVEN_VALUE)", myErr.Code, gomysql.ER_NO_PARTITION_FOR_GIVEN_VALUE)
+	}
+	if !strings.Contains(myErr.Message, "generated column") || !strings.Contains(myErr.Message, "row_end") {
+		t.Errorf("refusal must name the generated PK member: %q", myErr.Message)
+	}
+	// The sibling refusals steer to "_flashback for a binlog-only view"; this
+	// one must NOT — the binlog-only view is exactly the corrupt one for a
+	// versioned table (history rows as inserts, deletes as row_end updates).
+	// Matched on the steer phrase, not on "_flashback": the message prefix
+	// legitimately names the query type, which IS "_flashback" on that path.
+	if strings.Contains(myErr.Message, "binlog-only view") {
+		t.Errorf("versioned-PK refusal must not steer to the binlog-only view: %q", myErr.Message)
+	}
+}
+
+// TestRunSnapshotFullTable_generatedPKRefusal drives the baseline-merge path
+// (#1266): the timestamp type passes the SupportedPKType loop, so without the
+// gate the merge would die per-row with MissingPKColumnError surfaced as a
+// generic wire error. The gate fires before FullTableGate is touched, so a
+// zero-value Handler with only a resolver suffices (deleting the gate makes
+// this test die on the nil gate instead).
+func TestRunSnapshotFullTable_generatedPKRefusal(t *testing.T) {
+	h := &Handler{
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg:        Config{BaselineDir: t.TempDir()},
+		resolverFn: svShimResolver(),
+	}
+	_, err := h.runSnapshotFullTable(TimeTravelQuery{
+		Type: TypeSnapshot, Schema: "app", Table: "orders", AsOf: time.Now(),
+	})
+	assertGeneratedPKWireError(t, err)
+}
+
+// TestRunFullTable_generatedPKRefusal drives the binlog-only path (#1266) —
+// the _flashback full table and _snapshot's no-baseline fallback. This path
+// was WORSE than unhandled before the gate: with no baseline probe to fail
+// loudly, a versioned table's history-row inserts fold under their own full
+// pk_values and render as duplicate live rows, and a versioned DELETE (an
+// Update_rows tombstone, never a Delete_rows) stays live.
+func TestRunFullTable_generatedPKRefusal(t *testing.T) {
+	h := &Handler{
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		resolverFn: svShimResolver(),
+	}
+	_, err := h.runFullTable(TimeTravelQuery{
+		Type: TypeFlashback, Schema: "app", Table: "orders", AsOf: time.Now(),
+	})
+	assertGeneratedPKWireError(t, err)
+}

--- a/internal/shim/fulltable_generatedpk_1266_test.go
+++ b/internal/shim/fulltable_generatedpk_1266_test.go
@@ -43,22 +43,26 @@ func assertGeneratedPKWireError(t *testing.T, err error) {
 	if !strings.Contains(myErr.Message, "generated column") || !strings.Contains(myErr.Message, "row_end") {
 		t.Errorf("refusal must name the generated PK member: %q", myErr.Message)
 	}
-	// The sibling refusals steer to "_flashback for a binlog-only view"; this
-	// one must NOT — the binlog-only view is exactly the corrupt one for a
-	// versioned table (history rows as inserts, deletes as row_end updates).
-	// Matched on the steer phrase, not on "_flashback": the message prefix
-	// legitimately names the query type, which IS "_flashback" on that path.
-	if strings.Contains(myErr.Message, "binlog-only view") {
-		t.Errorf("versioned-PK refusal must not steer to the binlog-only view: %q", myErr.Message)
+	// The sibling refusals steer to "use _flashback for a binlog-only view";
+	// this one must NOT — the binlog-only view is exactly the corrupt one for
+	// a versioned table (history rows as inserts, deletes as row_end updates).
+	// The "resolve <type>: " prefix is stripped first: the query type itself
+	// legitimately reads "_flashback" on that path, so a whole-message match
+	// would either false-fail or have to settle for a phrase the message can
+	// dodge by rewording.
+	_, body, _ := strings.Cut(myErr.Message, ": ")
+	if strings.Contains(body, "_flashback") || strings.Contains(body, "binlog-only view") {
+		t.Errorf("versioned-PK refusal must not steer to _flashback or the binlog-only view: %q", myErr.Message)
 	}
 }
 
 // TestRunSnapshotFullTable_generatedPKRefusal drives the baseline-merge path
 // (#1266): the timestamp type passes the SupportedPKType loop, so without the
 // gate the merge would die per-row with MissingPKColumnError surfaced as a
-// generic wire error. The gate fires before FullTableGate is touched, so a
-// zero-value Handler with only a resolver suffices (deleting the gate makes
-// this test die on the nil gate instead).
+// generic wire error. A zero-value Handler with only a resolver suffices:
+// Gate.Acquire is nil-safe by design (nil = unlimited), so deleting the gate
+// does not panic — the run degrades past the empty baseline dir and the test
+// fails on the message assertions instead.
 func TestRunSnapshotFullTable_generatedPKRefusal(t *testing.T) {
 	h := &Handler{
 		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -72,8 +76,8 @@ func TestRunSnapshotFullTable_generatedPKRefusal(t *testing.T) {
 }
 
 // TestRunFullTable_generatedPKRefusal drives the binlog-only path (#1266) —
-// the _flashback full table and _snapshot's no-baseline fallback. This path
-// was WORSE than unhandled before the gate: with no baseline probe to fail
+// the _flashback full table and _snapshot's no-baseline fallback. Before the
+// gate this path was silent corruption: with no baseline probe to fail
 // loudly, a versioned table's history-row inserts fold under their own full
 // pk_values and render as duplicate live rows, and a versioned DELETE (an
 // Update_rows tombstone, never a Delete_rows) stays live.
@@ -86,4 +90,39 @@ func TestRunFullTable_generatedPKRefusal(t *testing.T) {
 		Type: TypeFlashback, Schema: "app", Table: "orders", AsOf: time.Now(),
 	})
 	assertGeneratedPKWireError(t, err)
+}
+
+// TestRunSnapshotFullTable_emptyDataTypeKeepsWrongPathVerdict pins the shim's
+// gate ordering: a PK member with an empty DataType (the PG snapshot shape,
+// #1009/#1198) that is ALSO marked generated must keep the wrong-path verdict,
+// never the MariaDB-shaped generated-PK message.
+func TestRunSnapshotFullTable_emptyDataTypeKeepsWrongPathVerdict(t *testing.T) {
+	h := &Handler{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg:    Config{BaselineDir: t.TempDir()},
+		resolverFn: func() (*metadata.Resolver, error) {
+			return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+				"app.orders": {Schema: "app", Table: "orders", PKColumns: []string{"id"},
+					Columns: []metadata.ColumnMeta{
+						{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "", IsGenerated: true},
+					}},
+			}), nil
+		},
+	}
+	_, err := h.runSnapshotFullTable(TimeTravelQuery{
+		Type: TypeSnapshot, Schema: "app", Table: "orders", AsOf: time.Now(),
+	})
+	if err == nil {
+		t.Fatal("expected the PG wrong-path refusal, got nil")
+	}
+	var myErr *gomysql.MyError
+	if !errors.As(err, &myErr) {
+		t.Fatalf("error = %T %v, want *mysql.MyError", err, err)
+	}
+	if strings.Contains(myErr.Message, "generated column") {
+		t.Errorf("empty DataType must win the #1009 wrong-path verdict, got the generated-PK message: %q", myErr.Message)
+	}
+	if !strings.Contains(myErr.Message, "PG snapshot shape") {
+		t.Errorf("want the PG wrong-path verdict, got: %q", myErr.Message)
+	}
 }

--- a/internal/shim/handler.go
+++ b/internal/shim/handler.go
@@ -885,6 +885,13 @@ func (h *Handler) runShowTablesFromVirtual(currentDB, virtualSchema string) (*my
 // those columns dropped — same behaviour as a regular MySQL
 // `SELECT *` after an ALTER TABLE that removed a column.
 func (h *Handler) runFullTable(q TimeTravelQuery) (*mysql.Result, error) {
+	// #1266: a generated PK member (MariaDB system versioning) makes the
+	// binlog-only full-table fold corrupt, not merely partial — refuse before
+	// spending a gate slot. See checkGeneratedPKFullTable.
+	if err := h.checkGeneratedPKFullTable(q.Type, q.Schema, q.Table); err != nil {
+		return nil, err
+	}
+
 	ctx, cancel := h.queryContext()
 	defer cancel()
 

--- a/internal/shim/snapshot.go
+++ b/internal/shim/snapshot.go
@@ -474,13 +474,16 @@ func (h *Handler) pkColumnMetas(schema, table string) ([]metadata.ColumnMeta, bo
 // refusals above: the binlog-only view is exactly the corrupt one here
 // (history-row inserts fold under their own full pk_values and render as
 // duplicate live rows, and a versioned DELETE is an Update_rows tombstone the
-// latest-event rule keeps as live — verified against MariaDB 11.4).
+// latest-event rule keeps as live — verified against MariaDB 11.4). And no
+// shim single-row steer either: the versioned PK is composite (id, row_end),
+// so PKColumnCheck refuses the `WHERE pk = v` shape on these tables — the one
+// single-row path that does work is the CLI's, with an explicit column list.
 func generatedPKFullTableError(qType QueryType, schema, table string, c metadata.ColumnMeta) error {
 	return mysql.NewError(mysql.ER_NO_PARTITION_FOR_GIVEN_VALUE, fmt.Sprintf(
 		"resolve %s: primary-key column %s of %s.%s is a generated column (most commonly MariaDB system versioning, "+
 			"which extends the PK with its ROW END period column); neither the baseline merge nor a binlog-only fold "+
 			"can render this table faithfully — history rows and versioned deletes share the surviving key — so the "+
-			"full-table view is refused; single-row lookups are unaffected",
+			"full-table view is refused; use the CLI's single-row reconstruct with an explicit PK column list",
 		qType, c.Name, schema, table))
 }
 
@@ -493,6 +496,13 @@ func generatedPKFullTableError(qType QueryType, schema, table string, c metadata
 func (h *Handler) checkGeneratedPKFullTable(qType QueryType, schema, table string) error {
 	pkCols, ok := h.pkColumnMetas(schema, table)
 	if !ok {
+		// Blind spot, said out loud: with no snapshot metadata the corrupt
+		// shape is undetectable and the fold proceeds unchecked. Debug, not
+		// Warn — a snapshot-less deployment (plain _flashback use) hits this
+		// on every full-table query and has nothing to fix; resolver LOAD
+		// failures already get a rate-limited Warn in resolverCache.get.
+		h.logger.Debug("shim: cannot evaluate the generated-PK gate (no snapshot metadata); full-table fold proceeds unchecked",
+			"schema", schema, "table", table)
 		return nil
 	}
 	c, found := reconstruct.GeneratedPKColumn(pkCols)

--- a/internal/shim/snapshot.go
+++ b/internal/shim/snapshot.go
@@ -185,6 +185,16 @@ func (h *Handler) runSnapshotFullTable(q TimeTravelQuery) (*mysql.Result, error)
 				q.Type, c.Name, q.Schema, q.Table, c.DataType))
 		}
 	}
+	// A generated PK member — the MariaDB system-versioning shape (#1266) —
+	// refuses BOTH full-table paths, so no _flashback steer here: the baseline
+	// merge cannot canonicalize a column the baseline omits, and the
+	// binlog-only fold is the corrupt view (see checkGeneratedPKFullTable).
+	// After the type loop on purpose, same ordering as the CLI's
+	// ReconstructTable gate: an empty DataType must keep winning the #1009
+	// wrong-path verdict above.
+	if c, found := reconstruct.GeneratedPKColumn(pkCols); found {
+		return nil, generatedPKFullTableError(q.Type, q.Schema, q.Table, c)
+	}
 
 	ctx, cancel := h.queryContext()
 	defer cancel()
@@ -455,6 +465,41 @@ func (h *Handler) pkColumnMetas(schema, table string) ([]metadata.ColumnMeta, bo
 		return nil, false
 	}
 	return tm.PKColumnMetas(), true
+}
+
+// generatedPKFullTableError renders the wire refusal for a full-table
+// time-travel view of a table whose PK contains a generated column (#1266) —
+// the MariaDB system-versioning shape (PRIMARY KEY silently extended with the
+// ROW END period column). Deliberately NO _flashback steer, unlike the
+// refusals above: the binlog-only view is exactly the corrupt one here
+// (history-row inserts fold under their own full pk_values and render as
+// duplicate live rows, and a versioned DELETE is an Update_rows tombstone the
+// latest-event rule keeps as live — verified against MariaDB 11.4).
+func generatedPKFullTableError(qType QueryType, schema, table string, c metadata.ColumnMeta) error {
+	return mysql.NewError(mysql.ER_NO_PARTITION_FOR_GIVEN_VALUE, fmt.Sprintf(
+		"resolve %s: primary-key column %s of %s.%s is a generated column (most commonly MariaDB system versioning, "+
+			"which extends the PK with its ROW END period column); neither the baseline merge nor a binlog-only fold "+
+			"can render this table faithfully — history rows and versioned deletes share the surviving key — so the "+
+			"full-table view is refused; single-row lookups are unaffected",
+		qType, c.Name, schema, table))
+}
+
+// checkGeneratedPKFullTable is the runFullTable-side entry of the #1266 gate:
+// it resolves the PK metas itself and returns the wire refusal when a
+// generated PK member is present, nil otherwise. Best-effort by design — an
+// unavailable resolver or unresolved table returns nil, the same degrade every
+// pkColumnMetas caller applies, so it can only ADD a refusal where the
+// metadata proves the corrupt shape, never block a table it cannot see.
+func (h *Handler) checkGeneratedPKFullTable(qType QueryType, schema, table string) error {
+	pkCols, ok := h.pkColumnMetas(schema, table)
+	if !ok {
+		return nil
+	}
+	c, found := reconstruct.GeneratedPKColumn(pkCols)
+	if !found {
+		return nil
+	}
+	return generatedPKFullTableError(qType, schema, table, c)
 }
 
 // fullTableTextCell renders one merged-resultset value to a uniform text cell

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -113,6 +113,13 @@ func VerifyTable(ctx context.Context, cfg Config, schema, table string) (TableRe
 			return inconclusive(res, pkTypeGateReason(c)), nil
 		}
 	}
+	// A generated PK member — the MariaDB system-versioning shape (#1266) —
+	// is a permanent property of the table, not a transient condition, so it
+	// is inconclusive (like "no primary key"), never a mismatch or an error:
+	// a verify that fails forever on a versioned table is cry-wolf noise.
+	if c, ok := reconstruct.GeneratedPKColumn(pkCols); ok {
+		return inconclusive(res, generatedPKGateReason(c)), nil
+	}
 
 	// 1. Live source fingerprint at a consistent snapshot. Normalized (see
 	// renderCellNormalized) so it stays symmetric with step 5's reconstruct
@@ -335,6 +342,15 @@ func inconclusive(res TableResult, detail string) TableResult {
 // CLI flag names in the text: the console's verify engine emits it too.
 func pkTypeGateReason(c metadata.ColumnMeta) string {
 	return reconstruct.PKTypeGateReason(c, "verify", "verify")
+}
+
+// generatedPKGateReason renders the inconclusive detail for a primary key
+// containing a generated column — the MariaDB system-versioning shape (#1266).
+// Shared by VerifyTable (live-source) and VerifyBaselinePair (baseline-
+// anchored) so the two modes cannot drift; see reconstruct.GeneratedPKColumn
+// for the full rationale.
+func generatedPKGateReason(c metadata.ColumnMeta) string {
+	return reconstruct.GeneratedPKGateReason(c, "verify")
 }
 
 // deferredReprUnresolved reports whether some change's row image carries a

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -115,8 +115,11 @@ func VerifyTable(ctx context.Context, cfg Config, schema, table string) (TableRe
 	}
 	// A generated PK member — the MariaDB system-versioning shape (#1266) —
 	// is a permanent property of the table, not a transient condition, so it
-	// is inconclusive (like "no primary key"), never a mismatch or an error:
-	// a verify that fails forever on a versioned table is cry-wolf noise.
+	// is inconclusive (like "no primary key"), never a mismatch or an error.
+	// A run scoped to ONLY such tables still exits non-zero (all-inconclusive
+	// = unproven, Report.ExitError), matching the no-PK convention; the win
+	// is that one versioned table no longer poisons a multi-table run with a
+	// hard per-table error.
 	if c, ok := reconstruct.GeneratedPKColumn(pkCols); ok {
 		return inconclusive(res, generatedPKGateReason(c)), nil
 	}

--- a/internal/verify/verify_baseline.go
+++ b/internal/verify/verify_baseline.go
@@ -149,6 +149,15 @@ func VerifyBaselinePair(ctx context.Context, cfg BaselineConfig, p BaselinePair)
 				return inconclusive(res, pkTypeGateReason(c)), nil
 			}
 		}
+		// Generated PK member (MariaDB system versioning, #1266): permanent
+		// table property → inconclusive, same stance as VerifyTable. Inside
+		// the !pg branch with the type gate — the canonicalizer this protects
+		// is bypassed entirely on the PG path. ExplainBaselinePairMismatch
+		// needs no sibling gate: it only runs after this function reported a
+		// MISMATCH, which a gated table never does.
+		if c, ok := reconstruct.GeneratedPKColumn(pkCols); ok {
+			return inconclusive(res, generatedPKGateReason(c)), nil
+		}
 	}
 	// The reconstruction is bounded at the new baseline's exact anchor. MySQL
 	// uses the binlog file:pos; PostgreSQL uses the slot consistent-point LSN

--- a/internal/verify/verify_generatedpk_1266_test.go
+++ b/internal/verify/verify_generatedpk_1266_test.go
@@ -1,0 +1,75 @@
+package verify
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/metadata"
+)
+
+// svResolver stubs the MariaDB system-versioning PK shape (#1266): the PK
+// silently extended with the STORED GENERATED ROW END period column.
+func svResolver() *metadata.Resolver {
+	return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"app.orders": {Schema: "app", Table: "orders", Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+			{Name: "row_end", OrdinalPosition: 4, IsPK: true, DataType: "timestamp", ColumnType: "timestamp(6)", IsGenerated: true},
+		}},
+	})
+}
+
+// TestVerifyTable_generatedPKInconclusive: a versioned table is a PERMANENT
+// shape, so live-source verify must report it inconclusive — never a mismatch
+// or an error that fails every run forever (#1266). The gate fires before any
+// DB access, so SourceDB/IndexDB stay nil (deleting the gate makes this test
+// die on the nil source checksum instead).
+func TestVerifyTable_generatedPKInconclusive(t *testing.T) {
+	res, err := VerifyTable(context.Background(), Config{Resolver: svResolver()}, "app", "orders")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != StatusInconclusive {
+		t.Fatalf("status = %q, want inconclusive", res.Status)
+	}
+	if !strings.Contains(res.Detail, "generated column") || !strings.Contains(res.Detail, `"row_end"`) {
+		t.Fatalf("want the generated-PK reason naming row_end, got: %q", res.Detail)
+	}
+}
+
+// TestVerifyBaselinePair_generatedPKInconclusive: same stance on the
+// baseline-anchored path. The detail must be the generated-PK reason, not the
+// anchor precondition that would fire next if the gate were deleted (the
+// BaselinePair carries no usable anchor on purpose, so the two outcomes are
+// distinguishable).
+func TestVerifyBaselinePair_generatedPKInconclusive(t *testing.T) {
+	cfg := BaselineConfig{Resolver: svResolver(), SourceFlavor: ""} // "" == mysql
+	res, err := VerifyBaselinePair(context.Background(), cfg, BaselinePair{Schema: "app", Table: "orders"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != StatusInconclusive {
+		t.Fatalf("status = %q, want inconclusive", res.Status)
+	}
+	if !strings.Contains(res.Detail, "generated column") {
+		t.Fatalf("want the generated-PK reason, got: %q", res.Detail)
+	}
+}
+
+// TestVerifyBaselinePair_pgBypassesGeneratedPKGate pins the gate's placement
+// inside the !pg branch: the PK canonicalizer it protects is bypassed entirely
+// on the PostgreSQL path, so a PG run must fall through to the LSN-anchor
+// precondition, never the MariaDB-shaped generated-PK message.
+func TestVerifyBaselinePair_pgBypassesGeneratedPKGate(t *testing.T) {
+	cfg := BaselineConfig{Resolver: svResolver(), SourceFlavor: flavorPostgres}
+	res, err := VerifyBaselinePair(context.Background(), cfg, BaselinePair{Schema: "app", Table: "orders", NewLSN: 0})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(res.Detail, "generated column") {
+		t.Fatalf("PG path must bypass the generated-PK gate, got: %q", res.Detail)
+	}
+	if !strings.Contains(res.Detail, "LSN anchor") {
+		t.Fatalf("want the PG LSN-anchor reason, got: %q", res.Detail)
+	}
+}

--- a/internal/verify/verify_generatedpk_1266_test.go
+++ b/internal/verify/verify_generatedpk_1266_test.go
@@ -73,3 +73,48 @@ func TestVerifyBaselinePair_pgBypassesGeneratedPKGate(t *testing.T) {
 		t.Fatalf("want the PG LSN-anchor reason, got: %q", res.Detail)
 	}
 }
+
+// pgShapedGeneratedResolver combines the two gate triggers on one PK column:
+// empty DataType (the PG snapshot shape, #1009) AND IsGenerated. The type gate
+// must win — see the ordering tests below, which pin the loop-then-gate order
+// the in-code comments claim.
+func pgShapedGeneratedResolver() *metadata.Resolver {
+	return metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"app.orders": {Schema: "app", Table: "orders", Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "", IsGenerated: true},
+		}},
+	})
+}
+
+func TestVerifyTable_emptyDataTypeKeepsWrongPathVerdict(t *testing.T) {
+	res, err := VerifyTable(context.Background(), Config{Resolver: pgShapedGeneratedResolver()}, "app", "orders")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != StatusInconclusive {
+		t.Fatalf("status = %q, want inconclusive", res.Status)
+	}
+	if strings.Contains(res.Detail, "generated column") {
+		t.Fatalf("empty DataType must win the #1009 wrong-path verdict, got the generated-PK reason: %q", res.Detail)
+	}
+	if !strings.Contains(res.Detail, "PostgreSQL") {
+		t.Fatalf("want the PG wrong-path reason, got: %q", res.Detail)
+	}
+}
+
+func TestVerifyBaselinePair_emptyDataTypeKeepsWrongPathVerdict(t *testing.T) {
+	cfg := BaselineConfig{Resolver: pgShapedGeneratedResolver(), SourceFlavor: ""} // "" == mysql
+	res, err := VerifyBaselinePair(context.Background(), cfg, BaselinePair{Schema: "app", Table: "orders"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != StatusInconclusive {
+		t.Fatalf("status = %q, want inconclusive", res.Status)
+	}
+	if strings.Contains(res.Detail, "generated column") {
+		t.Fatalf("empty DataType must win the #1009 wrong-path verdict, got the generated-PK reason: %q", res.Detail)
+	}
+	if !strings.Contains(res.Detail, "PostgreSQL") {
+		t.Fatalf("want the PG wrong-path reason, got: %q", res.Detail)
+	}
+}

--- a/internal/verify/verify_generatedpk_mariadb_integration_test.go
+++ b/internal/verify/verify_generatedpk_mariadb_integration_test.go
@@ -1,0 +1,75 @@
+//go:build integration
+
+package verify
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestVerifyTable_mariadbSystemVersioning_generatedPKGate pins the premise the
+// whole #1266 gate rests on against a REAL MariaDB source: creating a
+// system-versioned table with explicit period columns extends its PRIMARY KEY
+// with row_end, and the snapshot pipeline records that member as generated
+// (metadata derives is_generated from GENERATION_EXPRESSION, which MariaDB
+// fills with "ROW END") — so reconstruct.GeneratedPKColumn fires on
+// production-shaped metadata, not only on the hand-built resolvers of the
+// unit tests. If MariaDB ever changes the PK extension or the
+// information_schema signal, this test fails instead of the prose in
+// GeneratedPKColumn's doc comment silently going stale.
+func TestVerifyTable_mariadbSystemVersioning_generatedPKGate(t *testing.T) {
+	sourceDB, sourceName := testutil.CreateTestMariaDB(t)
+	indexDB, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	testutil.MustExec(t, sourceDB, fmt.Sprintf(
+		"CREATE TABLE `%s`.`sv_orders` ("+
+			"`id` INT PRIMARY KEY, `val` VARCHAR(20), "+
+			"`row_start` TIMESTAMP(6) GENERATED ALWAYS AS ROW START, "+
+			"`row_end` TIMESTAMP(6) GENERATED ALWAYS AS ROW END, "+
+			"PERIOD FOR SYSTEM_TIME(`row_start`,`row_end`)"+
+			") WITH SYSTEM VERSIONING", sourceName))
+
+	if _, err := metadata.TakeSnapshot(sourceDB, indexDB, []string{sourceName}); err != nil {
+		t.Fatalf("TakeSnapshot: %v", err)
+	}
+	resolver, err := metadata.NewResolver(indexDB, 0)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+	tm, err := resolver.Resolve(sourceName, "sv_orders")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// The premise, on real metadata: MariaDB extended the PK with row_end and
+	// the snapshot marked it generated.
+	c, ok := reconstruct.GeneratedPKColumn(tm.PKColumnMetas())
+	if !ok {
+		t.Fatalf("GeneratedPKColumn = false; PK metas = %+v — MariaDB no longer extends the PK with a "+
+			"generated period column, or the snapshot lost the is_generated signal", tm.PKColumnMetas())
+	}
+	if c.Name != "row_end" {
+		t.Fatalf("generated PK member = %q, want row_end", c.Name)
+	}
+
+	// End-to-end verdict through the real path: inconclusive with the
+	// versioning-aware reason, before any source fingerprinting happens.
+	res, err := VerifyTable(context.Background(), Config{Resolver: resolver, SourceDB: sourceDB, IndexDB: indexDB},
+		sourceName, "sv_orders")
+	if err != nil {
+		t.Fatalf("VerifyTable: %v", err)
+	}
+	if res.Status != StatusInconclusive {
+		t.Fatalf("status = %q, want inconclusive", res.Status)
+	}
+	if !strings.Contains(res.Detail, "generated column") {
+		t.Fatalf("want the generated-PK reason, got: %q", res.Detail)
+	}
+}


### PR DESCRIPTION
closes #1266

## Summary
- **Empirical finding that reshaped the fix** (MariaDB 11.4, real binlog): the issue's suggested direction — exclude generated columns from the reconstruct-side PK join key — would corrupt silently. The binlog carries **history rows as Write_rows** and **versioned DELETEs as row_end Update_rows** under the same remaining key, so a reduced key folds history over current state, appends orphan history rows as duplicate live rows, and resurrects deleted rows. Full support needs versioning-aware fold semantics (follow-up material; evidence recorded on `GeneratedPKColumn`'s doc comment).
- New `reconstruct.GeneratedPKColumn` + `GeneratedPKGateReason`: detect a STORED/VIRTUAL generated PK member (the MariaDB system-versioning shape, `PRIMARY KEY (id, row_end)`) and render the shared refusal text.
- `ReconstructTable` refuses **up front** on both full-table paths — baseline merge (previously died per-row with `MissingPKColumnError` deep in the probe) and the **binlog-only fallback** (previously *silent corruption*: no baseline probe to fail loudly, history inserts emitted as duplicate live rows).
- `verify` (live-source `VerifyTable` and baseline-anchored `VerifyBaselinePair`) reports the shape as **`inconclusive`** instead of `error` — a permanent table property must not fail every verify run forever (same stance as "table has no primary key"). Gate sits inside the `!pg` branch; `ExplainBaselinePairMismatch` needs no sibling (only runs after a MISMATCH, which a gated table never reports).
- Unchanged and still working: `bintrail baseline`, single-row reconstruct with explicit PK columns, query, recover.

## Test plan
- [x] Wiring tests through the real call paths (nil DBs; deleting a gate makes each test die on the nil DB downstream): `TestReconstructTable_generatedPKRefusal_baselinePath` / `_binlogOnlyPath`, `TestVerifyTable_generatedPKInconclusive`, `TestVerifyBaselinePair_generatedPKInconclusive`, `TestVerifyBaselinePair_pgBypassesGeneratedPKGate`
- [x] `go test ./... -count=1` green; `internal/reconstruct` + `internal/verify` also green under `-race`
- [x] `go vet -tags integration ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
