### PR TITLE
reconstruct: keep the boundary-probe error surface-neutral (no --at leak to MCP)

### DIFF
--- a/internal/reconstruct/boundary.go
+++ b/internal/reconstruct/boundary.go
@@ -97,7 +97,13 @@ func TrimPartialTailTransaction(
 	lookAfter := at.Truncate(time.Second).Add(time.Second)
 	continues, err := gtidHasEventAfter(ctx, db, engine, fm, gtid, lookAfter)
 	if err != nil {
-		return nil, fmt.Errorf("check whether transaction %s continues past --at: %w", gtid, err)
+		// Surface-neutral on purpose (#1286): this error reaches MCP clients
+		// verbatim via ErrorResult, and the tool parameter there is `at`, not
+		// `--at` — naming the CLI flag is the leak class the MCP no-flag-leak
+		// rule exists to prevent. Same pattern as query.GapError /
+		// SourceEmptyError: the library Error() stays flag-free and each
+		// surface attaches its own wording.
+		return nil, fmt.Errorf("check whether transaction %s continues past the requested cut point: %w", gtid, err)
 	}
 	if !continues {
 		return events, nil

--- a/internal/reconstruct/boundary_test.go
+++ b/internal/reconstruct/boundary_test.go
@@ -70,4 +70,9 @@ func TestTrimPartialTailTransaction_probeErrorIsSurfaceNeutral(t *testing.T) {
 	if strings.Contains(err.Error(), "--at") {
 		t.Errorf("boundary-probe error must stay surface-neutral (no --at CLI flag), got %q", err)
 	}
+	// Positive half: the negative alone would also pass if the error came
+	// from a layer before the wrapper — pin that the probe's wrapper ran.
+	if !strings.Contains(err.Error(), "continues past") {
+		t.Errorf("expected the boundary-probe wrapper in the error, got %q", err)
+	}
 }

--- a/internal/reconstruct/boundary_test.go
+++ b/internal/reconstruct/boundary_test.go
@@ -2,8 +2,12 @@ package reconstruct
 
 import (
 	"context"
+	"database/sql"
+	"strings"
 	"testing"
 	"time"
+
+	_ "github.com/go-sql-driver/mysql"
 
 	"github.com/dbtrail/dbtrail/internal/query"
 )
@@ -42,5 +46,28 @@ func TestTrimPartialTailTransaction_noGTIDSkipsProbe(t *testing.T) {
 	}
 	if len(got2) != 1 {
 		t.Errorf("want the empty-GTID event passed through unchanged, got %d events", len(got2))
+	}
+}
+
+// TestTrimPartialTailTransaction_probeErrorIsSurfaceNeutral pins #1286: the
+// MCP reconstruct tool hands the boundary-probe error verbatim to ErrorResult,
+// and the tool parameter there is `at` — so the library string must not name
+// the `--at` CLI flag; each surface owns its own wording (the
+// query.GapError / SourceEmptyError precedent). A dead index DB (nothing
+// listens on port 1) forces the probe's error path without needing MySQL.
+func TestTrimPartialTailTransaction_probeErrorIsSurfaceNeutral(t *testing.T) {
+	db, err := sql.Open("mysql", "u:p@tcp(127.0.0.1:1)/x?timeout=200ms")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	gtid := "3e11fa47-71ca-11e1-9e33-c80aa9429562:23"
+	events := []query.ResultRow{{EventTimestamp: time.Now(), GTID: &gtid}}
+	_, err = TrimPartialTailTransaction(context.Background(), db, query.New(db), query.FetchMergedOptions{}, events, time.Now())
+	if err == nil {
+		t.Fatal("a dead index DB must fail the probe")
+	}
+	if strings.Contains(err.Error(), "--at") {
+		t.Errorf("boundary-probe error must stay surface-neutral (no --at CLI flag), got %q", err)
 	}
 }


### PR DESCRIPTION
closes #1286

## Summary
- The #783 boundary-probe error (`TrimPartialTailTransaction`) reached MCP clients verbatim via `ErrorResult` while naming the `--at` CLI flag; the MCP tool parameter is `at`, so this was the exact leak class the no-CLI-flag-leak rule prevents.
- Library string is now surface-neutral ("continues past the requested cut point"), following the `query.GapError`/`SourceEmptyError` pattern: `Error()` stays flag-free, each surface owns its own wording. The `slog.Warn` in the same function keeps `--at` on purpose — server-side log, never client-visible.
- Grepped the file: this was the only error string in `boundary.go`.

## Test plan
- [x] New guard test drives the probe's real error path against a dead index DB (nothing listens on port 1, no MySQL needed) and asserts the error carries no `--at`.
- [x] `go build`, `go vet` (both tag sets), `-race` on the package, full `go test ./... -count=1` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
