### PR TITLE
cascade: gate system-versioned child edges in both phases via a metadata probe

### DIFF
--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -543,6 +543,7 @@ MariaDB silently extends a system-versioned table's `PRIMARY KEY` with its `ROW 
 
 - **Full-table `reconstruct`** (baseline merge and binlog-only fallback alike) and the shim's **full-table `_flashback`/`_snapshot`** views refuse with an error naming the generated PK column.
 - **`verify`** reports the table as `inconclusive` — a permanent property of the table's shape, not a failure. A run scoped only to such tables still exits non-zero (nothing was proven).
+- **`recover-cascade`** skips any FK edge whose **child** table is system-versioned, reporting it as a permanent incompleteness caveat (its cascade side effects are not synthesized) — a candidate scan over such a child would rebuild rows from history-polluted state.
 - **Still available**: `query` and `recover` are not gated, and single-row `reconstruct` works with an explicit column list, e.g. `--pk 1 --pk-columns id`.
 
 ### Column type encodings (BLOB/TEXT, GEOMETRY, VECTOR)

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -543,7 +543,7 @@ MariaDB silently extends a system-versioned table's `PRIMARY KEY` with its `ROW 
 
 - **Full-table `reconstruct`** (baseline merge and binlog-only fallback alike) and the shim's **full-table `_flashback`/`_snapshot`** views refuse with an error naming the generated PK column.
 - **`verify`** reports the table as `inconclusive` — a permanent property of the table's shape, not a failure. A run scoped only to such tables still exits non-zero (nothing was proven).
-- **`recover-cascade`** skips any FK edge whose **child** table is system-versioned, reporting it as a permanent incompleteness caveat (its cascade side effects are not synthesized) — a candidate scan over such a child would rebuild rows from history-polluted state. Detection reads the schema snapshot, so keep it current (`bintrail snapshot`); without one the gate cannot see the table's shape.
+- **`recover-cascade`** skips any FK edge whose **child** table's primary key contains a generated column (typically MariaDB system versioning), reporting it as a permanent incompleteness caveat (its cascade side effects are not synthesized) — a candidate scan over such a child would rebuild rows from history-polluted state. Detection reads the schema snapshot, so keep it current (`bintrail snapshot`); without one, the gate only fires when a configured baseline covers the table.
 - **Still available**: `query` and `recover` are not gated, and single-row `reconstruct` works with an explicit column list, e.g. `--pk 1 --pk-columns id`.
 
 ### Column type encodings (BLOB/TEXT, GEOMETRY, VECTOR)

--- a/docs/query-and-recovery.md
+++ b/docs/query-and-recovery.md
@@ -543,7 +543,7 @@ MariaDB silently extends a system-versioned table's `PRIMARY KEY` with its `ROW 
 
 - **Full-table `reconstruct`** (baseline merge and binlog-only fallback alike) and the shim's **full-table `_flashback`/`_snapshot`** views refuse with an error naming the generated PK column.
 - **`verify`** reports the table as `inconclusive` — a permanent property of the table's shape, not a failure. A run scoped only to such tables still exits non-zero (nothing was proven).
-- **`recover-cascade`** skips any FK edge whose **child** table is system-versioned, reporting it as a permanent incompleteness caveat (its cascade side effects are not synthesized) — a candidate scan over such a child would rebuild rows from history-polluted state.
+- **`recover-cascade`** skips any FK edge whose **child** table is system-versioned, reporting it as a permanent incompleteness caveat (its cascade side effects are not synthesized) — a candidate scan over such a child would rebuild rows from history-polluted state. Detection reads the schema snapshot, so keep it current (`bintrail snapshot`); without one the gate cannot see the table's shape.
 - **Still available**: `query` and `recover` are not gated, and single-row `reconstruct` works with an explicit column list, e.g. `--pk 1 --pk-columns id`.
 
 ### Column type encodings (BLOB/TEXT, GEOMETRY, VECTOR)

--- a/internal/cascade/cascade.go
+++ b/internal/cascade/cascade.go
@@ -51,7 +51,9 @@ import (
 	"time"
 
 	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
 )
 
 // CascadeFK is one foreign-key edge plus its referential delete action.
@@ -146,6 +148,37 @@ type Options struct {
 	// When true, baseline augmentation is skipped + flagged, exactly like a
 	// truncated binlog scan.
 	ArchivesPresent bool
+	// PKMetas, when non-nil, resolves a table's primary-key column metadata
+	// from the schema snapshot (#1273). The engine uses it to skip child
+	// edges whose PK contains a generated column — the MariaDB system-
+	// versioning shape (#1266): such a table's binlog carries history-row
+	// inserts and row_end tombstone updates under the surviving key, so the
+	// per-pk_values candidate scan would synthesize restores from
+	// history-polluted state, and the baseline omits the generated member
+	// anyway. Gated edges are skipped with a permanent `generatedpk:` caveat
+	// covering BOTH phases. nil disables the gate; the Phase-2 provider still
+	// refuses on its own via reconstruct.ErrGeneratedPK, which the caveat
+	// classifier recognizes — the backstop for probe-less callers.
+	PKMetas func(schema, table string) []metadata.ColumnMeta
+}
+
+// PKMetasFromResolver adapts a schema resolver into Options.PKMetas. A nil
+// resolver yields nil (gate off), matching the call sites' best-effort
+// resolver loading — the Phase-2 provider backstop still refuses on its own.
+// Resolution failures degrade to nil metas (gate silent for that table): the
+// cascade engine must keep working against indexes whose snapshot predates
+// the table, exactly as it did before the gate existed.
+func PKMetasFromResolver(r *metadata.Resolver) func(schema, table string) []metadata.ColumnMeta {
+	if r == nil {
+		return nil
+	}
+	return func(schema, table string) []metadata.ColumnMeta {
+		tm, err := r.Resolve(schema, table)
+		if err != nil {
+			return nil
+		}
+		return tm.PKColumnMetas()
+	}
 }
 
 // skewSampleLimit bounds the child-side DDL-skew probe: how many child
@@ -474,6 +507,25 @@ func SynthesizeVictims(
 		failed   bool // operational failure — the caller must skip this edge
 	}
 	scanChildren := func(fk CascadeFK, parentKey string, rootTS time.Time) childScan {
+		// #1273: a child whose PK contains a generated column — the MariaDB
+		// system-versioning shape — cannot be synthesized from EITHER phase:
+		// its binlog history carries history-row inserts and row_end tombstone
+		// updates under the surviving key (the #1266 evidence), so the
+		// per-pk_values candidate scan would rebuild children from
+		// history-polluted state, and the baseline omits the generated PK
+		// member. Skip the edge with a permanent caveat instead, before any
+		// index or baseline work.
+		if opts.PKMetas != nil {
+			for _, c := range opts.PKMetas(fk.Schema, fk.Table) {
+				if c.IsGenerated {
+					addIncomplete("generatedpk:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
+						"%s.%s cannot be synthesized: primary-key column %q is a generated column (the MariaDB "+
+							"system-versioning shape) — a PERMANENT property of the table, not a transient failure; "+
+							"its cascade side effects are not recovered", fk.Schema, fk.Table, c.Name))
+					return childScan{failed: true}
+				}
+			}
+		}
 		until := rootTS
 		// Phase-1 window; widened to the baseline snapshot below.
 		since := rootTS.Add(-opts.Lookback)
@@ -494,6 +546,19 @@ func SynthesizeVictims(
 			bl, covered, berr := opts.Baseline.BaselineChildren(ctx, fk.Schema, fk.Table, fk.Column, parentKey, rootTS, opts.CandidateLimit)
 			switch {
 			case berr != nil:
+				// A generated-PK refusal (#1273) is a PERMANENT table
+				// property, not a lookup failure: file it under its own
+				// caveat key and skip the edge entirely — falling through to
+				// Phase-1 would scan the same history-polluted candidates the
+				// refusal exists to avoid. This is the backstop for callers
+				// that pass no PKMetas probe; with the probe wired, the gate
+				// at the top of scanChildren fires first.
+				if errors.Is(berr, reconstruct.ErrGeneratedPK) {
+					addIncomplete("generatedpk:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
+						"%s.%s cannot be synthesized: %v — a PERMANENT property of the table, not a transient "+
+							"lookup failure; its cascade side effects are not recovered", fk.Schema, fk.Table, berr))
+					return childScan{failed: true}
+				}
 				addIncomplete("baselinefail:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
 					"baseline lookup failed for %s.%s (recovery may be partial): %v", fk.Schema, fk.Table, berr))
 			case covered:

--- a/internal/cascade/cascade.go
+++ b/internal/cascade/cascade.go
@@ -591,7 +591,12 @@ func SynthesizeVictims(
 				if errors.Is(berr, reconstruct.ErrGeneratedPK) {
 					// Not berr verbatim: it already names the table and the
 					// generated column, and the caveat frame names both again —
-					// re-state the cause once, cleanly.
+					// re-state the cause once, cleanly. Memoize the verdict
+					// too: the refusal is a static table property, so later
+					// parents on this edge must neither re-run the provider
+					// scan nor emit the keychain probe's caveat (the hoisted
+					// gates consult the same memo).
+					genPKGated[fk.Schema+"."+fk.Table] = true
 					addGeneratedPKCaveat(fk, "its baseline lookup refused it: the primary key contains a "+
 						"generated column (most commonly the MariaDB system-versioning shape)")
 					return childScan{failed: true}

--- a/internal/cascade/cascade.go
+++ b/internal/cascade/cascade.go
@@ -126,6 +126,14 @@ type BaselineProvider interface {
 	// fkCol == parentPK in the newest complete baseline for (schema, table) at
 	// or before `at`, capped at limit. ok is false when no baseline covers the
 	// table (the caller then runs Phase-1 only for it).
+	//
+	// Contract for PERMANENT refusals (#1273): an implementation refusing a
+	// table because its primary key contains a generated column must wrap
+	// reconstruct.ErrGeneratedPK in the returned error, so the engine files
+	// the caveat as permanent (`generatedpk:`) and skips Phase-1 for the edge
+	// — a plain error lands in the transient `baselinefail:` bucket and the
+	// engine proceeds to scan the exact candidates the refusal exists to
+	// avoid.
 	BaselineChildren(ctx context.Context, schema, table, fkCol, parentPK string, at time.Time, limit int) (lookup BaselineLookup, ok bool, err error)
 }
 
@@ -158,7 +166,10 @@ type Options struct {
 	// anyway. Gated edges are skipped with a permanent `generatedpk:` caveat
 	// covering BOTH phases. nil disables the gate; the Phase-2 provider still
 	// refuses on its own via reconstruct.ErrGeneratedPK, which the caveat
-	// classifier recognizes — the backstop for probe-less callers.
+	// classifier recognizes — but ONLY when a baseline actually covers the
+	// table (a no-baseline edge returns ok=false before the provider's gate
+	// runs), so with no probe and no covering baseline the gate is off
+	// entirely. Wire the probe.
 	PKMetas func(schema, table string) []metadata.ColumnMeta
 }
 
@@ -431,6 +442,40 @@ func SynthesizeVictims(
 		warned[key] = true
 		warnings = append(warnings, msg)
 	}
+	// addGeneratedPKCaveat is the ONE caveat frame for both #1273 gate paths
+	// (the PKMetas probe and the provider-error backstop), so the two cannot
+	// drift in wording or key format; detail carries the path-specific cause.
+	addGeneratedPKCaveat := func(fk CascadeFK, detail string) {
+		addIncomplete("generatedpk:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
+			"%s.%s cannot be synthesized: %s — a PERMANENT property of the table, not a transient failure; "+
+				"its cascade side effects (and those of any deeper descendants through it) are not recovered, and for "+
+				"an ON UPDATE root the parent key reversal in the emitted SQL is still applied, leaving such child "+
+				"rows referencing a key that no longer exists", fk.Schema, fk.Table, detail))
+	}
+	// genPKGated memoizes the probe verdict per child table — a static fact of
+	// the schema snapshot, while scanChildren runs per (edge × parent key);
+	// same static-fact memo pattern as skewChecked. The memo also keeps the
+	// caveat's Sprintf from being rebuilt just for addIncomplete's dedup to
+	// discard it.
+	genPKGated := map[string]bool{}
+	generatedPKGated := func(fk CascadeFK) bool {
+		key := fk.Schema + "." + fk.Table
+		if gated, seen := genPKGated[key]; seen {
+			return gated
+		}
+		gated := false
+		if opts.PKMetas != nil {
+			if c, ok := reconstruct.GeneratedPKColumn(opts.PKMetas(fk.Schema, fk.Table)); ok {
+				gated = true
+				addGeneratedPKCaveat(fk, fmt.Sprintf(
+					"primary-key column %q is a generated column — most commonly the MariaDB system-versioning "+
+						"shape, whose binlog history carries history rows and versioned deletes under the surviving key",
+					c.Name))
+			}
+		}
+		genPKGated[key] = gated
+		return gated
+	}
 
 	// Count columns per constraint so composite (multi-column) FKs can be
 	// detected: the single-column victim match below would mis-reconstruct them
@@ -509,22 +554,12 @@ func SynthesizeVictims(
 	scanChildren := func(fk CascadeFK, parentKey string, rootTS time.Time) childScan {
 		// #1273: a child whose PK contains a generated column — the MariaDB
 		// system-versioning shape — cannot be synthesized from EITHER phase:
-		// its binlog history carries history-row inserts and row_end tombstone
-		// updates under the surviving key (the #1266 evidence), so the
-		// per-pk_values candidate scan would rebuild children from
-		// history-polluted state, and the baseline omits the generated PK
-		// member. Skip the edge with a permanent caveat instead, before any
-		// index or baseline work.
-		if opts.PKMetas != nil {
-			for _, c := range opts.PKMetas(fk.Schema, fk.Table) {
-				if c.IsGenerated {
-					addIncomplete("generatedpk:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
-						"%s.%s cannot be synthesized: primary-key column %q is a generated column (the MariaDB "+
-							"system-versioning shape) — a PERMANENT property of the table, not a transient failure; "+
-							"its cascade side effects are not recovered", fk.Schema, fk.Table, c.Name))
-					return childScan{failed: true}
-				}
-			}
+		// the per-pk_values candidate scan would rebuild children from
+		// history-polluted state (the #1266 evidence), and the baseline omits
+		// the generated PK member. Skip the edge with a permanent caveat
+		// instead, before any index or baseline work.
+		if generatedPKGated(fk) {
+			return childScan{failed: true}
 		}
 		until := rootTS
 		// Phase-1 window; widened to the baseline snapshot below.
@@ -554,9 +589,11 @@ func SynthesizeVictims(
 				// that pass no PKMetas probe; with the probe wired, the gate
 				// at the top of scanChildren fires first.
 				if errors.Is(berr, reconstruct.ErrGeneratedPK) {
-					addIncomplete("generatedpk:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
-						"%s.%s cannot be synthesized: %v — a PERMANENT property of the table, not a transient "+
-							"lookup failure; its cascade side effects are not recovered", fk.Schema, fk.Table, berr))
+					// Not berr verbatim: it already names the table and the
+					// generated column, and the caveat frame names both again —
+					// re-state the cause once, cleanly.
+					addGeneratedPKCaveat(fk, "its baseline lookup refused it: the primary key contains a "+
+						"generated column (most commonly the MariaDB system-versioning shape)")
 					return childScan{failed: true}
 				}
 				addIncomplete("baselinefail:"+fk.Schema+"."+fk.Table, fmt.Sprintf(
@@ -944,6 +981,17 @@ func SynthesizeVictims(
 							fk.Schema, fk.Table, fk.ConstraintName))
 						continue
 					}
+					// #1273 gate BEFORE the key-chain probe: a gated edge is
+					// skipped unconditionally, so running the probe would only
+					// add a redundant `keychain:` caveat implying a probing
+					// limitation on an edge that was never going to be probed.
+					// Deliberately AFTER `cascadedHere = true`, like the
+					// excluded-child branch above: the parent's own key
+					// reversal is real and must still be emitted (the caveat
+					// says so).
+					if generatedPKGated(fk) {
+						continue
+					}
 					if depth == 0 {
 						checkKeyChain(fk, pev, parentOldKey, item.rootTS, rootKey,
 							"some ON UPDATE cascade children may NOT be reconstructed")
@@ -1058,6 +1106,11 @@ func SynthesizeVictims(
 					continue
 				}
 				parentPK := valToString(refVal)
+				// #1273 gate before the key-chain probe — same reasoning as the
+				// ON UPDATE path: no probe caveat for an edge skipped outright.
+				if generatedPKGated(fk) {
+					continue
+				}
 				if depth == 0 && fk.UpdateRule == "CASCADE" {
 					// #1125: the delete-path analog of the key-chain blind spot.
 					// If an earlier UPDATE moved the referenced key INTO the value

--- a/internal/cascade/generatedpk_1273_test.go
+++ b/internal/cascade/generatedpk_1273_test.go
@@ -1,0 +1,120 @@
+package cascade_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/cascade"
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/reconstruct"
+)
+
+// The no-MySQL unit halves of the #1273 generated-PK cascade gate, in the
+// excluded_child_test.go style: both gates must fire BEFORE any index or
+// baseline scan, so a nil-DB engine proves the skip happens up front (any
+// fetch would panic).
+
+func cascadeDeleteFixture() ([]cascade.CascadeFK, []query.ResultRow) {
+	fks := []cascade.CascadeFK{{
+		Schema: "app", Table: "child", ConstraintName: "fk_del", Column: "pid",
+		ReferencedSchema: "app", ReferencedTable: "parent", ReferencedColumn: "id",
+		DeleteRule: "CASCADE", UpdateRule: "RESTRICT",
+	}}
+	parentDel := query.ResultRow{
+		SchemaName: "app", TableName: "parent", EventType: event.EventDelete,
+		PKValues: "1", RowBefore: map[string]any{"id": float64(1)},
+		EventTimestamp: time.Now(),
+	}
+	return fks, []query.ResultRow{parentDel}
+}
+
+// TestSynthesizeVictims_generatedPKChildSkippedViaProbe: with the PKMetas
+// probe wired (as the CLI/console/MCP call sites do), a child whose PK
+// contains a generated column — the MariaDB system-versioning shape — is
+// skipped in BOTH phases with the permanent generatedpk caveat, before any
+// candidate scan could rebuild children from history-polluted state.
+func TestSynthesizeVictims_generatedPKChildSkippedViaProbe(t *testing.T) {
+	fks, parents := cascadeDeleteFixture()
+	res, err := cascade.SynthesizeVictims(context.Background(), query.New(nil), fks, parents, cascade.Options{
+		PKMetas: func(schema, table string) []metadata.ColumnMeta {
+			if schema == "app" && table == "child" {
+				return []metadata.ColumnMeta{
+					{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+					{Name: "row_end", OrdinalPosition: 4, IsPK: true, DataType: "timestamp", IsGenerated: true},
+				}
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if res.Complete() {
+		t.Fatal("a generated-PK child edge must not report Complete")
+	}
+	if len(res.Victims) != 0 || len(res.SetNullRows) != 0 {
+		t.Errorf("gated edge must synthesize nothing, got %d victims / %d set-null rows", len(res.Victims), len(res.SetNullRows))
+	}
+	var flagged bool
+	for _, msg := range res.Incomplete {
+		if strings.Contains(msg, "app.child") && strings.Contains(msg, "generated column") &&
+			strings.Contains(msg, "PERMANENT") {
+			flagged = true
+		}
+	}
+	if !flagged {
+		t.Errorf("Incomplete must carry the permanent generated-PK caveat, got: %v", res.Incomplete)
+	}
+}
+
+// generatedPKProvider fakes a Phase-2 provider whose lookup refuses with the
+// reconstruct.ErrGeneratedPK sentinel — what cascadebaseline returns for a
+// versioned child since #1269/#1273.
+type generatedPKProvider struct{}
+
+func (generatedPKProvider) BaselineChildren(ctx context.Context, schema, table, fkCol, parentPK string, at time.Time, limit int) (cascade.BaselineLookup, bool, error) {
+	return cascade.BaselineLookup{}, false, fmt.Errorf("baseline scan of %s.%s: %w: primary-key column \"row_end\" is generated",
+		schema, table, reconstruct.ErrGeneratedPK)
+}
+
+// TestSynthesizeVictims_generatedPKBackstopViaProviderError: WITHOUT a PKMetas
+// probe, the Phase-2 provider's sentinel-wrapped refusal must land in the
+// permanent generatedpk caveat — never the transient-sounding baselinefail
+// bucket — and must skip the edge entirely: falling through to Phase-1 would
+// scan the same history-polluted candidates (the nil-DB engine proves the
+// skip; a Phase-1 fetch would panic).
+func TestSynthesizeVictims_generatedPKBackstopViaProviderError(t *testing.T) {
+	fks, parents := cascadeDeleteFixture()
+	res, err := cascade.SynthesizeVictims(context.Background(), query.New(nil), fks, parents, cascade.Options{
+		Baseline: generatedPKProvider{},
+	})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if res.Complete() {
+		t.Fatal("a generated-PK provider refusal must not report Complete")
+	}
+	if len(res.Victims) != 0 {
+		t.Errorf("gated edge must synthesize nothing, got %d victims", len(res.Victims))
+	}
+	var permanent, transient bool
+	for _, msg := range res.Incomplete {
+		if strings.Contains(msg, "PERMANENT") && strings.Contains(msg, "app.child") {
+			permanent = true
+		}
+		if strings.Contains(msg, "baseline lookup failed") {
+			transient = true
+		}
+	}
+	if !permanent {
+		t.Errorf("Incomplete must carry the permanent generated-PK caveat, got: %v", res.Incomplete)
+	}
+	if transient {
+		t.Errorf("the sentinel must not land in the transient baselinefail bucket: %v", res.Incomplete)
+	}
+}

--- a/internal/cascade/generatedpk_1273_test.go
+++ b/internal/cascade/generatedpk_1273_test.go
@@ -15,15 +15,20 @@ import (
 )
 
 // The no-MySQL unit halves of the #1273 generated-PK cascade gate, in the
-// excluded_child_test.go style: both gates must fire BEFORE any index or
+// excluded_child_test.go style: the gates must fire BEFORE any index or
 // baseline scan, so a nil-DB engine proves the skip happens up front (any
 // fetch would panic).
 
-func cascadeDeleteFixture() ([]cascade.CascadeFK, []query.ResultRow) {
+// cascadeDeleteFixture builds one CASCADE-delete edge to app.child plus a
+// parent DELETE root. updateRule is the mutation-sensitivity dial: "CASCADE"
+// arms the DELETE path's checkKeyChain probe, so deleting the hoisted gate
+// (which sits ABOVE the probe) makes the gated tests die on the nil-DB fetch
+// inside checkKeyChain instead of passing via scanChildren's internal gate.
+func cascadeDeleteFixture(updateRule string) ([]cascade.CascadeFK, []query.ResultRow) {
 	fks := []cascade.CascadeFK{{
 		Schema: "app", Table: "child", ConstraintName: "fk_del", Column: "pid",
 		ReferencedSchema: "app", ReferencedTable: "parent", ReferencedColumn: "id",
-		DeleteRule: "CASCADE", UpdateRule: "RESTRICT",
+		DeleteRule: "CASCADE", UpdateRule: updateRule,
 	}}
 	parentDel := query.ResultRow{
 		SchemaName: "app", TableName: "parent", EventType: event.EventDelete,
@@ -33,32 +38,22 @@ func cascadeDeleteFixture() ([]cascade.CascadeFK, []query.ResultRow) {
 	return fks, []query.ResultRow{parentDel}
 }
 
-// TestSynthesizeVictims_generatedPKChildSkippedViaProbe: with the PKMetas
-// probe wired (as the CLI/console/MCP call sites do), a child whose PK
-// contains a generated column — the MariaDB system-versioning shape — is
-// skipped in BOTH phases with the permanent generatedpk caveat, before any
-// candidate scan could rebuild children from history-polluted state.
-func TestSynthesizeVictims_generatedPKChildSkippedViaProbe(t *testing.T) {
-	fks, parents := cascadeDeleteFixture()
-	res, err := cascade.SynthesizeVictims(context.Background(), query.New(nil), fks, parents, cascade.Options{
-		PKMetas: func(schema, table string) []metadata.ColumnMeta {
-			if schema == "app" && table == "child" {
-				return []metadata.ColumnMeta{
-					{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
-					{Name: "row_end", OrdinalPosition: 4, IsPK: true, DataType: "timestamp", IsGenerated: true},
-				}
-			}
-			return nil
-		},
-	})
-	if err != nil {
-		t.Fatalf("SynthesizeVictims: %v", err)
+// svChildPKMetas is the probe both gate tests wire: app.child's PK carries a
+// generated member (the MariaDB system-versioning shape).
+func svChildPKMetas(schema, table string) []metadata.ColumnMeta {
+	if schema == "app" && table == "child" {
+		return []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+			{Name: "row_end", OrdinalPosition: 4, IsPK: true, DataType: "timestamp", IsGenerated: true},
+		}
 	}
+	return nil
+}
+
+func assertGeneratedPKCaveat(t *testing.T, res cascade.Result) {
+	t.Helper()
 	if res.Complete() {
 		t.Fatal("a generated-PK child edge must not report Complete")
-	}
-	if len(res.Victims) != 0 || len(res.SetNullRows) != 0 {
-		t.Errorf("gated edge must synthesize nothing, got %d victims / %d set-null rows", len(res.Victims), len(res.SetNullRows))
 	}
 	var flagged bool
 	for _, msg := range res.Incomplete {
@@ -68,13 +63,72 @@ func TestSynthesizeVictims_generatedPKChildSkippedViaProbe(t *testing.T) {
 		}
 	}
 	if !flagged {
-		t.Errorf("Incomplete must carry the permanent generated-PK caveat, got: %v", res.Incomplete)
+		t.Fatalf("Incomplete must carry the permanent generated-PK caveat, got: %v", res.Incomplete)
 	}
+}
+
+// TestSynthesizeVictims_generatedPKChildSkippedViaProbe: with the PKMetas
+// probe wired (as the CLI/console/MCP call sites do), a versioned child edge
+// is skipped in BOTH phases with the permanent generatedpk caveat, before any
+// candidate scan could rebuild children from history-polluted state. The
+// fixture's UpdateRule "CASCADE" makes the DELETE-path HOIST independently
+// observable: without it, checkKeyChain (which the hoist sits above) fetches
+// on the nil DB and this test dies by panic rather than passing through
+// scanChildren's internal gate.
+func TestSynthesizeVictims_generatedPKChildSkippedViaProbe(t *testing.T) {
+	fks, parents := cascadeDeleteFixture("CASCADE")
+	res, err := cascade.SynthesizeVictims(context.Background(), query.New(nil), fks, parents, cascade.Options{
+		PKMetas: svChildPKMetas,
+	})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(res.Victims) != 0 || len(res.SetNullRows) != 0 {
+		t.Errorf("gated edge must synthesize nothing, got %d victims / %d set-null rows", len(res.Victims), len(res.SetNullRows))
+	}
+	assertGeneratedPKCaveat(t, res)
+}
+
+// TestSynthesizeVictims_generatedPKUpdateRootHoist covers the ON UPDATE
+// root path's hoist and the caveat's boldest claim: the gate sits
+// deliberately AFTER `cascadedHere = true`, so the parent's OWN key reversal
+// is still emitted (KeyUpdateParents) while the versioned child edge is
+// skipped — exactly what the caveat text warns about. Deleting that hoist
+// makes checkKeyChain fetch on the nil DB (panic); moving the gate ABOVE
+// `cascadedHere = true` silently drops the parent reversal and the
+// KeyUpdateParents assertion catches it.
+func TestSynthesizeVictims_generatedPKUpdateRootHoist(t *testing.T) {
+	fks := []cascade.CascadeFK{{
+		Schema: "app", Table: "child", ConstraintName: "fk_upd", Column: "pid",
+		ReferencedSchema: "app", ReferencedTable: "parent", ReferencedColumn: "id",
+		DeleteRule: "RESTRICT", UpdateRule: "CASCADE",
+	}}
+	parentUpd := query.ResultRow{
+		SchemaName: "app", TableName: "parent", EventType: event.EventUpdate,
+		PKValues:       "1",
+		RowBefore:      map[string]any{"id": float64(1)},
+		RowAfter:       map[string]any{"id": float64(2)},
+		EventTimestamp: time.Now(),
+	}
+	res, err := cascade.SynthesizeVictims(context.Background(), query.New(nil), fks, []query.ResultRow{parentUpd}, cascade.Options{
+		PKMetas: svChildPKMetas,
+	})
+	if err != nil {
+		t.Fatalf("SynthesizeVictims: %v", err)
+	}
+	if len(res.KeyUpdates) != 0 {
+		t.Errorf("gated edge must synthesize no FK restores, got %d", len(res.KeyUpdates))
+	}
+	if len(res.KeyUpdateParents) != 1 {
+		t.Fatalf("the parent's own key reversal must still be emitted for a gated edge (gate sits after cascadedHere), got %d KeyUpdateParents", len(res.KeyUpdateParents))
+	}
+	assertGeneratedPKCaveat(t, res)
 }
 
 // generatedPKProvider fakes a Phase-2 provider whose lookup refuses with the
 // reconstruct.ErrGeneratedPK sentinel — what cascadebaseline returns for a
-// versioned child since #1269/#1273.
+// versioned child since #1269/#1273 (the REAL provider's wrap is pinned by
+// errors.Is in internal/cascadebaseline/provider_generatedpk_1266_test.go).
 type generatedPKProvider struct{}
 
 func (generatedPKProvider) BaselineChildren(ctx context.Context, schema, table, fkCol, parentPK string, at time.Time, limit int) (cascade.BaselineLookup, bool, error) {
@@ -87,9 +141,11 @@ func (generatedPKProvider) BaselineChildren(ctx context.Context, schema, table, 
 // permanent generatedpk caveat — never the transient-sounding baselinefail
 // bucket — and must skip the edge entirely: falling through to Phase-1 would
 // scan the same history-polluted candidates (the nil-DB engine proves the
-// skip; a Phase-1 fetch would panic).
+// skip; a Phase-1 fetch would panic). UpdateRule RESTRICT here on purpose:
+// with no probe the hoists cannot fire, so an armed checkKeyChain would panic
+// before the provider branch this test exists to reach.
 func TestSynthesizeVictims_generatedPKBackstopViaProviderError(t *testing.T) {
-	fks, parents := cascadeDeleteFixture()
+	fks, parents := cascadeDeleteFixture("RESTRICT")
 	res, err := cascade.SynthesizeVictims(context.Background(), query.New(nil), fks, parents, cascade.Options{
 		Baseline: generatedPKProvider{},
 	})
@@ -116,5 +172,29 @@ func TestSynthesizeVictims_generatedPKBackstopViaProviderError(t *testing.T) {
 	}
 	if transient {
 		t.Errorf("the sentinel must not land in the transient baselinefail bucket: %v", res.Incomplete)
+	}
+}
+
+// TestPKMetasFromResolver pins the adapter's two documented degrade paths:
+// a nil resolver yields a nil probe (gate off — the call sites' best-effort
+// resolver loading), and a table the resolver cannot resolve degrades to nil
+// metas (gate silent for that table) instead of erroring the run.
+func TestPKMetasFromResolver(t *testing.T) {
+	if cascade.PKMetasFromResolver(nil) != nil {
+		t.Fatal("nil resolver must yield a nil probe")
+	}
+	r := metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"app.child": {Schema: "app", Table: "child", Columns: []metadata.ColumnMeta{
+			{Name: "id", OrdinalPosition: 1, IsPK: true, DataType: "int"},
+			{Name: "row_end", OrdinalPosition: 4, IsPK: true, DataType: "timestamp", IsGenerated: true},
+		}},
+	})
+	probe := cascade.PKMetasFromResolver(r)
+	metas := probe("app", "child")
+	if len(metas) != 2 || metas[1].Name != "row_end" || !metas[1].IsGenerated {
+		t.Fatalf("probe must return the PK metas in ordinal order, got: %+v", metas)
+	}
+	if got := probe("app", "missing"); got != nil {
+		t.Fatalf("a resolve failure must degrade to nil metas, got: %+v", got)
 	}
 }

--- a/internal/cascadebaseline/provider.go
+++ b/internal/cascadebaseline/provider.go
@@ -98,8 +98,12 @@ func (p *Provider) BaselineChildren(ctx context.Context, schema, table, fkCol, p
 	// re-snapshot can ever satisfy. Fail loud with the real cause instead,
 	// same stance as the fkFilterSafe refusal below.
 	if c, found := reconstruct.GeneratedPKColumn(tm.PKColumnMetas()); found {
-		return cascade.BaselineLookup{}, false, fmt.Errorf("baseline scan of %s.%s: %s",
-			schema, table, reconstruct.GeneratedPKGateReason(c, "the cascade baseline fallback"))
+		// Wrapped with the ErrGeneratedPK sentinel (#1273) so the cascade
+		// engine's caveat classifier can file this under the permanent
+		// `generatedpk:` caveat — and skip Phase-1 for the edge too — instead
+		// of the transient-sounding `baselinefail:` bucket.
+		return cascade.BaselineLookup{}, false, fmt.Errorf("baseline scan of %s.%s: %w: %s",
+			schema, table, reconstruct.ErrGeneratedPK, reconstruct.GeneratedPKGateReason(c, "the cascade baseline fallback"))
 	}
 	// The FK filter binds parentPK as a STRING against the baseline column.
 	// DuckDB coerces it exactly for integer/string FK columns, but for

--- a/internal/cascadebaseline/provider.go
+++ b/internal/cascadebaseline/provider.go
@@ -98,12 +98,15 @@ func (p *Provider) BaselineChildren(ctx context.Context, schema, table, fkCol, p
 	// re-snapshot can ever satisfy. Fail loud with the real cause instead,
 	// same stance as the fkFilterSafe refusal below.
 	if c, found := reconstruct.GeneratedPKColumn(tm.PKColumnMetas()); found {
-		// Wrapped with the ErrGeneratedPK sentinel (#1273) so the cascade
-		// engine's caveat classifier can file this under the permanent
-		// `generatedpk:` caveat — and skip Phase-1 for the edge too — instead
-		// of the transient-sounding `baselinefail:` bucket.
-		return cascade.BaselineLookup{}, false, fmt.Errorf("baseline scan of %s.%s: %w: %s",
-			schema, table, reconstruct.ErrGeneratedPK, reconstruct.GeneratedPKGateReason(c, "the cascade baseline fallback"))
+		// Classified as reconstruct.ErrGeneratedPK (#1273) so the cascade
+		// engine's caveat classifier files this under the permanent
+		// `generatedpk:` caveat — and skips Phase-1 for the edge too — instead
+		// of the transient-sounding `baselinefail:` bucket. Built via
+		// GeneratedPKRefusalError, not %w: the sentinel's own text would
+		// stutter against the gate reason's opening clause.
+		return cascade.BaselineLookup{}, false, reconstruct.GeneratedPKRefusalError(fmt.Sprintf(
+			"baseline scan of %s.%s: %s",
+			schema, table, reconstruct.GeneratedPKGateReason(c, "the cascade baseline fallback")))
 	}
 	// The FK filter binds parentPK as a STRING against the baseline column.
 	// DuckDB coerces it exactly for integer/string FK columns, but for

--- a/internal/cascadebaseline/provider_generatedpk_1266_test.go
+++ b/internal/cascadebaseline/provider_generatedpk_1266_test.go
@@ -2,6 +2,7 @@ package cascadebaseline
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -33,6 +34,15 @@ func TestProvider_generatedPKRefusesWithRealCause(t *testing.T) {
 	_, _, err := New(find, resolver).BaselineChildren(context.Background(), "shop", "child", "pid", "1", time.Now(), 100)
 	if err == nil {
 		t.Fatal("expected the generated-PK refusal, got nil")
+	}
+	// #1273: the REAL provider must wrap the sentinel — the cascade engine's
+	// permanent-caveat classifier keys on errors.Is, and the engine-side
+	// backstop test uses a fake provider that hand-writes the wrap, so this
+	// is the one assertion tying the two together. Reverting the %w to a
+	// plain %s would silently reclassify the refusal as transient
+	// baselinefail AND let Phase-1 scan the history-polluted candidates.
+	if !errors.Is(err, reconstruct.ErrGeneratedPK) {
+		t.Fatalf("refusal must wrap reconstruct.ErrGeneratedPK, got: %v", err)
 	}
 	if !strings.Contains(err.Error(), "generated column") || !strings.Contains(err.Error(), `"row_end"`) {
 		t.Fatalf("want the generated-PK cause naming row_end, got: %v", err)

--- a/internal/cli/recover_cascade.go
+++ b/internal/cli/recover_cascade.go
@@ -300,6 +300,7 @@ func runRecoverCascade(cmd *cobra.Command, args []string) error {
 				MaxDepth:        rcMaxDepth,
 				Baseline:        baselineProvider,
 				ArchivesPresent: archivesExist,
+				PKMetas:         cascade.PKMetasFromResolver(resolver),
 			})
 			results = append(results, r)
 			if serr != nil {

--- a/internal/cli/recover_cascade_integration_test.go
+++ b/internal/cli/recover_cascade_integration_test.go
@@ -117,6 +117,48 @@ func TestRecoverCascade_endToEnd(t *testing.T) {
 	}
 }
 
+// TestRecoverCascade_generatedPKChildGatedViaCLIWiring pins the CLI surface's
+// PKMetas wiring (#1273): the snapshot marks the child's PK as containing a
+// STORED GENERATED member (the MariaDB system-versioning shape), so the
+// CLI-built cascade.Options must carry the probe. With it, the edge is
+// skipped with the permanent generatedpk caveat and NO child INSERTs are
+// synthesized from the indexed events; delete the `PKMetas:` line in the
+// CLI's SynthesizeVictims call and both assertions fail (Phase-1 would scan
+// and synthesize the two children).
+func TestRecoverCascade_generatedPKChildGatedViaCLIWiring(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, dbName, dsn := seedCascadeIndex(t)
+	// seedCascadeIndex snapshots only the parent; give the child the
+	// versioned PK shape (id, row_end) with row_end STORED GENERATED.
+	h := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour).Format("2006-01-02 15:04:05")
+	testutil.MustExec(t, db, `INSERT INTO schema_snapshots
+		(snapshot_id, snapshot_time, schema_name, table_name, column_name,
+		 ordinal_position, column_key, data_type, is_nullable, is_generated)
+		VALUES (1, ?, ?, 'child', 'id', 1, 'PRI', 'int', 'NO', 0),
+		       (1, ?, ?, 'child', 'pid', 2, '', 'int', 'YES', 0),
+		       (1, ?, ?, 'child', 'row_end', 3, 'PRI', 'timestamp', 'NO', 1)`,
+		h, dbName, h, dbName, h, dbName)
+
+	out := t.TempDir() + "/cascade.sql"
+	cleanCascadeFlags(dsn, dbName, out)
+	rcAllowIncomplete = true // caveat still lands in the output banner; exit stays 0
+
+	if err := runCascadeCmd(t); err != nil {
+		t.Fatalf("runRecoverCascade with --allow-incomplete: %v", err)
+	}
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	sql := string(b)
+	if !strings.Contains(sql, "generated column") || !strings.Contains(sql, "PERMANENT") {
+		t.Errorf("output must carry the permanent generated-PK caveat\n---\n%s", sql)
+	}
+	if c := strings.Count(sql, "INSERT INTO `"+dbName+"`.`child`"); c != 0 {
+		t.Errorf("gated child edge must synthesize no INSERTs, got %d\n---\n%s", c, sql)
+	}
+}
+
 // addArchiveRow makes ResolveArchiveSources return non-empty (no disk
 // dependency) by registering an S3-located archived partition.
 func addArchiveRow(t *testing.T, db *sql.DB) {

--- a/internal/console/recover_cascade.go
+++ b/internal/console/recover_cascade.go
@@ -420,6 +420,7 @@ func (s *Server) synthesizeCascade(ctx context.Context, b *bundle, p cascadeSynt
 				MaxDepth:        p.MaxDepth,
 				Baseline:        baselineProvider,
 				ArchivesPresent: archivesExist,
+				PKMetas:         cascade.PKMetasFromResolver(b.resolver),
 			})
 			results = append(results, r)
 			if serr != nil {

--- a/internal/mcptools/recover_cascade.go
+++ b/internal/mcptools/recover_cascade.go
@@ -342,6 +342,7 @@ func MakeRecoverCascadeTool(cfg Config) func(context.Context, *mcp.CallToolReque
 					MaxDepth:        maxDepth,
 					Baseline:        baselineProvider,
 					ArchivesPresent: archivesExist,
+					PKMetas:         cascade.PKMetasFromResolver(resolver),
 				})
 				results = append(results, r)
 				if serr != nil {

--- a/internal/reconstruct/pkgatereason.go
+++ b/internal/reconstruct/pkgatereason.go
@@ -1,11 +1,19 @@
 package reconstruct
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/dbtrail/dbtrail/internal/metadata"
 )
+
+// ErrGeneratedPK is the errors.Is sentinel wrapped by refusals caused by a
+// generated primary-key member — the MariaDB system-versioning shape
+// (#1266/#1273). Machine callers (the cascade engine's caveat classifier)
+// use it to tell this PERMANENT table property apart from transient lookup
+// failures without string matching.
+var ErrGeneratedPK = errors.New("primary key contains a generated column")
 
 // PKTypeGateReason renders the refusal detail for a primary-key column a
 // MySQL-path SupportedPKType gate rejected. Two physically different causes

--- a/internal/reconstruct/pkgatereason.go
+++ b/internal/reconstruct/pkgatereason.go
@@ -8,12 +8,36 @@ import (
 	"github.com/dbtrail/dbtrail/internal/metadata"
 )
 
-// ErrGeneratedPK is the errors.Is sentinel wrapped by refusals caused by a
+// ErrGeneratedPK is the errors.Is sentinel for refusals caused by a
 // generated primary-key member — the MariaDB system-versioning shape
 // (#1266/#1273). Machine callers (the cascade engine's caveat classifier)
 // use it to tell this PERMANENT table property apart from transient lookup
 // failures without string matching.
+//
+// Who carries it: every ERROR-typed refusal from this shape — the
+// cascadebaseline provider's BaselineChildren refusal and
+// fullTableGeneratedPKRefusal below, both built via GeneratedPKRefusalError.
+// The verify inconclusive detail and the shim wire message are STRINGS by
+// construction and cannot carry a sentinel; do not branch on errors.Is for
+// those surfaces.
 var ErrGeneratedPK = errors.New("primary key contains a generated column")
+
+// generatedPKErr classifies as ErrGeneratedPK via Is WITHOUT injecting the
+// sentinel's text into the rendered message — a %w wrap stutters ("primary
+// key contains a generated column: primary-key column ... is a generated
+// column ..."). Same pattern as MissingPKColumnError below.
+type generatedPKErr struct{ msg string }
+
+func (e *generatedPKErr) Error() string { return e.msg }
+
+// Is makes errors.Is(err, ErrGeneratedPK) true for the concrete type.
+func (e *generatedPKErr) Is(target error) bool { return target == ErrGeneratedPK }
+
+// GeneratedPKRefusalError builds an error that renders exactly msg and
+// matches errors.Is(err, ErrGeneratedPK). Every error-typed generated-PK
+// refusal must be built through this, or the cascade engine's permanent-
+// caveat classifier files it as a transient lookup failure.
+func GeneratedPKRefusalError(msg string) error { return &generatedPKErr{msg: msg} }
 
 // PKTypeGateReason renders the refusal detail for a primary-key column a
 // MySQL-path SupportedPKType gate rejected. Two physically different causes
@@ -99,10 +123,11 @@ func GeneratedPKGateReason(c metadata.ColumnMeta, surface string) string {
 
 // fullTableGeneratedPKRefusal is the error both full-table reconstruct paths
 // (baseline merge and binlog-only fallback) return when the PK contains a
-// generated column, so the two cannot drift.
+// generated column, so the two cannot drift. Classified as ErrGeneratedPK
+// (via GeneratedPKRefusalError) so machine callers need no string matching.
 func fullTableGeneratedPKRefusal(schema, table string, pkCol metadata.ColumnMeta) error {
-	return fmt.Errorf("full-table reconstruct: %s.%s: %s", schema, table,
-		GeneratedPKGateReason(pkCol, "full-table reconstruct"))
+	return GeneratedPKRefusalError(fmt.Sprintf("full-table reconstruct: %s.%s: %s", schema, table,
+		GeneratedPKGateReason(pkCol, "full-table reconstruct")))
 }
 
 // fullTablePKTypeRefusal is the error ReconstructTable's PK-type gate returns


### PR DESCRIPTION
closes #1273

## Summary
- **The gap**: cascade Phase-1 (no baseline configured — the default) had no metadata seam, so a system-versioned child's candidate scan treated each history-row INSERT as an independent candidate and missed tombstoned deletes — synthesized restores from history-polluted state, silently. Phase-2's refusal (added in #1269) was also mislabeled as a transient `baselinefail:` and still fell through to the same polluted Phase-1 scan.
- **`cascade.Options.PKMetas`** — optional PK-metadata probe (adapted from the schema resolver via `PKMetasFromResolver`, wired at all three call sites: CLI, console, MCP). A child edge with a generated PK member is skipped in **both** phases with a permanent `generatedpk:` caveat, before any index or baseline work. Exit semantics unchanged: non-zero without `--allow-incomplete`; suppressing it consciously yields a safe skip (nothing synthesized), never wrong SQL.
- **`reconstruct.ErrGeneratedPK`** sentinel — wrapped by the cascadebaseline provider's refusal so probe-less callers get the same permanent classification (no string matching, per the sentinel-verdict convention), and the edge skips Phase-1 too.
- Docs: one bullet in the system-versioned tables section.

## Test plan
- [x] Nil-DB engine unit tests (excluded_child_test.go style — a reached fetch panics, proving the gates fire before any scan): probe path and provider-sentinel backstop path, including the assertion that the sentinel never lands in the `baselinefail:` bucket
- [x] `go test ./... -count=1` green; `go test -tags integration ./internal/cascade/ ./internal/cascadebaseline/` green against live MySQL; `go vet -tags integration ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
