### PR TITLE
mcp: name the archive-reconcile remedy in the reconstruct GapError rewrite

### DIFF
--- a/internal/mcptools/reconstruct.go
+++ b/internal/mcptools/reconstruct.go
@@ -459,8 +459,16 @@ func MakeReconstructTool(cfg Config) func(context.Context, *mcp.CallToolRequest,
 func reconstructFetchError(err error) error {
 	var gapErr *query.GapError
 	if errors.As(err, &gapErr) {
+		// The rebuilt-index case lands here too, and there the non-lossy
+		// remedy is an operator command, named before the lossy override —
+		// same ordering as the CLI hint from #1268 (#1270). Naming a shell
+		// command is fine (the SourceEmptyError branch below already does);
+		// the leak rule only forbids `--allow-gaps`, the flag this surface
+		// cannot pass.
 		return fmt.Errorf("%w; the reconstruction would be silently incomplete. "+
-			"Re-run with allow_gaps: true to accept a known-incomplete result, or narrow `at` to a covered window", err)
+			"Gap detection reads archive_state, so a rebuilt index reports already-archived hours as gaps too — "+
+			"if archives exist in storage, have the operator run `bintrail archive reconcile --repair --index-dsn ... --archive-s3 s3://...` (or --archive-dir) to repopulate archive_state, then retry. "+
+			"Otherwise re-run with allow_gaps: true to accept a known-incomplete result, or narrow `at` to a covered window", err)
 	}
 	var emptyErr *query.SourceEmptyError
 	if errors.As(err, &emptyErr) {

--- a/internal/mcptools/reconstruct.go
+++ b/internal/mcptools/reconstruct.go
@@ -454,8 +454,9 @@ func MakeReconstructTool(cfg Config) func(context.Context, *mcp.CallToolRequest,
 
 // reconstructFetchError rewrites the two typed fetch failures with remediation
 // an MCP client can actually act on. The library types stay command-neutral and
-// the CLI wraps them with flag advice (`--allow-gaps`), which is meaningless
-// here — the same reason the recover tool rewrites *recovery.ScriptBudgetError.
+// the CLI wraps them with the reconcile hint plus `--allow-gaps` flag advice;
+// only the flag half is meaningless here — the same reason the recover tool
+// rewrites *recovery.ScriptBudgetError.
 func reconstructFetchError(err error) error {
 	var gapErr *query.GapError
 	if errors.As(err, &gapErr) {
@@ -463,8 +464,8 @@ func reconstructFetchError(err error) error {
 		// remedy is an operator command, named before the lossy override —
 		// same ordering as the CLI hint from #1268 (#1270). Naming a shell
 		// command is fine (the SourceEmptyError branch below already does);
-		// the leak rule only forbids `--allow-gaps`, the flag this surface
-		// cannot pass.
+		// the leak rule forbids flag spellings the client would pass on its
+		// own surface — here, `--allow-gaps`.
 		return fmt.Errorf("%w; the reconstruction would be silently incomplete. "+
 			"Gap detection reads archive_state, so a rebuilt index reports already-archived hours as gaps too — "+
 			"if archives exist in storage, have the operator run `bintrail archive reconcile --repair --index-dsn ... --archive-s3 s3://...` (or --archive-dir) to repopulate archive_state, then retry. "+

--- a/internal/mcptools/reconstruct_test.go
+++ b/internal/mcptools/reconstruct_test.go
@@ -3,6 +3,7 @@ package mcptools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -345,7 +346,29 @@ func TestReconstructWarningsCaptureGap(t *testing.T) {
 // archive-reconcile remedy for the rebuilt-index case — deleting the hint
 // leaves an agent with only the lossy override.
 func TestReconstructFetchErrorGapNamesToolParam(t *testing.T) {
-	msg := reconstructFetchError(&query.GapError{GapHours: []time.Time{time.Date(2026, 6, 1, 3, 0, 0, 0, time.UTC)}}).Error()
+	wrapped := reconstructFetchError(&query.GapError{GapHours: []time.Time{time.Date(2026, 6, 1, 3, 0, 0, 0, time.UTC)}})
+	var gapErr *query.GapError
+	if !errors.As(wrapped, &gapErr) {
+		t.Errorf("the rewrite must keep the %%w chain so callers can still errors.As the library type, got: %v", wrapped)
+	}
+	msg := wrapped.Error()
+	if strings.Contains(msg, "--allow-gaps") {
+		t.Errorf("the MCP rewrite must not hand the client the CLI flag, got: %s", msg)
+	}
+	if !strings.Contains(msg, "allow_gaps: true") {
+		t.Errorf("the rewrite must name the tool parameter that overrides it, got: %s", msg)
+	}
+	// `--repair` specifically: without it reconcile is a dry-run and the
+	// "non-lossy remedy" fixes nothing.
+	if !strings.Contains(msg, "archive reconcile --repair") {
+		t.Errorf("the rewrite must name the reconcile remedy in its acting form, got: %s", msg)
+	}
+}
+
+// TestReconstructFetchErrorSourceEmptyNamesToolParam pins the same contract on
+// the pre-existing SourceEmptyError branch, previously untested.
+func TestReconstructFetchErrorSourceEmptyNamesToolParam(t *testing.T) {
+	msg := reconstructFetchError(&query.SourceEmptyError{Source: "s3://bucket/prefix"}).Error()
 	if strings.Contains(msg, "--allow-gaps") {
 		t.Errorf("the MCP rewrite must not hand the client the CLI flag, got: %s", msg)
 	}
@@ -353,7 +376,7 @@ func TestReconstructFetchErrorGapNamesToolParam(t *testing.T) {
 		t.Errorf("the rewrite must name the tool parameter that overrides it, got: %s", msg)
 	}
 	if !strings.Contains(msg, "archive reconcile") {
-		t.Errorf("the rewrite must name the non-lossy reconcile remedy, got: %s", msg)
+		t.Errorf("the rewrite must name the reconcile remedy, got: %s", msg)
 	}
 }
 
@@ -380,6 +403,11 @@ func TestReconstructCaptureGapErrorNamesToolParam(t *testing.T) {
 			}
 			if !strings.Contains(msg, "app.users") {
 				t.Errorf("the refusal must name the table, got: %s", msg)
+			}
+			// A permanent capture loss has no reconcile remedy — copying the
+			// fetch-gap hint here would be false hope (#1270).
+			if strings.Contains(msg, "archive reconcile") {
+				t.Errorf("the capture-loss refusal must not suggest reconcile, got: %s", msg)
 			}
 		})
 	}

--- a/internal/mcptools/reconstruct_test.go
+++ b/internal/mcptools/reconstruct_test.go
@@ -339,6 +339,24 @@ func TestReconstructWarningsCaptureGap(t *testing.T) {
 	}
 }
 
+// TestReconstructFetchErrorGapNamesToolParam is the sibling guard for the
+// planner-gap rewrite (#1270): the message must name the tool parameter
+// (allow_gaps: true), never `--allow-gaps`, and must keep the non-lossy
+// archive-reconcile remedy for the rebuilt-index case — deleting the hint
+// leaves an agent with only the lossy override.
+func TestReconstructFetchErrorGapNamesToolParam(t *testing.T) {
+	msg := reconstructFetchError(&query.GapError{GapHours: []time.Time{time.Date(2026, 6, 1, 3, 0, 0, 0, time.UTC)}}).Error()
+	if strings.Contains(msg, "--allow-gaps") {
+		t.Errorf("the MCP rewrite must not hand the client the CLI flag, got: %s", msg)
+	}
+	if !strings.Contains(msg, "allow_gaps: true") {
+		t.Errorf("the rewrite must name the tool parameter that overrides it, got: %s", msg)
+	}
+	if !strings.Contains(msg, "archive reconcile") {
+		t.Errorf("the rewrite must name the non-lossy reconcile remedy, got: %s", msg)
+	}
+}
+
 // TestReconstructCaptureGapErrorNamesToolParam guards the CLI-flag leak: the
 // refusal an MCP client receives must name the tool parameter it actually has
 // (allow_gaps: true), never `--allow-gaps`, which an agent can only translate


### PR DESCRIPTION
closes #1270

## Summary
- The rebuilt-index scenario (`archive_state` empty, hours rotated out of MySQL) lands on the planner `*query.GapError` branch of `reconstructFetchError`, which offered an MCP agent only `allow_gaps: true` — the lossy override — when full coverage was one `archive reconcile --repair` away.
- Extends that rewrite to name the non-lossy operator remedy first (same bridge wording as the CLI fix in PR #1268), keeping `allow_gaps: true` and the narrow-`at` alternative as fallbacks.
- Surface rules hold: `--allow-gaps` never appears (leak rule); naming the `bintrail archive reconcile` operator command is precedented by the `SourceEmptyError` branch of the same helper.
- New unit test `TestReconstructFetchErrorGapNamesToolParam` pins the three properties (no CLI flag, tool param named, reconcile hint present) — sibling of the existing `TestReconstructCaptureGapErrorNamesToolParam`.

## Not touched (by design)
- `SourceEmptyError` branch: already names reconcile.
- `reconstructCaptureGapError`: permanent capture loss — recommending reconcile there would be false hope (no archive ever held that data).

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `go vet ./...`, `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
