### PR TITLE
fix(console): full-table window starts at the earliest usable baseline

### DIFF
--- a/internal/console/coverage_api.go
+++ b/internal/console/coverage_api.go
@@ -68,6 +68,40 @@ type coverageResponse struct {
 	BrokenTables []string `json:"broken_tables,omitempty"`
 }
 
+// tableAnchors holds the two baseline anchors of one table, which answer two
+// different questions and must not be conflated.
+//
+// newest decides whether the table is BROKEN: if even its most recent baseline
+// predates the delta floor, no point in time is fully reconstructable for it.
+//
+// earliestUsable decides where the table's restorable window STARTS.
+// reconstruct.FindBaseline does not use a table's newest baseline — it picks
+// the newest snapshot AT OR BEFORE the requested instant — so an instant older
+// than the newest baseline is served from an older one, provided that one's
+// own anchor is inside delta coverage. Taking the newest here understated the
+// window by however long ago the last baseline ran, and got worse the more
+// diligently an operator snapshotted: every new baseline pushed the reported
+// floor forward (#1294).
+type tableAnchors struct {
+	newest         time.Time
+	earliestUsable time.Time
+}
+
+// observe folds one baseline file's anchor in, with the verdict already graded
+// against the delta floor. Usable means at or above the floor — ok and aging
+// both qualify; aging says the window is shrinking, not that it is gone.
+func (a *tableAnchors) observe(ts time.Time, v status.BaselineStalenessVerdict) {
+	if ts.After(a.newest) {
+		a.newest = ts
+	}
+	switch v {
+	case status.BaselineOK, status.BaselineAging:
+		if a.earliestUsable.IsZero() || ts.Before(a.earliestUsable) {
+			a.earliestUsable = ts
+		}
+	}
+}
+
 // serverID labels log lines with the request's selected server — a
 // multi-server console emitting unattributed warns is undebuggable.
 func serverID(r *http.Request) string {
@@ -129,12 +163,15 @@ func (s *Server) handleCoverage(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 		resp.FullTableStatus = "ok"
-		newest := make(map[string]time.Time, len(files))
+		anchors := make(map[string]*tableAnchors, len(files))
 		for _, f := range files {
 			k := f.Schema + "." + f.Table
-			if f.SnapshotTime.After(newest[k]) {
-				newest[k] = f.SnapshotTime
+			a := anchors[k]
+			if a == nil {
+				a = &tableAnchors{}
+				anchors[k] = a
 			}
+			a.observe(f.SnapshotTime, sum.Floor.Grade(f.SnapshotTime, now))
 		}
 		// Graded THROUGH the floor, never against its hour alone: on a
 		// multi-source index the hour is the live floor and an anchor below
@@ -143,23 +180,26 @@ func (s *Server) handleCoverage(w http.ResponseWriter, r *http.Request) {
 		// the floor's own narrowing exists to avoid.
 		var from time.Time
 		var unevaluable bool
-		for k, ts := range newest {
-			switch sum.Floor.Grade(ts, now) {
-			case status.BaselineBroken:
-				resp.BrokenTables = append(resp.BrokenTables, k)
-			case status.BaselineUnknown:
-				// Neither broken nor usable: it must not join broken_tables
-				// AND must not define the window below, or "ok" would assert
-				// restorability from an anchor whose coverage is unknown.
-				unevaluable = true
-			default:
+		for k, a := range anchors {
+			if !a.earliestUsable.IsZero() {
 				// The window covering ALL usable tables starts at the LATEST
-				// usable anchor: table i is reconstructable for points >= its
-				// own anchor, so "every table" holds only past the newest one.
-				if ts.After(from) {
-					from = ts
+				// of their individual starts — and a table's own start is its
+				// EARLIEST usable anchor, not its newest (see tableAnchors).
+				if a.earliestUsable.After(from) {
+					from = a.earliestUsable
 				}
+				continue
 			}
+			// No usable anchor at all: the newest one says which kind of
+			// nothing this is.
+			if sum.Floor.Grade(a.newest, now) == status.BaselineBroken {
+				resp.BrokenTables = append(resp.BrokenTables, k)
+				continue
+			}
+			// Neither broken nor usable: it must not join broken_tables AND
+			// must not define the window, or "ok" would assert restorability
+			// from an anchor whose coverage is unknown.
+			unevaluable = true
 		}
 		sort.Strings(resp.BrokenTables)
 		if unevaluable {

--- a/internal/console/coverage_api_test.go
+++ b/internal/console/coverage_api_test.go
@@ -58,7 +58,8 @@ func coverageGet(t *testing.T, srv *Server) coverageResponse {
 }
 
 // TestCoverageAPI pins the live-RPO statement (#1194): the delta window from
-// the strict floor, the full-table window from the LATEST usable anchor,
+// the strict floor, the full-table window from each table's EARLIEST usable
+// anchor reduced by max across tables (#1294),
 // broken tables named, and the degraded states each keeping their identity.
 func TestCoverageAPI(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
@@ -126,8 +127,10 @@ func TestCoverageAPI(t *testing.T) {
 		if got.FullTableStatus != "ok" {
 			t.Fatalf("full_table_status = %q", got.FullTableStatus)
 		}
-		// LATEST usable anchor wins — the -10h users anchor must not widen
-		// the all-tables claim past orders' -1h anchor.
+		// Max ACROSS tables: users' -10h anchor must not widen the
+		// all-tables claim past orders, whose only usable anchor is -1h (its
+		// -200h one is below the floor). Within a table the earliest usable
+		// anchor wins, which #1294 covers separately.
 		if got.FullTableFrom != anchorNew.Format(consoleTSFormat) {
 			t.Fatalf("full_table_from = %q, want %q (not %q)", got.FullTableFrom,
 				anchorNew.Format(consoleTSFormat), anchorOld.Format(consoleTSFormat))
@@ -186,4 +189,72 @@ func TestCoverageAPI(t *testing.T) {
 			t.Fatalf("nil db must degrade to unavailable with no window: %+v", got)
 		}
 	})
+}
+
+// A table can have SEVERAL baselines inside coverage, and reconstruct serves an
+// instant from the newest one AT OR BEFORE it — so the table is restorable from
+// its EARLIEST usable anchor, not its newest. Reducing to the newest understated
+// the window by however long ago the last baseline ran, and got worse with good
+// hygiene: every new snapshot pushed the reported floor forward (#1294).
+//
+// The pre-existing fixture could not catch this — its one multi-anchor table has
+// a single USABLE anchor, so both rules agree there.
+func TestCoverageFullTableWindowUsesEarliestUsableAnchor(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	latest := now.Add(-30 * time.Second)
+	part := now.Add(-100 * time.Hour).Format("p_2006010215") // floor: -100h
+	tsDir := func(age time.Duration) string { return now.Add(-age).Format("2006-01-02T15-04-05Z") }
+
+	dir := t.TempDir()
+	// orders: THREE anchors, two of them usable (-1h, -50h) and one below the
+	// floor (-200h). users: one usable anchor at -10h.
+	writeBaselineFixture(t, dir, tsDir(time.Hour), "shop", "orders.parquet")
+	writeBaselineFixture(t, dir, tsDir(50*time.Hour), "shop", "orders.parquet")
+	writeBaselineFixture(t, dir, tsDir(200*time.Hour), "shop", "orders.parquet")
+	writeBaselineFixture(t, dir, tsDir(10*time.Hour), "shop", "users.parquet")
+
+	srv := newBaselineServer(t, dir, true)
+	srv.cm.boot.db = coverageMockDB(t, part, latest, nil)
+	srv.cm.boot.dbName = "binlog_index"
+	got := coverageGet(t, srv)
+
+	if got.FullTableStatus != "ok" {
+		t.Fatalf("full_table_status = %q, want ok", got.FullTableStatus)
+	}
+	if len(got.BrokenTables) != 0 {
+		t.Fatalf("broken_tables = %v; every table here has a usable baseline", got.BrokenTables)
+	}
+	// orders starts at -50h (its earliest usable anchor, NOT its newest -1h
+	// one); users starts at -10h. "every table" therefore holds from -10h.
+	want := now.Add(-10 * time.Hour).Format(consoleTSFormat)
+	if got.FullTableFrom != want {
+		t.Errorf("full_table_from = %q, want %q\n"+
+			"reducing to the NEWEST anchor per table would give %q — a window %v narrower than the truth",
+			got.FullTableFrom, want, now.Add(-time.Hour).Format(consoleTSFormat), 9*time.Hour)
+	}
+}
+
+// A baseline BELOW the floor must not widen the window even though older
+// anchors now participate: its deltas are gone, so it restores nothing.
+func TestCoverageFullTableWindowIgnoresBelowFloorAnchors(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	latest := now.Add(-30 * time.Second)
+	part := now.Add(-100 * time.Hour).Format("p_2006010215")
+	tsDir := func(age time.Duration) string { return now.Add(-age).Format("2006-01-02T15-04-05Z") }
+
+	dir := t.TempDir()
+	writeBaselineFixture(t, dir, tsDir(5*time.Hour), "shop", "orders.parquet")
+	writeBaselineFixture(t, dir, tsDir(300*time.Hour), "shop", "orders.parquet") // below the floor
+
+	srv := newBaselineServer(t, dir, true)
+	srv.cm.boot.db = coverageMockDB(t, part, latest, nil)
+	srv.cm.boot.dbName = "binlog_index"
+	got := coverageGet(t, srv)
+
+	if want := now.Add(-5 * time.Hour).Format(consoleTSFormat); got.FullTableFrom != want {
+		t.Errorf("full_table_from = %q, want %q — the -300h anchor is below the floor and restores nothing", got.FullTableFrom, want)
+	}
+	if len(got.BrokenTables) != 0 {
+		t.Errorf("broken_tables = %v; the table has a usable newer baseline, so it is not broken", got.BrokenTables)
+	}
 }


### PR DESCRIPTION
The coverage card reduced each table to its NEWEST baseline anchor and
started the full-table window there. But reconstruct does not use a
table's newest baseline — FindBaseline picks the newest snapshot AT OR
BEFORE the requested instant, so an instant older than the newest
baseline is served from an older one whenever that one's anchor is
itself inside delta coverage.

The window was therefore understated by however long ago the last
baseline ran, and it got WORSE with good hygiene: every new snapshot
pushed the reported floor forward. A live install with 18 snapshots back
to April and five weeks of delta coverage was told it could restore only
from 20 hours ago.

Per table now: the newest anchor still decides BROKEN (if even the most
recent baseline predates the floor, nothing is reconstructable for that
table), while the earliest usable anchor decides where its window
starts. The all-tables claim stays the max across tables, which is what
makes "every table" true.

The existing fixture could not catch this — its one multi-anchor table
has a single usable anchor, so both rules agree on it. The new test
gives a table two usable anchors, where the rules disagree by nine
hours; mutating the reduction back to the newest anchor fails it.

Only this reduction was wrong. The other Grade call sites — per-entry
staleness, OverallBaselineStaleness, and the notify watcher's broken
list — are asking whether anything is broken, and the newest anchor is
the right input for that.

Closes #1294