### PR TITLE
feat(console): refresh control on the Restore coverage card

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -55,6 +55,7 @@ const ICONS = {
   warn: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" style="width:15px;height:15px"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/><path d="M12 9v4M12 17h.01"/></svg>`,
   calendar: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"></rect><path d="M8 3v4M16 3v4M3 10h18"></path></svg>`,
   ext: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>`,
+  refresh: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-2.64-6.36"/><path d="M21 3v6h-6"/></svg>`,
 };
 
 // ── module state ─────────────────────────────────────────────────────────────
@@ -122,7 +123,14 @@ function $all(sel, root = document) { return Array.from(root.querySelectorAll(se
 // svgEl parses a STATIC, trusted SVG constant into a detached SVG node. It is
 // NOT an innerHTML sink: image/svg+xml parsing never executes script, and the
 // argument is always a module constant — never server or user data.
+// XML parsing applies no default namespace, so a constant without an explicit
+// xmlns yields a namespace-less <svg>: it takes up its CSS box and paints
+// NOTHING. Every icon here was in that state — the extension nav item, for one,
+// has been rendering label-only. Inject the namespace rather than requiring
+// each constant to remember it, so the next icon added cannot reintroduce this.
+const SVG_NS = `xmlns="http://www.w3.org/2000/svg"`;
 function svgEl(s) {
+  if (!s.includes("xmlns=")) s = s.replace("<svg", "<svg " + SVG_NS);
   const doc = new DOMParser().parseFromString(s, "image/svg+xml");
   return document.importNode(doc.documentElement, true);
 }
@@ -678,14 +686,75 @@ function setActiveNav(route) {
 
 // ── Overview ─────────────────────────────────────────────────────────────────
 
+// covLast is the payload the visible coverage card was built from, so a FAILED
+// refresh can re-render the same numbers instead of blanking them — and label
+// them stale, which is the part that keeps that honest. One Overview is on
+// screen at a time, so one slot is enough.
+let covLast = null; // { data, at } — `at` is the local clock time of the fetch
+
+// covRefresh builds the card's refresh control: a fetch-time stamp plus the
+// button. `stamp` is {at, error} — a refresh that failed keeps the previous
+// numbers on screen and says when they are from, rather than replacing real
+// values with an "unavailable" card or, worse, leaving them looking current.
+function covRefresh(stamp) {
+  const wrap = el("div", { class: "cov-refresh" });
+  if (stamp && stamp.error) {
+    wrap.append(el("span", { class: "cov-asof bad", text: "refresh failed · showing " + stamp.at }));
+  } else if (stamp && stamp.at) {
+    wrap.append(el("span", { class: "cov-asof", text: "as of " + stamp.at }));
+  }
+  const btn = el("button", {
+    class: "cov-refresh-btn", type: "button",
+    title: "Re-read capture lag and continuity",
+    "aria-label": "Refresh restore coverage",
+    onclick: (e) => refreshCovCard(e.currentTarget),
+  });
+  btn.append(icon("refresh", "cov-refresh-ico"));
+  wrap.append(btn);
+  return wrap;
+}
+
+// refreshCovCard re-reads /api/coverage and rebuilds ONLY this card. The values
+// on screen stay put until the response lands, so there is no flash of empty
+// chips, and the rebuild goes back through covCard so the freshness-driven
+// tones (#1227) and the never-green rules apply to refreshed values exactly as
+// they do on first paint.
+async function refreshCovCard(btn) {
+  const card = btn.closest(".cov-card");
+  if (!card || btn.disabled) return;
+  const gen = serverGen, vgen = viewGen;
+  btn.disabled = true;
+  btn.classList.add("spin");
+  let next = null, failed = false;
+  try {
+    next = await api("/api/coverage");
+  } catch (err) {
+    console.error("coverage refresh failed", err);
+    failed = true;
+  }
+  // Switched server or route mid-flight: whatever came back describes a view
+  // the operator is no longer looking at.
+  if (gen !== serverGen || vgen !== viewGen || !card.isConnected) return;
+  if (failed) {
+    const prev = covLast || { data: { continuity: "unavailable" }, at: "" };
+    card.replaceWith(covCard(prev.data, { at: prev.at, error: true }));
+    return;
+  }
+  covLast = { data: next, at: nowClock() };
+  card.replaceWith(covCard(next, { at: covLast.at }));
+}
+
+function nowClock() { return new Date().toLocaleTimeString(); }
+
 // covCard renders the live RPO statement (#1194). The window's upper edge is
 // the last INDEXED event on purpose — "restorable up to now" with a dead
 // stream would be false assurance; the lag chip is what says "now". Degrades
 // loudly: gap_lost/unavailable red, unknown amber, empty index explicit.
-function covCard(c) {
+function covCard(c, stamp) {
   const card = el("section", { class: "ov-panel cov-card" });
   card.append(el("div", { class: "ov-panel-head" },
-    el("h2", { class: "ov-panel-title", text: "Restore coverage" })));
+    el("h2", { class: "ov-panel-title", text: "Restore coverage" }),
+    covRefresh(stamp)));
   const cont = c.continuity || "unknown";
   const bad = cont === "gap_lost" || cont === "unavailable";
   const warn = cont === "unknown";
@@ -815,7 +884,10 @@ function buildOverview(status, eventsData, coverage) {
 
   // Restore coverage — the live RPO statement (#1194). Best-effort: no card
   // when the fetch failed, never a fabricated window.
-  if (coverage) v.append(covCard(coverage));
+  if (coverage) {
+    covLast = { data: coverage, at: nowClock() };
+    v.append(covCard(coverage, { at: covLast.at }));
+  }
 
   // stats
   const stats = el("div", { class: "ov-stats" });

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1451,6 +1451,28 @@ button { font-family: inherit; }
 .cov-line { margin: 6px 0 0; font-size: 14px; color: var(--ink); }
 .cov-line.bad { color: var(--delete); font-weight: 600; }
 .cov-line.warn { color: var(--ink-2); }
+.cov-refresh { display: flex; align-items: center; gap: 8px; }
+.cov-asof { font-family: var(--f-mono); font-size: 11px; color: var(--ink-4); }
+.cov-asof.bad { color: var(--delete); }
+.cov-refresh-btn {
+  display: flex; align-items: center; justify-content: center;
+  width: 26px; height: 26px; padding: 0;
+  border: 1px solid var(--line); border-radius: var(--radius-sm);
+  background: none; color: var(--ink-3); cursor: pointer;
+  transition: color .18s var(--ease), background .18s var(--ease);
+}
+.cov-refresh-btn:hover:not(:disabled) { background: var(--accent-bg); color: var(--accent); }
+.cov-refresh-btn:disabled { cursor: default; color: var(--ink-4); }
+.cov-refresh-ico { display: flex; }
+.cov-refresh-ico svg { width: 14px; height: 14px; }
+/* The spinner is the only signal that an in-flight refresh is happening — the
+   values deliberately stay on screen until the response lands. */
+.cov-refresh-btn.spin .cov-refresh-ico svg { animation: covspin .7s linear infinite; }
+@keyframes covspin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .cov-refresh-btn.spin .cov-refresh-ico svg { animation: none; }
+  .cov-refresh-btn.spin { opacity: .55; }
+}
 .cov-chips { display: flex; gap: 8px; margin-top: 8px; flex-wrap: wrap; }
 .cov-chip { font-family: var(--f-mono); font-size: 12px; padding: 2px 9px; border: 1px solid var(--line); border-radius: 10px; color: var(--ink-2); }
 .cov-chip.ok { color: var(--insert); border-color: var(--insert); }


### PR DESCRIPTION
Closes #1289.

Capture lag is the one number on the Restore coverage card an operator actively watches move, and it was fetched once per route load. After kicking a stalled daemon or waiting out a burst, seeing the new value meant a full page reload.

## The control

Refetches `/api/coverage` and rebuilds **only** that card:

- Values stay on screen until the response lands — no flash of empty chips. The button disables and spins; that spinner is the only in-flight signal, deliberately.
- The rebuild goes back through `covCard`, so the freshness-driven lag tone (#1227) and the never-green rules for `none`/`unknown` apply to refreshed values exactly as on first paint.
- A fetch-time stamp (`as of 10:00:00`) sits next to the button, so a just-refreshed `83s` is distinguishable from a stale one.
- A refresh that lands after a server or route switch is discarded — it describes a view the operator is no longer looking at.

**Failure is labeled, not swallowed.** The issue text said to fall back to the `continuity: "unavailable"` rendering; that turned out to be the wrong call. Blanking real values loses information, and showing them unlabeled would claim they are current. The card keeps the numbers and says `refresh failed · showing 10:51:39`.

Out of scope, as filed: page-wide auto-refresh.

## Prerequisite: the SVG namespace bug

`svgEl` parses icon constants as `image/svg+xml`, and XML parsing applies no default namespace. Without an explicit `xmlns` the result is a namespace-less `<svg>` that occupies its CSS box and **paints nothing**. No `ICONS` entry carries `xmlns`, so this affected all twelve `icon()` call sites — visible today as the extension nav item rendering label-only (Forensics shows as text with no glyph, unlike the index.html-inlined nav icons around it).

The refresh button would have shipped as an empty bordered box. `svgEl` now injects the namespace when a constant omits it, which fixes this generally rather than per-constant, so the next icon added cannot reintroduce it. The `image/svg+xml` parse — and the security rationale documented above it — is unchanged.

## Verification

Driven in Chrome against the real `covCard`/`refreshCovCard` with a stubbed `api()`:

| scenario | result |
|---|---|
| in flight | button disabled, spinning, previous `capture lag 83s` still shown |
| success | repaints `capture lag 7s` + new window + new `as of` stamp |
| three rapid clicks | exactly **1** fetch fired |
| fetch throws | keeps `capture lag 7s`, shows `refresh failed · showing 10:51:39` |
| refresh returns `freshness: stalled`, `continuity: gap_lost` | all three chips `bad`, plus the STALLED and permanently-lost lines |
| icons after the namespace fix | `SVGSVGElement` / `SVGPathElement` in `http://www.w3.org/2000/svg` |

`go test ./internal/console/... ./consoleapp/...` green.
