### PR TITLE
perf(query): skip archive sources when live already holds the top N

### DIFF
--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -217,6 +217,44 @@ func FetchMergedFull(
 	return rows, src.plan, skipped, nil
 }
 
+// topNSatisfiedLive reports whether the live partitions alone already hold the
+// answer to a newest-first page, so the archive sources can be skipped. An
+// archive source is an S3 scan; "the newest 100 events" — the console's Events
+// view, and the query behind Overview — was paying for a full multi-file
+// download whose every row then sorted in below the cut (#1295).
+//
+// All four conditions are load-bearing:
+//
+//   - DESC. ASC asks for the OLDEST rows, which is exactly where the archives
+//     live. (The keyset-cursor path is ASC-only, so it never takes this branch.)
+//   - A FILLED page. A short live result means the live half did not reach the
+//     limit and the archives genuinely extend it.
+//   - ONE contiguous live range in the plan, with the cutoff row inside it.
+//     This is what rules out an archived hour sitting ABOVE the cutoff. Normally
+//     archives are strictly older than every live partition — rotation archives
+//     the oldest partitions as it drops them — but that is a property of how
+//     partitions are usually retired, not an invariant of the schema: a restored
+//     or hand-surgered index can interleave archived hours between live ones,
+//     and then a filled live page is NOT the true top N. Requiring a single
+//     range covering the cutoff makes the span from the cutoff upward provably
+//     live-covered, whatever produced the layout.
+//   - A plan at all. No plan, no proof.
+//
+// Time and table filters need no special case: whatever they exclude, the live
+// rows that survive are still newer than everything below the cutoff, so a full
+// page of them is still the true top N.
+func topNSatisfiedLive(opts Options, rows []ResultRow, plan *QueryPlan) bool {
+	if opts.Limit <= 0 || len(rows) < opts.Limit || OrderDirection(opts.Order) != "DESC" {
+		return false
+	}
+	if plan == nil || len(plan.MySQLRanges) != 1 {
+		return false
+	}
+	// rows are already sorted newest-first, so the limit-th row is the cutoff.
+	cutoff := rows[opts.Limit-1].EventTimestamp
+	return !cutoff.Before(plan.MySQLRanges[0].Start)
+}
+
 // DefaultStreamBatchSize is the page size FetchMergedStream uses when the
 // caller passes 0. Chosen as a compromise between resident memory (a page of
 // ResultRows carries both decoded JSON row images, so roughly 1-2 KB per event
@@ -504,6 +542,12 @@ func fetchPage(
 			return nil, nil, nil, ferr
 		}
 		rows = r
+	}
+
+	if topNSatisfiedLive(o.Opts, rows, src.plan) {
+		slog.Debug("planner: skipping archive sources (newest-first page filled from contiguous live coverage)",
+			"limit", o.Opts.Limit, "sources", len(src.archSources))
+		return rows[:o.Opts.Limit], nil, nil, nil
 	}
 
 	// Archive fetches get the misfiled-archive file-scoping hint (#1037); the

--- a/internal/query/topn_skip_test.go
+++ b/internal/query/topn_skip_test.go
@@ -1,0 +1,175 @@
+package query
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+func hourRange(startAgo, endAgo time.Duration, now time.Time) TimeRange {
+	return TimeRange{Start: now.Add(-startAgo), End: now.Add(-endAgo)}
+}
+
+// rowsAt builds n rows newest-first, one minute apart, ending at `oldest`.
+func rowsAt(n int, oldest time.Time) []ResultRow {
+	out := make([]ResultRow, n)
+	for i := range out {
+		out[i] = ResultRow{EventID: uint64(n - i), EventTimestamp: oldest.Add(time.Duration(n-1-i) * time.Minute)}
+	}
+	return out
+}
+
+func TestTopNSatisfiedLive(t *testing.T) {
+	now := time.Now().UTC()
+	live := hourRange(24*time.Hour, 0, now) // live covers the last 24h
+	cutoffInside := now.Add(-2 * time.Hour)
+
+	tests := []struct {
+		name string
+		opts Options
+		rows []ResultRow
+		plan *QueryPlan
+		want bool
+		why  string
+	}{
+		{
+			name: "filled DESC page inside one live range",
+			opts: Options{Limit: 100, Order: "DESC"},
+			rows: rowsAt(100, cutoffInside),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: true,
+			why:  "the archives are all below the cutoff and cannot survive the limit",
+		},
+		{
+			name: "short page",
+			opts: Options{Limit: 100, Order: "DESC"},
+			rows: rowsAt(40, cutoffInside),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "live did not fill the limit, so the archives genuinely extend the result",
+		},
+		{
+			name: "ASC asks for the oldest rows",
+			opts: Options{Limit: 100, Order: "ASC"},
+			rows: rowsAt(100, cutoffInside),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "oldest-first is exactly where the archives live",
+		},
+		{
+			name: "empty order defaults to ASC",
+			opts: Options{Limit: 100},
+			rows: rowsAt(100, cutoffInside),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "OrderDirection defaults to ASC, which must not take the skip",
+		},
+		{
+			name: "no limit",
+			opts: Options{Order: "DESC"},
+			rows: rowsAt(100, cutoffInside),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "without a limit every archived row is still wanted",
+		},
+		{
+			name: "interleaved live coverage",
+			opts: Options{Limit: 100, Order: "DESC"},
+			rows: rowsAt(100, now.Add(-200*time.Hour)),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{
+				hourRange(300*time.Hour, 250*time.Hour, now),
+				hourRange(24*time.Hour, 0, now),
+			}},
+			want: false,
+			why:  "two live ranges mean an archived hour can sit ABOVE the cutoff",
+		},
+		{
+			name: "cutoff below the live range",
+			opts: Options{Limit: 100, Order: "DESC"},
+			rows: rowsAt(100, now.Add(-48*time.Hour)),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "the page reaches below live coverage, so the span above it is not provably live",
+		},
+		{
+			name: "no plan",
+			opts: Options{Limit: 100, Order: "DESC"},
+			rows: rowsAt(100, cutoffInside),
+			plan: nil,
+			want: false,
+			why:  "no plan, no proof",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := topNSatisfiedLive(tt.opts, tt.rows, tt.plan); got != tt.want {
+				t.Errorf("topNSatisfiedLive = %v, want %v — %s", got, tt.want, tt.why)
+			}
+		})
+	}
+}
+
+// The wiring, not just the predicate: a filled newest-first page must leave the
+// archive fetcher UNCALLED. Deleting the skip from fetchPage has to fail here,
+// or the predicate above is decorative.
+func TestFetchPageSkipsArchivesOnFilledTopN(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	const limit = 3
+	// One statement: a wide SELECT joined against a narrow keys subquery (the
+	// late-materialisation shape), so the mock returns the wide column list.
+	live := sqlmock.NewRows([]string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
+	})
+	for i := range limit {
+		live.AddRow(uint64(limit-i), "mysql-bin.000001", 100, 200, now.Add(-time.Duration(i)*time.Minute),
+			nil, nil, "shop", "orders", 2, "1",
+			nil, nil, nil, 1, nil, nil,
+			nil)
+	}
+	mock.ExpectQuery("SELECT").WillReturnRows(live)
+
+	var archiveCalls int
+	src := mergeSources{
+		archSources: []string{"s3://bucket/bintrail_id=x"},
+		plan:        &QueryPlan{MySQLRanges: []TimeRange{{Start: now.Add(-24 * time.Hour), End: now.Add(time.Hour)}}},
+	}
+	o := FetchMergedOptions{
+		Opts:      Options{Limit: limit, Order: "DESC"},
+		AllowGaps: true,
+		ArchiveFetcher: func(context.Context, Options, string) ([]ResultRow, error) {
+			archiveCalls++
+			return []ResultRow{{EventID: 999, EventTimestamp: now.Add(-72 * time.Hour)}}, nil
+		},
+	}
+
+	rows, _, _, err := fetchPage(context.Background(), New(db), o, src)
+	if err != nil {
+		t.Fatalf("fetchPage: %v", err)
+	}
+	if archiveCalls != 0 {
+		t.Errorf("archive fetcher called %d time(s); a filled newest-first page must not touch S3", archiveCalls)
+	}
+	if len(rows) != limit {
+		t.Errorf("rows = %d, want %d", len(rows), limit)
+	}
+	for _, r := range rows {
+		if r.EventID == 999 {
+			t.Error("an archived row survived a page the live half already filled")
+		}
+	}
+}
+
+var _ = sql.ErrNoRows


### PR DESCRIPTION
"Give me the newest 100 events" was fanning out to the Parquet archives
in S3, downloading and scanning them, merging, sorting, and then
discarding every archived row below the cut. On a live deployment that
made the console's Events view — and the query behind Overview — take
about 20 seconds for 699 kB.

Under a newest-first order, a page the live partitions already filled IS
the answer: every archived event sits below the live floor, so nothing
the archive scan returns can survive the limit.

The predicate is deliberately narrow, and each condition earns its
place. ASC asks for the oldest rows, which is where the archives live. A
short live result means the live half did not reach the limit and the
archives genuinely extend it. And the plan must show ONE contiguous live
range containing the cutoff row: archives are normally strictly older
than every live partition, since rotation archives the oldest partitions
as it drops them — but that is how partitions are usually retired, not
an invariant of the schema. A restored or hand-surgered index can
interleave archived hours between live ones, and there a filled live
page is NOT the true top N. Requiring one range covering the cutoff
makes the span above it provably live-covered whatever produced the
layout.

Time and table filters need no special case: whatever they exclude, the
live rows that survive are still newer than everything below the cutoff.

The keyset-cursor path is ASC-only, so streaming never takes this
branch.

Tested both halves: a table-driven test over the predicate (including
the interleaved-coverage and cutoff-below-live cases that must NOT
skip), and a wiring test asserting the archive fetcher is never called
for a filled newest-first page — disabling the call in fetchPage fails
the latter.

Closes #1295