### PR TITLE
mcp: surface skipped archive sources in query/recover tool results

### DIFF
--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -319,7 +319,10 @@ func resolveDSN(override string) (string, error) {
 func errorResult(err error) *mcp.CallToolResult { return mcptools.ErrorResult(err) }
 
 func resolveArchiveSources(ctx context.Context, db *sql.DB) []string {
-	return mcptools.EnvArchiveSources(ctx, db)
+	// The discovery-failure signal is consumed by the tool handlers
+	// themselves (#1285); callers of this helper only need the list.
+	s, _ := mcptools.EnvArchiveSources(ctx, db)
+	return s
 }
 
 const defaultMCPQueryMaxLimit = mcptools.DefaultQueryMaxLimit

--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -318,13 +318,6 @@ func resolveDSN(override string) (string, error) {
 
 func errorResult(err error) *mcp.CallToolResult { return mcptools.ErrorResult(err) }
 
-func resolveArchiveSources(ctx context.Context, db *sql.DB) []string {
-	// The discovery-failure signal is consumed by the tool handlers
-	// themselves (#1285); callers of this helper only need the list.
-	s, _ := mcptools.EnvArchiveSources(ctx, db)
-	return s
-}
-
 const defaultMCPQueryMaxLimit = mcptools.DefaultQueryMaxLimit
 
 func mcpQueryMaxLimit() int { return mcptools.EnvQueryMaxLimit() }

--- a/cmd/bintrail-mcp/main_test.go
+++ b/cmd/bintrail-mcp/main_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dbtrail/dbtrail/internal/mcptools"
 	"github.com/dbtrail/dbtrail/internal/parser"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -258,6 +259,15 @@ func TestErrorResult(t *testing.T) {
 }
 
 // ─── resolveArchiveSources ──────────────────────────────────────────────────
+
+// resolveArchiveSources is a test-only shim over mcptools.EnvArchiveSources:
+// production flows through Target.archiveSources, which also consumes the
+// discovery-failure signal these listing tests don't need. It lives here (not
+// main.go) so no production caller can inherit the signal-dropping `_`.
+func resolveArchiveSources(ctx context.Context, db *sql.DB) []string {
+	s, _ := mcptools.EnvArchiveSources(ctx, db)
+	return s
+}
 
 func TestResolveArchiveSources_envVars(t *testing.T) {
 	t.Setenv("BINTRAIL_ARCHIVE_S3", "s3://my-bucket/archives/")

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -268,6 +268,17 @@ archive sources from `archive_state` in the index database (or from the
 from MySQL and Parquet are merged, deduplicated, and sorted before output or SQL
 generation. Pass `no_archive` to disable this.
 
+When archives misbehave, the two tools diverge on purpose
+([#1285](https://github.com/dbtrail/dbtrail/issues/1285)): `query` degrades and
+says so — the result carries trailing `Warning: archive_source_skipped: …` lines
+for sources that failed to read, `Warning: archive_discovery_failed: …` when
+discovery itself failed, and `Warning: archive_scan_incomplete: …` when the
+misfiled-archive registry scan failed — while `recover` **refuses** to generate
+a script in any of those cases: a reversal missing part of the matched events is
+a partial undo, not a smaller one. The refusal names the escape hatch — retry
+with `no_archive: true` to generate from the live index only, accepting that
+archived events will not be reversed.
+
 **Index DSN.** The server connects to the index via the `BINTRAIL_INDEX_DSN`
 environment variable (set once at startup) or the per-call `index_dsn` parameter,
 which overrides the env var. Set the env var at startup so callers don't repeat
@@ -293,7 +304,9 @@ the console serves `/mcp` these parameters are **rejected**: the baseline is tha
 server's own configuration, and an MCP client must not point the console at
 arbitrary storage.
 
-**`allow_gaps` defaults to `false`, unlike `query`/`recover`.** A hole in the
+**`allow_gaps` defaults to `false`, unlike `query`'s degrade-with-warnings
+posture (`recover` likewise refuses on archive trouble — see Archive
+auto-discovery above).** A hole in the
 captured history makes a reconstruction *silently wrong* (a state that never
 existed), not merely incomplete, so the tool aborts with an actionable error and
 you opt in explicitly. It also refuses outright — no override — when a

--- a/internal/mcptools/archiveskip_integration_test.go
+++ b/internal/mcptools/archiveskip_integration_test.go
@@ -15,13 +15,16 @@ import (
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
 
-// TestIntegrationArchiveSkipWarning pins the #1285 wiring for BOTH tools: a
-// registered archive source whose fetch fails (its only file is not valid
-// Parquet) must surface as an archive_source_skipped warning in the tool
-// RESULT, not only in the server log — an MCP client sees nothing else, so a
-// response missing every event held by a source would otherwise read as
-// complete. Deleting the skippedArchives append or the ArchiveSkipNotice call
-// in either tool turns this red.
+// TestIntegrationArchiveSkipWarning pins the #1285 wiring for both tools and
+// both failure shapes. Per-source fetch failure (a registered archive whose
+// only file is not valid Parquet): the query tool must carry an
+// archive_source_skipped warning in the RESULT — an MCP client sees nothing
+// else — and the recover tool must REFUSE (a knowingly incomplete reversal
+// script is never returned; no_archive is the escape hatch, and it must
+// actually work). Discovery failure (archive_state unreadable): query warns
+// archive_discovery_failed, recover refuses. Deleting the skippedArchives
+// append, the ArchiveSkipNotice call, the discoveryFailed plumbing, or either
+// refusal turns a branch of this red.
 func TestIntegrationArchiveSkipWarning(t *testing.T) {
 	testutil.SkipIfNoMySQL(t)
 	db, _ := testutil.CreateTestDB(t)
@@ -33,7 +36,7 @@ func TestIntegrationArchiveSkipWarning(t *testing.T) {
 	// A discoverable local archive whose only file is garbage:
 	// ResolveArchiveSources returns the bintrail_id base (the directory
 	// exists, so the local path is preferred), then parquetquery.Fetch fails
-	// on the corrupt file and the tool must skip-and-warn.
+	// on the corrupt file.
 	base := filepath.Join(t.TempDir(), "bintrail_id=skip-test")
 	hourDir := filepath.Join(base, "date=2026-06-01", "hour=12")
 	if err := os.MkdirAll(hourDir, 0o755); err != nil {
@@ -68,10 +71,48 @@ func TestIntegrationArchiveSkipWarning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("recover handler: %v", err)
 	}
-	if rres.IsError {
-		t.Fatalf("recover tool errored: %s", resultText(rres))
+	if !rres.IsError {
+		t.Fatalf("recover must REFUSE on a failed archive source, got a script: %s", resultText(rres))
 	}
-	if txt := resultText(rres); !strings.Contains(txt, "-- Warning: archive_source_skipped") || !strings.Contains(txt, base) {
-		t.Errorf("recover result must warn about the skipped source as a SQL comment, got: %s", txt)
+	if txt := resultText(rres); !strings.Contains(txt, base) || !strings.Contains(txt, "no_archive") {
+		t.Errorf("recover refusal must name the failed source and the no_archive escape hatch, got: %s", txt)
+	}
+
+	// The escape hatch must actually work: no_archive skips discovery and
+	// generates from the live index only.
+	rok, _, err := MakeRecoverTool(cfg)(context.Background(), &mcp.CallToolRequest{}, RecoverArgs{Schema: "app", Table: "orders", NoArchive: true})
+	if err != nil {
+		t.Fatalf("recover handler (no_archive): %v", err)
+	}
+	if rok.IsError {
+		t.Errorf("recover with no_archive must succeed, got: %s", resultText(rok))
+	}
+
+	// Discovery failure: archive_state present but unreadable (wrong shape →
+	// the SELECT errors). "Table absent" is deliberately NOT failure (1146 =
+	// pre-archive index); a broken read is.
+	testutil.MustExec(t, db, `DROP TABLE archive_state`)
+	testutil.MustExec(t, db, `CREATE TABLE archive_state (wrong_shape INT)`)
+
+	qres2, _, err := MakeQueryTool(cfg)(context.Background(), &mcp.CallToolRequest{}, QueryArgs{Schema: "app", Table: "orders"})
+	if err != nil {
+		t.Fatalf("query handler (discovery): %v", err)
+	}
+	if qres2.IsError {
+		t.Fatalf("query tool errored: %s", resultText(qres2))
+	}
+	if txt := resultText(qres2); !strings.Contains(txt, "archive_discovery_failed") {
+		t.Errorf("query result must warn about failed discovery, got: %s", txt)
+	}
+
+	rres2, _, err := MakeRecoverTool(cfg)(context.Background(), &mcp.CallToolRequest{}, RecoverArgs{Schema: "app", Table: "orders"})
+	if err != nil {
+		t.Fatalf("recover handler (discovery): %v", err)
+	}
+	if !rres2.IsError {
+		t.Fatalf("recover must REFUSE on failed discovery, got a script: %s", resultText(rres2))
+	}
+	if txt := resultText(rres2); !strings.Contains(txt, "discovery failed") || !strings.Contains(txt, "no_archive") {
+		t.Errorf("recover refusal must name discovery and the no_archive escape hatch, got: %s", txt)
 	}
 }

--- a/internal/mcptools/archiveskip_integration_test.go
+++ b/internal/mcptools/archiveskip_integration_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+package mcptools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestIntegrationArchiveSkipWarning pins the #1285 wiring for BOTH tools: a
+// registered archive source whose fetch fails (its only file is not valid
+// Parquet) must surface as an archive_source_skipped warning in the tool
+// RESULT, not only in the server log — an MCP client sees nothing else, so a
+// response missing every event held by a source would otherwise read as
+// complete. Deleting the skippedArchives append or the ArchiveSkipNotice call
+// in either tool turns this red.
+func TestIntegrationArchiveSkipWarning(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	// A discoverable local archive whose only file is garbage:
+	// ResolveArchiveSources returns the bintrail_id base (the directory
+	// exists, so the local path is preferred), then parquetquery.Fetch fails
+	// on the corrupt file and the tool must skip-and-warn.
+	base := filepath.Join(t.TempDir(), "bintrail_id=skip-test")
+	hourDir := filepath.Join(base, "date=2026-06-01", "hour=12")
+	if err := os.MkdirAll(hourDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	garbage := filepath.Join(hourDir, "events.parquet")
+	if err := os.WriteFile(garbage, []byte("not parquet"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testutil.MustExec(t, db, `INSERT INTO archive_state
+		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key, s3_uploaded_at)
+		VALUES ('p_2026060112', 'skip-test', ?, 1, NULL, NULL, NULL)`, garbage)
+
+	cfg := Config{
+		Resolve: func(context.Context, string) (*Target, error) {
+			return &Target{DB: db}, nil
+		},
+	}
+
+	qres, _, err := MakeQueryTool(cfg)(context.Background(), &mcp.CallToolRequest{}, QueryArgs{Schema: "app", Table: "orders"})
+	if err != nil {
+		t.Fatalf("query handler: %v", err)
+	}
+	if qres.IsError {
+		t.Fatalf("query tool errored: %s", resultText(qres))
+	}
+	if txt := resultText(qres); !strings.Contains(txt, "archive_source_skipped") || !strings.Contains(txt, base) {
+		t.Errorf("query result must warn about the skipped source, got: %s", txt)
+	}
+
+	rres, _, err := MakeRecoverTool(cfg)(context.Background(), &mcp.CallToolRequest{}, RecoverArgs{Schema: "app", Table: "orders"})
+	if err != nil {
+		t.Fatalf("recover handler: %v", err)
+	}
+	if rres.IsError {
+		t.Fatalf("recover tool errored: %s", resultText(rres))
+	}
+	if txt := resultText(rres); !strings.Contains(txt, "-- Warning: archive_source_skipped") || !strings.Contains(txt, base) {
+		t.Errorf("recover result must warn about the skipped source as a SQL comment, got: %s", txt)
+	}
+}

--- a/internal/mcptools/archiveskip_integration_test.go
+++ b/internal/mcptools/archiveskip_integration_test.go
@@ -33,6 +33,22 @@ func TestIntegrationArchiveSkipWarning(t *testing.T) {
 		t.Fatalf("EnsureSchema: %v", err)
 	}
 
+	cfg := Config{
+		Resolve: func(context.Context, string) (*Target, error) {
+			return &Target{DB: db}, nil
+		},
+	}
+
+	// Cry-wolf guard: a healthy target (empty archive_state, no archive
+	// trouble) must carry NO archive warnings.
+	q0, _, err := MakeQueryTool(cfg)(context.Background(), &mcp.CallToolRequest{}, QueryArgs{Schema: "app", Table: "orders"})
+	if err != nil {
+		t.Fatalf("query handler (healthy): %v", err)
+	}
+	if txt := resultText(q0); strings.Contains(txt, "archive_") {
+		t.Errorf("healthy target must render no archive warnings, got: %s", txt)
+	}
+
 	// A discoverable local archive whose only file is garbage:
 	// ResolveArchiveSources returns the bintrail_id base (the directory
 	// exists, so the local path is preferred), then parquetquery.Fetch fails
@@ -49,12 +65,6 @@ func TestIntegrationArchiveSkipWarning(t *testing.T) {
 	testutil.MustExec(t, db, `INSERT INTO archive_state
 		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key, s3_uploaded_at)
 		VALUES ('p_2026060112', 'skip-test', ?, 1, NULL, NULL, NULL)`, garbage)
-
-	cfg := Config{
-		Resolve: func(context.Context, string) (*Target, error) {
-			return &Target{DB: db}, nil
-		},
-	}
 
 	qres, _, err := MakeQueryTool(cfg)(context.Background(), &mcp.CallToolRequest{}, QueryArgs{Schema: "app", Table: "orders"})
 	if err != nil {
@@ -114,5 +124,24 @@ func TestIntegrationArchiveSkipWarning(t *testing.T) {
 	}
 	if txt := resultText(rres2); !strings.Contains(txt, "discovery failed") || !strings.Contains(txt, "no_archive") {
 		t.Errorf("recover refusal must name discovery and the no_archive escape hatch, got: %s", txt)
+	}
+
+	// Standalone posture: EnvArchiveDiscovery reaches state discovery only
+	// through EnvArchiveSources' fallthrough — the discovery signal must
+	// survive that hop (#1288 review: discarding the bool there recreates the
+	// #1285 bug on the shipped default surface with everything else green).
+	t.Setenv("BINTRAIL_ARCHIVE_S3", "")
+	t.Setenv("BINTRAIL_ID", "")
+	cfgEnv := Config{
+		Resolve: func(context.Context, string) (*Target, error) {
+			return &Target{DB: db, EnvArchiveDiscovery: true}, nil
+		},
+	}
+	rres3, _, err := MakeRecoverTool(cfgEnv)(context.Background(), &mcp.CallToolRequest{}, RecoverArgs{Schema: "app", Table: "orders"})
+	if err != nil {
+		t.Fatalf("recover handler (env discovery): %v", err)
+	}
+	if !rres3.IsError || !strings.Contains(resultText(rres3), "discovery failed") {
+		t.Errorf("standalone env-discovery posture must refuse on failed state discovery, got: %s", resultText(rres3))
 	}
 }

--- a/internal/mcptools/archiveskip_test.go
+++ b/internal/mcptools/archiveskip_test.go
@@ -1,6 +1,7 @@
 package mcptools
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -26,5 +27,31 @@ func TestArchiveSkipNotice(t *testing.T) {
 	}
 	if strings.Contains(got, "--") {
 		t.Errorf("notice must carry no flag-shaped tokens, got %q", got)
+	}
+}
+
+// TestEnvArchiveSourcesSignal pins the standalone surface's discovery signal
+// (#1288 review: a mutation discarding stateArchiveSources' bool at the
+// fallthrough would recreate the #1285 bug verbatim with the suite green). A
+// nil DB makes state discovery a clean no-archives (nil, false), isolating
+// the env-pair logic.
+func TestEnvArchiveSourcesSignal(t *testing.T) {
+	ctx := context.Background()
+
+	t.Setenv("BINTRAIL_ARCHIVE_S3", "s3://bkt/prefix")
+	t.Setenv("BINTRAIL_ID", "id-1")
+	s, failed := EnvArchiveSources(ctx, nil)
+	if failed || len(s) != 1 || s[0] != "s3://bkt/prefix/bintrail_id=id-1" {
+		t.Errorf("full env pair must be (1 source, false), got (%v, %v)", s, failed)
+	}
+
+	t.Setenv("BINTRAIL_ID", "")
+	if _, failed := EnvArchiveSources(ctx, nil); !failed {
+		t.Error("half-set env pair is explicit archive intent that cannot be honored; discovery must be flagged unreliable")
+	}
+
+	t.Setenv("BINTRAIL_ARCHIVE_S3", "")
+	if s, failed := EnvArchiveSources(ctx, nil); failed || s != nil {
+		t.Errorf("no env + nil DB = no archives and no failure, got (%v, %v)", s, failed)
 	}
 }

--- a/internal/mcptools/archiveskip_test.go
+++ b/internal/mcptools/archiveskip_test.go
@@ -1,0 +1,36 @@
+package mcptools
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestArchiveSkipNotice pins the #1285 warning surface: wording mirrors the
+// reconstruct tool's archive_source_skipped entries, the recover variant is a
+// valid SQL comment, and nothing beyond the source name (no fetch-error
+// detail, no CLI flags) reaches the client-visible text.
+func TestArchiveSkipNotice(t *testing.T) {
+	if got := ArchiveSkipNotice("", nil); got != "" {
+		t.Errorf("no skips must render nothing, got %q", got)
+	}
+
+	got := ArchiveSkipNotice("", []string{"/data/archive/bintrail_id=a", "s3://bkt/bintrail_id=b"})
+	for _, want := range []string{
+		"Warning: archive_source_skipped: events held only by this source are missing from the result: /data/archive/bintrail_id=a",
+		"Warning: archive_source_skipped: events held only by this source are missing from the result: s3://bkt/bintrail_id=b",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in %q", want, got)
+		}
+	}
+	if strings.Contains(got, "--") {
+		t.Errorf("plain variant must carry no SQL-comment prefix (and no flag-shaped tokens), got %q", got)
+	}
+
+	sql := ArchiveSkipNotice("-- ", []string{"/data/archive/bintrail_id=a"})
+	for _, line := range strings.Split(strings.TrimSpace(sql), "\n") {
+		if line != "" && !strings.HasPrefix(line, "-- ") {
+			t.Errorf("every recover warning line must be a SQL comment, got %q", line)
+		}
+	}
+}

--- a/internal/mcptools/archiveskip_test.go
+++ b/internal/mcptools/archiveskip_test.go
@@ -5,17 +5,18 @@ import (
 	"testing"
 )
 
-// TestArchiveSkipNotice pins the #1285 warning surface: wording mirrors the
-// reconstruct tool's archive_source_skipped entries, the recover variant is a
-// valid SQL comment, and nothing beyond the source name (no fetch-error
-// detail, no CLI flags) reaches the client-visible text.
+// TestArchiveSkipNotice pins the #1285 query-tool warning surface: the
+// wording is the reconstruct tool's wording (one shared helper, no drift), a
+// discovery failure renders its own line, and nothing beyond the source name
+// (no fetch-error detail, no flag-shaped tokens) reaches the client text.
 func TestArchiveSkipNotice(t *testing.T) {
-	if got := ArchiveSkipNotice("", nil); got != "" {
-		t.Errorf("no skips must render nothing, got %q", got)
+	if got := ArchiveSkipNotice(false, nil); got != "" {
+		t.Errorf("no archive trouble must render nothing, got %q", got)
 	}
 
-	got := ArchiveSkipNotice("", []string{"/data/archive/bintrail_id=a", "s3://bkt/bintrail_id=b"})
+	got := ArchiveSkipNotice(true, []string{"/data/archive/bintrail_id=a", "s3://bkt/bintrail_id=b"})
 	for _, want := range []string{
+		"Warning: archive_discovery_failed: no archives were read",
 		"Warning: archive_source_skipped: events held only by this source are missing from the result: /data/archive/bintrail_id=a",
 		"Warning: archive_source_skipped: events held only by this source are missing from the result: s3://bkt/bintrail_id=b",
 	} {
@@ -24,13 +25,6 @@ func TestArchiveSkipNotice(t *testing.T) {
 		}
 	}
 	if strings.Contains(got, "--") {
-		t.Errorf("plain variant must carry no SQL-comment prefix (and no flag-shaped tokens), got %q", got)
-	}
-
-	sql := ArchiveSkipNotice("-- ", []string{"/data/archive/bintrail_id=a"})
-	for _, line := range strings.Split(strings.TrimSpace(sql), "\n") {
-		if line != "" && !strings.HasPrefix(line, "-- ") {
-			t.Errorf("every recover warning line must be a SQL comment, got %q", line)
-		}
+		t.Errorf("notice must carry no flag-shaped tokens, got %q", got)
 	}
 }

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -628,6 +628,7 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 		// as trailing warning lines so a result missing every event held by a
 		// source does not read as complete to an MCP client.
 		var skippedArchives []string
+		var misfiledScanFailed bool
 		if len(archSources) == 0 && !t.RedactStatementText {
 			// Fast path: no archives and no post-fetch redaction — fetch and
 			// format in one step.
@@ -640,7 +641,7 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 			// then format.
 			fetchOpts := opts
 			if len(archSources) > 0 {
-				fetchOpts.ExtraArchiveHours = misfiledArchiveHoursOrWarn(ctx, t.DB, opts.Since, opts.Until)
+				fetchOpts.ExtraArchiveHours, misfiledScanFailed = misfiledArchiveHours(ctx, t.DB, opts.Since, opts.Until)
 			}
 			results, err := engine.Fetch(ctx, fetchOpts)
 			if err != nil {
@@ -671,6 +672,9 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 		}
 		text += QueryResultNotice(ceilingApplied, requestedLimit, ceiling, n, opts.Limit)
 		text += ArchiveSkipNotice(discoveryFailed, skippedArchives)
+		if misfiledScanFailed {
+			text += "\nWarning: " + archiveScanIncompleteWarning() + "\n"
+		}
 
 		ext.Record(ctx, ext.AuditEvent{
 			Surface: cfg.auditSurface(),
@@ -783,7 +787,18 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 		var rows []query.ResultRow
 		if len(archSources) > 0 {
 			fetchOpts := opts
-			fetchOpts.ExtraArchiveHours = misfiledArchiveHoursOrWarn(ctx, t.DB, opts.Since, opts.Until)
+			extraHours, misfiledScanFailed := misfiledArchiveHours(ctx, t.DB, opts.Since, opts.Until)
+			if misfiledScanFailed {
+				// Third gate, same posture as the two around it: the registry
+				// scan that catches misfiled (backfilled) archives failed, so
+				// the per-source fetch may silently prune files whose events
+				// are in the window — a knowingly-possibly-incomplete reversal
+				// (the #1037 class).
+				return ErrorResult(fmt.Errorf(
+					"the archive registry could not be checked for misfiled (backfilled) archives; a reversal script generated without them could silently omit events. " +
+						"Retry with no_archive: true to recover from the live index only (archived events will NOT be reversed), or repair the index and retry")), nil, nil
+			}
+			fetchOpts.ExtraArchiveHours = extraHours
 			rows, err = engine.Fetch(ctx, fetchOpts)
 			if err != nil {
 				return ErrorResult(err), nil, nil
@@ -1070,7 +1085,11 @@ func ErrorResult(err error) *mcp.CallToolResult {
 // EnvArchiveSources returns Parquet archive source paths for use with
 // parquetquery.Fetch. It checks env vars BINTRAIL_ARCHIVE_S3 + BINTRAIL_ID
 // first (for explicit configuration — both must be set), then falls back to
-// auto-discovery from archive_state in the index database.
+// auto-discovery from archive_state in the index database. The second return
+// is true when discovery is UNRELIABLE: the archive_state read failed (see
+// stateArchiveSources), or the env pair is half-set — explicit archive intent
+// the fallback would otherwise silently discard. The fully-env-configured
+// path never fails discovery.
 func EnvArchiveSources(ctx context.Context, db *sql.DB) ([]string, bool) {
 	archiveS3 := os.Getenv("BINTRAIL_ARCHIVE_S3")
 	bintrailID := os.Getenv("BINTRAIL_ID")
@@ -1081,26 +1100,38 @@ func EnvArchiveSources(ctx context.Context, db *sql.DB) ([]string, bool) {
 	if archiveS3 != "" || bintrailID != "" {
 		slog.Warn("partial archive env var config; both BINTRAIL_ARCHIVE_S3 and BINTRAIL_ID must be set",
 			"BINTRAIL_ARCHIVE_S3", archiveS3, "BINTRAIL_ID", bintrailID)
+		// A half-set env pair is explicit archive intent that cannot be
+		// honored. With a rebuilt/empty archive_state — exactly the situation
+		// where the env pair is the documented remediation — the silent
+		// fallback would read as complete: the #1285 blind spot one env var
+		// away. Fall back to state discovery for whatever it finds, but flag
+		// discovery unreliable so the query tool warns and recover refuses.
+		s, _ := stateArchiveSources(ctx, db)
+		return s, true
 	}
 	return stateArchiveSources(ctx, db)
 }
 
-// misfiledArchiveHoursOrWarn wraps query.MisfiledArchiveHours (#1037) with the
-// MCP tools' warn-and-continue posture: on a registry read failure the fetch
-// proceeds with label-only pruning (the pre-#1037 behavior) rather than
-// failing the whole tool call.
-func misfiledArchiveHoursOrWarn(ctx context.Context, db *sql.DB, since, until *time.Time) []time.Time {
+// misfiledArchiveHours wraps query.MisfiledArchiveHours (#1037). The second
+// return is true when the registry scan FAILED: the per-source fetch would
+// then prune by hour label only and may silently skip misfiled (backfilled)
+// archives whose events are in the window. The query tool degrades with an
+// archive_scan_incomplete warning; the recover tool refuses — the same
+// knowingly-possibly-incomplete class as its other two archive gates. Never
+// fails without a time filter (since/until both nil): nothing is pruned then.
+func misfiledArchiveHours(ctx context.Context, db *sql.DB, since, until *time.Time) ([]time.Time, bool) {
 	hours, err := query.MisfiledArchiveHours(ctx, db, since, until)
 	if err != nil {
 		slog.Warn("could not check archive_state for misfiled archives (backfilled events); time-scoped archive pruning may skip them", "error", err)
-		return nil
+		return nil, true
 	}
-	return hours
+	return hours, false
 }
 
-// stateArchiveSources auto-discovers archive sources from archive_state,
-// warn-and-continue on failure (the MCP tools are deliberately permissive —
-// their own per-source fetch loops warn-and-continue too).
+// stateArchiveSources auto-discovers archive sources from archive_state. On a
+// registry read failure it returns (nil, true): the fetch layer stays
+// permissive, but the caller must surface the signal — the query tool warns,
+// the recover tool refuses (#1285).
 func stateArchiveSources(ctx context.Context, db *sql.DB) ([]string, bool) {
 	sources, err := query.ResolveArchiveSources(ctx, db)
 	if err != nil {
@@ -1170,6 +1201,13 @@ func archiveSourceSkippedWarning(src string) string {
 // failed": no source list exists, so archived events may silently be absent.
 func archiveDiscoveryFailedWarning() string {
 	return "archive_discovery_failed: no archives were read and archived hours may still be counted as covered; the result may be incomplete"
+}
+
+// archiveScanIncompleteWarning is the wording for a failed misfiled-archive
+// registry scan (#1037): archives WERE read, but time-scoped pruning may have
+// skipped backfilled files — softer than archive_discovery_failed.
+func archiveScanIncompleteWarning() string {
+	return "archive_scan_incomplete: the archive registry could not be checked for misfiled (backfilled) archives; time-scoped pruning may have skipped archived events in the window"
 }
 
 // ArchiveSkipNotice renders the query tool's trailing warning lines for

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -144,12 +144,17 @@ func (t *Target) stripStatementText(rows []query.ResultRow) {
 	}
 }
 
-// archiveSources returns Parquet archive source paths for this target, or nil
-// when archives are disabled or discovery fails (the MCP tools are
-// deliberately permissive: serve without archives rather than fail the call).
-func (t *Target) archiveSources(ctx context.Context) []string {
+// archiveSources returns Parquet archive source paths for this target, plus
+// whether DISCOVERY itself failed. On failure the fetch layer stays
+// permissive (serve without archives rather than fail outright) but the
+// signal must reach the client: the query tool renders an
+// archive_discovery_failed warning and the recover tool refuses (#1285 —
+// before this, a discovery failure was slog-only and a result missing every
+// archived event read as complete). NoArchive is (nil, false): archives are
+// OFF by request, nothing failed.
+func (t *Target) archiveSources(ctx context.Context) ([]string, bool) {
 	if t.NoArchive {
-		return nil
+		return nil, false
 	}
 	if t.EnvArchiveDiscovery {
 		return EnvArchiveSources(ctx, t.DB)
@@ -611,8 +616,9 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 		// target's own posture (console per-server no-archive, which already
 		// folds the process profile in) is enforced inside archiveSources.
 		var archSources []string
+		var discoveryFailed bool
 		if !args.NoArchive && args.Profile == "" {
-			archSources = t.archiveSources(ctx)
+			archSources, discoveryFailed = t.archiveSources(ctx)
 		}
 
 		var buf bytes.Buffer
@@ -664,7 +670,7 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 			text += fmt.Sprintf("\n%d row(s)\n", n)
 		}
 		text += QueryResultNotice(ceilingApplied, requestedLimit, ceiling, n, opts.Limit)
-		text += ArchiveSkipNotice("", skippedArchives)
+		text += ArchiveSkipNotice(discoveryFailed, skippedArchives)
 
 		ext.Record(ctx, ext.AuditEvent{
 			Surface: cfg.auditSurface(),
@@ -751,12 +757,28 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 		// mirror the query tool above.
 		engine := query.New(t.DB)
 		var archSources []string
+		var discoveryFailed bool
 		if !args.NoArchive && args.Profile == "" {
-			archSources = t.archiveSources(ctx)
+			archSources, discoveryFailed = t.archiveSources(ctx)
+		}
+		if discoveryFailed {
+			// Unlike the query tool — a browsing surface that degrades with a
+			// warning — recover REFUSES (#1285 review): a reversal script
+			// generated without knowing the archives could silently omit
+			// events, and undoing a partial subset can produce a state that
+			// never existed. This matches CLI recover (a failing source is
+			// fatal under its default) and the reconstruct tool's strict
+			// default; no_archive is the client-reachable escape hatch on
+			// THIS surface (a tool parameter, not a CLI flag).
+			return ErrorResult(fmt.Errorf(
+				"archive source discovery failed; a reversal script generated without the archives could silently omit events. " +
+					"Retry with no_archive: true to recover from the live index only (events already rotated to archives will NOT be reversed), " +
+					"or fix archive discovery and retry")), nil, nil
 		}
 
-		// See the query tool above: failed-and-skipped archive sources are
-		// surfaced as trailing SQL-comment warnings (#1285).
+		// Failed-and-skipped archive sources collect here and REFUSE after the
+		// fetch loop — see the discovery refusal above for why recover never
+		// warns-and-continues (#1285).
 		var skippedArchives []string
 		var rows []query.ResultRow
 		if len(archSources) > 0 {
@@ -781,6 +803,14 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 			if err != nil {
 				return ErrorResult(err), nil, nil
 			}
+		}
+
+		if len(skippedArchives) > 0 {
+			return ErrorResult(fmt.Errorf(
+				"archive source failed and its events cannot be fetched: %s. "+
+					"Refusing to generate a knowingly incomplete reversal script — undoing a partial subset of the matched events can produce a state that never existed. "+
+					"Retry with no_archive: true to recover from the live index only (events held by the failed archive will NOT be reversed), or repair the archive source and retry",
+				strings.Join(skippedArchives, ", "))), nil, nil
 		}
 
 		// The fetch above ran Order=DESC so --limit kept the newest suffix of
@@ -833,7 +863,6 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 		if n >= opts.Limit {
 			text += fmt.Sprintf("\n-- Warning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.\n", opts.Limit)
 		}
-		text += ArchiveSkipNotice("-- ", skippedArchives)
 
 		ext.Record(ctx, ext.AuditEvent{
 			Surface: cfg.auditSurface(),
@@ -1042,12 +1071,12 @@ func ErrorResult(err error) *mcp.CallToolResult {
 // parquetquery.Fetch. It checks env vars BINTRAIL_ARCHIVE_S3 + BINTRAIL_ID
 // first (for explicit configuration — both must be set), then falls back to
 // auto-discovery from archive_state in the index database.
-func EnvArchiveSources(ctx context.Context, db *sql.DB) []string {
+func EnvArchiveSources(ctx context.Context, db *sql.DB) ([]string, bool) {
 	archiveS3 := os.Getenv("BINTRAIL_ARCHIVE_S3")
 	bintrailID := os.Getenv("BINTRAIL_ID")
 	if archiveS3 != "" && bintrailID != "" {
 		base := strings.TrimSuffix(archiveS3, "/") + "/bintrail_id=" + bintrailID
-		return []string{base}
+		return []string{base}, false
 	}
 	if archiveS3 != "" || bintrailID != "" {
 		slog.Warn("partial archive env var config; both BINTRAIL_ARCHIVE_S3 and BINTRAIL_ID must be set",
@@ -1072,13 +1101,15 @@ func misfiledArchiveHoursOrWarn(ctx context.Context, db *sql.DB, since, until *t
 // stateArchiveSources auto-discovers archive sources from archive_state,
 // warn-and-continue on failure (the MCP tools are deliberately permissive —
 // their own per-source fetch loops warn-and-continue too).
-func stateArchiveSources(ctx context.Context, db *sql.DB) []string {
+func stateArchiveSources(ctx context.Context, db *sql.DB) ([]string, bool) {
 	sources, err := query.ResolveArchiveSources(ctx, db)
 	if err != nil {
 		slog.Warn("archive auto-discovery failed; proceeding without archives", "error", err)
-		return nil
+		// true = discovery FAILED — distinct from "no archives exist" (nil,
+		// false); the caller owes the client a warning or a refusal.
+		return nil, true
 	}
-	return sources
+	return sources, false
 }
 
 // DefaultQueryMaxLimit is the hard row ceiling for the MCP query tool (#654):
@@ -1126,25 +1157,40 @@ func QueryResultNotice(ceilingApplied bool, requestedLimit, ceiling, n, limit in
 	return ""
 }
 
-// ArchiveSkipNotice renders trailing warning lines for archive sources whose
-// fetch failed and was skipped (#1285): an MCP client sees only the result
-// text, so a response missing every event held by a source must not read as
-// complete — the blind spot the reconstruct tool's "archive_source_skipped"
-// warnings already close, mirrored here with the same wording. prefix is
-// prepended to each line: "" for the query tool (plain-text notices, the
-// QueryResultNotice precedent — trailing lines after a JSON body included)
-// and "-- " for the recover tool, whose result is an executable SQL script a
-// bare Warning line would break. Deliberately names only the SOURCE, not the
-// fetch error: error detail stays in the server log, keeping local paths,
-// DuckDB internals, and anything the no-CLI-flag-leak rule covers out of the
-// client-visible result.
-func ArchiveSkipNotice(prefix string, skipped []string) string {
-	if len(skipped) == 0 {
-		return ""
-	}
+// archiveSourceSkippedWarning is the ONE wording for a skipped archive
+// source, shared by the reconstruct tool's warnings array and
+// ArchiveSkipNotice — two byte-identical copies would drift silently, and
+// both the tests and any client matching on the wording treat the mirroring
+// as a contract.
+func archiveSourceSkippedWarning(src string) string {
+	return "archive_source_skipped: events held only by this source are missing from the result: " + src
+}
+
+// archiveDiscoveryFailedWarning is the shared wording for "discovery itself
+// failed": no source list exists, so archived events may silently be absent.
+func archiveDiscoveryFailedWarning() string {
+	return "archive_discovery_failed: no archives were read and archived hours may still be counted as covered; the result may be incomplete"
+}
+
+// ArchiveSkipNotice renders the query tool's trailing warning lines for
+// archive trouble (#1285): a discovery failure and/or per-source fetch
+// failures. An MCP client sees only the result text, so a response missing
+// archived events must not read as complete — the blind spot the reconstruct
+// tool's warnings already close, mirrored via the shared helpers above.
+// Trailing plain-text lines are the QueryResultNotice precedent (JSON bodies
+// included). Each line names only the SOURCE — which for a local archive is a
+// server-side path, exactly as the ratified reconstruct precedent already
+// exposes — and never the fetch ERROR: error detail (DuckDB internals,
+// remediation hints, anything the no-CLI-flag-leak rule covers) stays in the
+// server log. The recover tool does not use this: it REFUSES on archive
+// trouble instead (see MakeRecoverTool).
+func ArchiveSkipNotice(discoveryFailed bool, skipped []string) string {
 	var b strings.Builder
+	if discoveryFailed {
+		b.WriteString("\nWarning: " + archiveDiscoveryFailedWarning() + "\n")
+	}
 	for _, s := range skipped {
-		b.WriteString("\n" + prefix + "Warning: archive_source_skipped: events held only by this source are missing from the result: " + s + "\n")
+		b.WriteString("\nWarning: " + archiveSourceSkippedWarning(s) + "\n")
 	}
 	return b.String()
 }

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -618,6 +618,10 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 		var buf bytes.Buffer
 		var n int
 
+		// Archive sources whose fetch failed and was skipped (#1285) — surfaced
+		// as trailing warning lines so a result missing every event held by a
+		// source does not read as complete to an MCP client.
+		var skippedArchives []string
 		if len(archSources) == 0 && !t.RedactStatementText {
 			// Fast path: no archives and no post-fetch redaction — fetch and
 			// format in one step.
@@ -640,6 +644,7 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 				ar, err := parquetquery.Fetch(ctx, fetchOpts, src)
 				if err != nil {
 					slog.Warn("archive query failed, skipping", "source", src, "error", err)
+					skippedArchives = append(skippedArchives, src)
 					continue
 				}
 				results = append(results, ar...)
@@ -659,6 +664,7 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 			text += fmt.Sprintf("\n%d row(s)\n", n)
 		}
 		text += QueryResultNotice(ceilingApplied, requestedLimit, ceiling, n, opts.Limit)
+		text += ArchiveSkipNotice("", skippedArchives)
 
 		ext.Record(ctx, ext.AuditEvent{
 			Surface: cfg.auditSurface(),
@@ -749,6 +755,9 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 			archSources = t.archiveSources(ctx)
 		}
 
+		// See the query tool above: failed-and-skipped archive sources are
+		// surfaced as trailing SQL-comment warnings (#1285).
+		var skippedArchives []string
 		var rows []query.ResultRow
 		if len(archSources) > 0 {
 			fetchOpts := opts
@@ -761,6 +770,7 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 				ar, err := parquetquery.Fetch(ctx, fetchOpts, src)
 				if err != nil {
 					slog.Warn("archive query failed, skipping", "source", src, "error", err)
+					skippedArchives = append(skippedArchives, src)
 					continue
 				}
 				rows = append(rows, ar...)
@@ -823,6 +833,7 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 		if n >= opts.Limit {
 			text += fmt.Sprintf("\n-- Warning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.\n", opts.Limit)
 		}
+		text += ArchiveSkipNotice("-- ", skippedArchives)
 
 		ext.Record(ctx, ext.AuditEvent{
 			Surface: cfg.auditSurface(),
@@ -1113,6 +1124,29 @@ func QueryResultNotice(ceilingApplied bool, requestedLimit, ceiling, n, limit in
 		return fmt.Sprintf("\nWarning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.\n", limit)
 	}
 	return ""
+}
+
+// ArchiveSkipNotice renders trailing warning lines for archive sources whose
+// fetch failed and was skipped (#1285): an MCP client sees only the result
+// text, so a response missing every event held by a source must not read as
+// complete — the blind spot the reconstruct tool's "archive_source_skipped"
+// warnings already close, mirrored here with the same wording. prefix is
+// prepended to each line: "" for the query tool (plain-text notices, the
+// QueryResultNotice precedent — trailing lines after a JSON body included)
+// and "-- " for the recover tool, whose result is an executable SQL script a
+// bare Warning line would break. Deliberately names only the SOURCE, not the
+// fetch error: error detail stays in the server log, keeping local paths,
+// DuckDB internals, and anything the no-CLI-flag-leak rule covers out of the
+// client-visible result.
+func ArchiveSkipNotice(prefix string, skipped []string) string {
+	if len(skipped) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, s := range skipped {
+		b.WriteString("\n" + prefix + "Warning: archive_source_skipped: events held only by this source are missing from the result: " + s + "\n")
+	}
+	return b.String()
 }
 
 // BuildQueryOptions converts the shared tool filter parameters into a

--- a/internal/mcptools/misfiled_test.go
+++ b/internal/mcptools/misfiled_test.go
@@ -1,0 +1,91 @@
+package mcptools
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// mockDiscoverableSource creates a real bintrail_id base directory (so
+// ResolveArchiveSources prefers the local path) and queues the discovery
+// SELECT on mock. Returns the base the tools will fetch from.
+func mockDiscoverableSource(t *testing.T, mock sqlmock.Sqlmock) string {
+	t.Helper()
+	base := filepath.Join(t.TempDir(), "bintrail_id=m1")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mock.ExpectQuery("GROUP BY bintrail_id").WillReturnRows(
+		sqlmock.NewRows([]string{"bintrail_id", "sample_local", "sample_bucket", "sample_key"}).
+			AddRow("m1", filepath.Join(base, "date=2026-06-01", "hour=12", "events.parquet"), nil, nil))
+	return base
+}
+
+// TestRecoverToolMisfiledScanFailureRefuses pins the third recover gate
+// (#1288 review): sources discovered fine, but the misfiled-archive registry
+// scan (#1037) fails, so time-scoped pruning could silently skip backfilled
+// files — recover must refuse, not emit a possibly-incomplete script. The
+// gate only arms under a time filter (no filter = nothing pruned), hence the
+// since arg.
+func TestRecoverToolMisfiledScanFailureRefuses(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mockDiscoverableSource(t, mock)
+	mock.ExpectQuery("archive_state").WillReturnError(errors.New("simulated registry failure"))
+
+	cfg := Config{
+		Resolve: func(context.Context, string) (*Target, error) {
+			return &Target{DB: db, ResolverLoaded: true}, nil
+		},
+	}
+	res, _, err := MakeRecoverTool(cfg)(context.Background(), &mcp.CallToolRequest{},
+		RecoverArgs{Schema: "app", Table: "orders", Since: "2026-06-01 00:00:00"})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("recover must refuse when the misfiled-archive scan fails, got: %s", resultText(res))
+	}
+	if txt := resultText(res); !strings.Contains(txt, "misfiled") || !strings.Contains(txt, "no_archive") {
+		t.Errorf("refusal must name the misfiled scan and the no_archive escape hatch, got: %s", txt)
+	}
+}
+
+// TestQueryToolMisfiledScanFailureWarns is the query-tool half: same failure,
+// browsing surface — degrade, but say so in the result.
+func TestQueryToolMisfiledScanFailureWarns(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mockDiscoverableSource(t, mock)
+	mock.ExpectQuery("archive_state").WillReturnError(errors.New("simulated registry failure"))
+	mock.ExpectQuery("binlog_events").WillReturnRows(sqlmock.NewRows(recoverToolMockCols))
+
+	cfg := Config{
+		Resolve: func(context.Context, string) (*Target, error) {
+			return &Target{DB: db, ResolverLoaded: true}, nil
+		},
+	}
+	res, _, err := MakeQueryTool(cfg)(context.Background(), &mcp.CallToolRequest{},
+		QueryArgs{Schema: "app", Table: "orders", Since: "2026-06-01 00:00:00"})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("query must degrade, not error, got: %s", resultText(res))
+	}
+	if txt := resultText(res); !strings.Contains(txt, "archive_scan_incomplete") {
+		t.Errorf("query result must carry the archive_scan_incomplete warning, got: %s", txt)
+	}
+}

--- a/internal/mcptools/reconstruct.go
+++ b/internal/mcptools/reconstruct.go
@@ -324,10 +324,11 @@ func MakeReconstructTool(cfg Config) func(context.Context, *mcp.CallToolRequest,
 		}
 
 		// 3. Fetch this PK's deltas in [baseline, at], oldest-first.
-		//    AllowGaps defaults FALSE — the opposite of the query/recover tools: a
-		//    coverage gap here means a silently-wrong row state, not a few missing
-		//    rows in a result an agent can see are missing. The window is bounded
-		//    at both ends.
+		//    AllowGaps defaults FALSE — stricter than the query tool, which
+		//    degrades with warnings (recover refuses on archive trouble too,
+		//    #1285): a coverage gap here means a silently-wrong row state, and
+		//    an MCP client cannot see that rows are missing. The window is
+		//    bounded at both ends.
 		//    We fetch even when baselineRow == nil: a row created AFTER the
 		//    baseline has no baseline entry yet still exists as of `at`, and
 		//    ApplyAt(nil, deltas, at) reconstructs it correctly. Reporting

--- a/internal/mcptools/reconstruct.go
+++ b/internal/mcptools/reconstruct.go
@@ -520,10 +520,10 @@ func reconstructWarnings(plan *query.QueryPlan, stale reconstruct.StaleWarning, 
 	// found=true with zero warnings over a knowingly incomplete window.
 	for _, s := range skippedSources {
 		if s == query.DiscoveryFailedSource {
-			warnings = append(warnings, "archive_discovery_failed: no archives were read and archived hours may still be counted as covered; the state below may be incomplete")
+			warnings = append(warnings, archiveDiscoveryFailedWarning())
 			continue
 		}
-		warnings = append(warnings, "archive_source_skipped: events held only by this source are missing from the result: "+s)
+		warnings = append(warnings, archiveSourceSkippedWarning(s))
 	}
 	if allowGaps && plan == nil {
 		warnings = append(warnings, "coverage_unverified: the query planner failed or could not run; gaps in the captured history may be undetected")


### PR DESCRIPTION
closes #1285

## Summary
- The MCP `query` and `recover` tools skipped a failed archive source — and swallowed a failed archive **discovery** — with only a server-side `slog.Warn`; an MCP client sees only the result text, so a response missing every archived event read as complete. Fourth surface of the #1281 class.
- **`query` (browsing surface): warn-and-continue.** Trailing warning lines mirror the reconstruct tool's wording via shared helpers (`archive_source_skipped: …` per failed source, `archive_discovery_failed: …` when discovery itself failed) — one source of truth, no copy-paste drift; `reconstructWarnings` now uses the same helpers.
- **`recover` (recovery surface): refuse.** A reversal script generated without a failed source's events is a knowingly incomplete undo — CLI `recover` is already fatal there under its default (`AllowGaps=false`) and the reconstruct tool refuses without `allow_gaps`, so warn-and-continue would have made MCP recover the only recovery surface emitting a partial script with no opt-in. The refusal names the failed sources and the client-reachable escape hatch (`no_archive: true` — a tool parameter, not a CLI flag; the no-leak rule holds).
- Warnings/errors name only the SOURCE, never the fetch error: error detail (DuckDB internals, remediation hints) stays in the server log.

## Test plan
- [x] Integration wiring test (ran against real MySQL locally, PASS): a registered archive whose only file is garbage → `query` warns in the result, `recover` refuses naming the source + `no_archive`, and `no_archive: true` actually generates; then a broken `archive_state` (wrong shape) → `query` warns `archive_discovery_failed`, `recover` refuses. Deleting any of the four wiring points turns a branch red.
- [x] Unit test pins the shared wording, the discovery line, and that no flag-shaped tokens reach client text.
- [x] `go build`, `go vet` (both tag sets), `-race` on the package, full `go test ./... -count=1` green. Rebased onto main post-#1282/#1283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
