### PR TITLE
console: name the archive-reconcile remedy in the reconstruct gap 422

### DIFF
--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -401,8 +401,14 @@ func (s *Server) handleReconstruct(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var gapErr *query.GapError
 		if errors.As(err, &gapErr) {
+			// Non-lossy remedy first, lossy override second — same ordering
+			// as the CLI (#1268) and MCP (#1271) surfaces. The console user
+			// may not be the operator, hence the "have the operator" framing.
 			writeJSONError(w, http.StatusUnprocessableEntity,
-				"can't reconstruct across a gap in the captured history — "+err.Error()+" (check \"Continue even if some history is missing\" to proceed anyway)")
+				"can't reconstruct across a gap in the captured history — "+err.Error()+
+					" — gap detection reads archive_state, so a rebuilt index reports already-archived hours as gaps too; "+
+					"if archives exist in storage, have the operator run `bintrail archive reconcile --repair --index-dsn ... --archive-s3 s3://...` (or --archive-dir) and retry, "+
+					"or check \"Continue even if some history is missing\" to proceed with a possibly incomplete result")
 			return
 		}
 		writeFetchError(w, err)

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -402,8 +402,9 @@ func (s *Server) handleReconstruct(w http.ResponseWriter, r *http.Request) {
 		var gapErr *query.GapError
 		if errors.As(err, &gapErr) {
 			// Non-lossy remedy first, lossy override second — same ordering
-			// as the CLI (#1268) and MCP (#1271) surfaces. The console user
-			// may not be the operator, hence the "have the operator" framing.
+			// as the CLI (#1268) and MCP (#1271) surfaces, and the same
+			// "have the operator" framing as MCP (only the CLI addresses the
+			// operator directly).
 			writeJSONError(w, http.StatusUnprocessableEntity,
 				"can't reconstruct across a gap in the captured history — "+err.Error()+
 					" — gap detection reads archive_state, so a rebuilt index reports already-archived hours as gaps too; "+

--- a/internal/console/reconstruct_integration_test.go
+++ b/internal/console/reconstruct_integration_test.go
@@ -199,6 +199,12 @@ func TestIntegrationReconstructGapRefused(t *testing.T) {
 	if rec.Code != 422 {
 		t.Errorf("reconstruct over a gap without allow_gaps: code=%d, want 422 (body=%s)", rec.Code, body)
 	}
+	// The refusal must name the non-lossy remedy, not just the checkbox
+	// override (#1275) — deleting the hint leaves the user with only the
+	// lossy exit.
+	if !strings.Contains(string(body), "archive reconcile --repair") {
+		t.Errorf("gap 422 must name the reconcile remedy, got body: %s", body)
+	}
 }
 
 func TestIntegrationReconstructUnknownPK(t *testing.T) {


### PR DESCRIPTION
closes #1275

## Summary
- Third surface of the #961 series (CLI fixed in #1268, MCP in #1271): the console's `/api/reconstruct` gap refusal (422) offered only the lossy override — the "Continue even if some history is missing" checkbox — and never the non-lossy remedy for the rebuilt-index case.
- The 422 message now mirrors the #1268/#1271 ordering: the `archive_state` bridge explanation, then the operator-run `bintrail archive reconcile --repair ...` remedy ("have the operator run" framing — the console user may not be the operator), then the checkbox as fallback.
- `GapError.Error()` stays library-neutral; the wording lives in the console handler, same layering as the other two surfaces.

## Test plan
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] `go vet ./...`, `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
