### PR TITLE
feat(ext): publish the resolved auth-file path to a credential backend

### DIFF
--- a/ext/consolecred.go
+++ b/ext/consolecred.go
@@ -41,6 +41,27 @@ type ConsoleCredentialProvider interface {
 	Verify(username, password string) *Credential
 }
 
+// ConsoleBootAuthPathReceiver is an OPTIONAL companion a ConsoleCredentialProvider
+// may implement. When it does, the console calls SetBootAuthPath once at
+// construction with the auth-file path it actually resolved — flag, environment,
+// or default, whichever won.
+//
+// This exists because installing a backend supersedes that file for login, so a
+// backend that wants to keep the operator's built-in credential working has to
+// read the file itself. Locating it independently means re-deriving a decision
+// the console has already made from inputs the backend cannot all see (a path
+// passed as a flag is invisible outside this process's flag parsing), and the
+// failure is not a degradation: the two disagree, the built-in credential stops
+// authenticating, and the operator is locked out of a console they configured
+// correctly.
+//
+// Implementing it is optional in both directions — a provider that does not
+// keeps whatever path it resolved on its own, and this call is the console's
+// only involvement.
+type ConsoleBootAuthPathReceiver interface {
+	SetBootAuthPath(path string)
+}
+
 // consoleCred is nil in the OSS build — the console's login form is served only
 // by the built-in single-user auth file.
 var consoleCred ConsoleCredentialProvider

--- a/internal/console/bootauthpath_test.go
+++ b/internal/console/bootauthpath_test.go
@@ -1,0 +1,70 @@
+package console
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/ext"
+)
+
+// recordingCredBackend is a credential provider that also implements
+// ext.ConsoleBootAuthPathReceiver, so it records what the console published.
+type recordingCredBackend struct {
+	fakeCredBackend
+	got   string
+	calls int
+}
+
+func (r *recordingCredBackend) SetBootAuthPath(p string) { r.got = p; r.calls++ }
+
+// Pin the shape an embedding build has to implement: if this signature moves,
+// every out-of-tree provider silently stops receiving the path (a failed type
+// assertion is not a compile error at the call site).
+var _ ext.ConsoleBootAuthPathReceiver = (*recordingCredBackend)(nil)
+
+func TestPublishesResolvedAuthPathToBackend(t *testing.T) {
+	explicit := filepath.Join(t.TempDir(), "elsewhere", "console-auth.yaml")
+	b := &recordingCredBackend{}
+	installCredBackend(t, b)
+
+	if _, err := New(Config{Listen: "127.0.0.1:8090", AuthPath: explicit}); err != nil {
+		t.Fatal(err)
+	}
+	if b.got != explicit {
+		t.Errorf("SetBootAuthPath(%q), want the configured %q", b.got, explicit)
+	}
+	if b.calls != 1 {
+		t.Errorf("SetBootAuthPath called %d times, want exactly 1", b.calls)
+	}
+}
+
+// With no path configured the backend must learn the DEFAULT the console fell
+// back to, not an empty string — the point is that both sides open one file.
+func TestPublishesDefaultAuthPathWhenUnset(t *testing.T) {
+	b := &recordingCredBackend{}
+	installCredBackend(t, b)
+
+	if _, err := New(Config{Listen: "127.0.0.1:8090"}); err != nil {
+		t.Fatal(err)
+	}
+	if want := DefaultAuthPath(); b.got != want {
+		t.Errorf("SetBootAuthPath(%q), want the default %q", b.got, want)
+	}
+}
+
+// A provider that does not implement the optional interface must still work:
+// the type assertion is the whole feature, and a failed one cannot panic.
+func TestBackendWithoutReceiverStillBuilds(t *testing.T) {
+	installCredBackend(t, fakeCredBackend{user: "u", pass: "p"})
+	if _, err := New(Config{Listen: "127.0.0.1:8090", AuthPath: filepath.Join(t.TempDir(), "absent.yaml")}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// No backend installed at all — the OSS build — must not trip the assertion
+// against a nil interface.
+func TestNoBackendInstalledIsFine(t *testing.T) {
+	if _, err := New(Config{Listen: "127.0.0.1:8090", Token: "tok", AuthPath: filepath.Join(t.TempDir(), "absent.yaml")}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -270,6 +270,15 @@ func New(cfg Config) (*Server, error) {
 	}
 	passwordCfg := authFile != nil
 
+	// Hand the resolved path to a credential backend that wants it. Installing
+	// a backend supersedes this file for login, so one that keeps the built-in
+	// credential working has to read the file itself — and it cannot see a path
+	// that arrived as a flag. Left to guess, it reads a different file than the
+	// console did and the operator's login stops working.
+	if r, ok := ext.ConsoleCredential().(ext.ConsoleBootAuthPathReceiver); ok {
+		r.SetBootAuthPath(authPath)
+	}
+
 	// Managed MCP token (#1052): an /mcp-ONLY credential minted from the UI.
 	// Missing file = the normal not-configured state; an unreadable file is
 	// logged loudly but never blocks startup — this daemon may be the stream


### PR DESCRIPTION
## Problem

Installing a `ConsoleCredentialProvider` supersedes the built-in auth file for `/api/auth/login` — the seam's docs already say so, and that a backend wanting to keep the operator's built-in credential working "must incorporate it itself". But nothing tells the backend **where that file is**. It has to re-derive a decision the console already made, from inputs it cannot all see: a path given as `--auth-file` / `--console-auth-file` never leaves this process's flag parsing.

The failure mode is not a degradation. The two sides open different files, the built-in credential stops matching, and the operator is locked out of a console they configured correctly — with the console and the backend each behaving exactly as documented. It surfaces the moment the backend's own user store gains its first entry, which looks like "the new user store broke my login" rather than a path mismatch.

## Change

`console.New` hands the path it actually resolved (flag, env, or default — whichever won) to a backend that implements the new optional `ext.ConsoleBootAuthPathReceiver`:

```go
type ConsoleBootAuthPathReceiver interface {
    SetBootAuthPath(path string)
}
```

Optional in both directions. A provider that does not implement it keeps whatever path it resolved on its own, so this is compatible with providers built against older cores; and the single call at construction is the console's entire involvement — no ownership of the file, no behavior change to the login route, the rate limiter, or session minting. The OSS build installs no provider, so nothing changes there.

## Tests

`internal/console/bootauthpath_test.go`: the explicit path is published verbatim and exactly once; an unset path publishes the default the console fell back to (not `""` — the point is that both sides open one file); a provider *without* the interface still builds; and no provider installed at all does not trip the assertion on a nil interface. A compile-time `var _ ext.ConsoleBootAuthPathReceiver = …` pins the signature, since a moved method would silently stop being called rather than fail to compile at the call site.

Mutation-checked: deleting the publish call fails both positive tests.

`go test ./internal/console/... ./consoleapp/... ./ext/...` green.
