### PR TITLE
feat(console): merge Time-travel into Restore

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -630,8 +630,9 @@ function routeFromLocation() {
 
 function navigate(route, params, push = true) {
   if (!isKnownRoute(route)) route = "overview";
-  // Reconstruct surface is gated; never navigate to a disabled Time-travel.
-  if (route === "timetravel" && !capsCache.reconstruct) route = "overview";
+  // Time-travel merged into Restore (#1298). The route stays known so old
+  // bookmarks and Back entries land somewhere useful instead of on Overview.
+  if (route === "timetravel") route = "recover";
   // Storage is a watch-daemon surface (rotation + archiving live there).
   if (route === "storage" && !capsCache.monitor) route = "overview";
   // The SQL panel is opt-in (BINTRAIL_CONSOLE_SQL_PANEL) and per-server gated.
@@ -1483,10 +1484,10 @@ function downloadEventsCSV(events) {
 function renderRecover(params) {
   const v = VIEW(); clear(v);
   const sub = el("p", { class: "page-sub" },
-    "Filter the changes you want to undo, preview the affected rows, then generate reversal SQL. ",
+    "See a row as it was at any moment, and get the SQL that puts it back. ",
     el("b", { text: "Nothing is ever executed" }),
     " — copy or download the script and apply it yourself after review.");
-  v.append(pageHead("Recover", sub));
+  v.append(pageHead("Restore", sub));
 
   // Context banner when arriving via an event "Undo" (pendingRecover).
   const ctx = pendingRecover;
@@ -1517,6 +1518,7 @@ function renderRecover(params) {
   form.append(actions);
   v.append(form);
 
+  v.append(stateSection(form));
   v.append(el("div", { id: "recover-warnings", class: "warnings" }));
   v.append(el("div", { id: "recover-preview" }));
   v.append(el("div", { id: "recover-out" }));
@@ -1681,14 +1683,133 @@ function undoEvent(e) {
   navigate("recover");
 }
 
+// ── Row state, inside Restore (#1298) ────────────────────────────────────────
+
+// stateSection is the folded-in Time-travel half: the SAME target the undo
+// form already carries (schema/table/pk), plus an instant. Two views that used
+// to be two destinations with identical forms — the operator read a timestamp
+// off Events, retyped the target into one, looked, then retyped it into the
+// other. Here the target is entered once.
+//
+// Gated twice, for two different reasons. capsCache.reconstruct is a per-server
+// capability (no baseline configured, nothing to reconstruct from), and the
+// panel says so rather than vanishing — an operator who cannot find it has no
+// way to learn that a baseline is what is missing. The permission gate mirrors
+// the nav's [data-perm]: the server's 403 is the real boundary, this only
+// spares a scoped session a control that would always error.
+function stateSection(form) {
+  const wrap = el("section", { class: "state-section", "data-perm": "reconstruct:execute" });
+  wrap.append(el("h2", { class: "state-title", text: "Row at a point in time" }));
+
+  if (!capsCache.reconstruct) {
+    wrap.append(el("p", { class: "state-note", text:
+      "Configure a baseline for this server to see a row's earlier state here. Undo SQL below works without one — it reverses recorded changes, so it cannot show a row nothing has touched." }));
+    return wrap;
+  }
+
+  wrap.append(el("p", { class: "state-note", text:
+    "Uses the schema, table and PK above. Shows the row as of an instant — your latest snapshot plus every change since." }));
+
+  const bar = el("div", { class: "state-bar" });
+  const at = fieldDateInput("At (UTC)", "state_at", "md", "now");
+  bar.append(at);
+  bar.append(el("button", { class: "btn btn-ghost", type: "button", text: "Show state",
+    onclick: () => runState(form, false) }));
+  bar.append(el("button", { class: "btn btn-ghost", type: "button", text: "Show history",
+    onclick: () => runState(form, true) }));
+  wrap.append(bar);
+  wrap.append(el("div", { id: "state-warnings", class: "warnings" }));
+  wrap.append(el("div", { id: "state-out" }));
+  return wrap;
+}
+
+// runState reads the target from the undo form — one target, two questions.
+async function runState(form, history) {
+  const gen = serverGen;
+  const out = $("#state-out", VIEW());
+  const warns = $("#state-warnings", VIEW());
+  const f = Object.fromEntries(new FormData(form).entries());
+  const atField = $('[name="state_at"]', VIEW());
+  if (!f.schema || !f.table || !f.pk) {
+    clear(warns);
+    renderError(out, "Schema, table and PK are all required — fill them in above.");
+    return;
+  }
+  const params = { schema: f.schema, table: f.table, pk: f.pk };
+  const atVal = atField && atField.value.trim();
+  if (atVal) params.at = atVal;
+  if (history) params.history = "true";
+  try {
+    const data = await api("/api/reconstruct?" + new URLSearchParams(params).toString());
+    if (gen !== serverGen) return;
+    renderWarnings(warns, data.warnings);
+    clear(out);
+    if (history) renderTimeline(out, data);
+    else {
+      renderStateAt(out, data);
+      out.append(restoreToStateAction(form, data));
+    }
+  } catch (err) {
+    if (gen !== serverGen) return;
+    clear(warns);
+    renderError(out, err);
+  }
+}
+
+// restoreToStateAction is the bridge that makes the two halves one errand:
+// the state on screen becomes the undo window that produces it.
+//
+// The arithmetic is exact, not approximate. reconstruct applies events
+// timestamped <= at; recover reverses events timestamped >= since and leaves
+// the row before the earliest of them. Setting since = at + 1s therefore
+// reverses precisely the events AFTER `at`, landing the row on the state shown
+// — event_timestamp is DATETIME(0), so no event can hide between at and at+1s.
+//
+// Passing `at` itself would be off by every event sharing that second, and
+// these indexes routinely carry dozens (a single write burst stamps them all
+// alike). Until is cleared for the same reason it is set by the Undo bridge:
+// a leftover upper bound would silently drop the newest damage from the window.
+function restoreToStateAction(form, data) {
+  const row = el("div", { class: "state-actions" });
+  if (!data.found) return row;
+  row.append(el("button", {
+    class: "btn btn-primary", type: "button", text: "Restore to this state",
+    title: "Reverse every change after " + data.at + ", leaving the row exactly as shown",
+    onclick: () => {
+      const since = shiftSeconds(data.at, 1);
+      if (!since) { toast("Could not read the selected instant."); return; }
+      form.elements.since.value = since;
+      form.elements.until.value = "";
+      previewRecover(form);
+      form.scrollIntoView({ behavior: "smooth", block: "start" });
+      toast("Undo window set to everything after " + data.at);
+    },
+  }));
+  row.append(el("span", { class: "state-actions-note", text:
+    "Sets the undo window to every change after this instant. Review the rows, then generate the SQL." }));
+  return row;
+}
+
+// shiftSeconds adds n seconds to a "YYYY-MM-DD HH:MM:SS" UTC stamp, returning
+// the same shape. Parsed as UTC explicitly: bare "YYYY-MM-DD HH:MM:SS" is
+// LOCAL time to Date(), which would shift the window by the browser's offset.
+function shiftSeconds(stamp, n) {
+  const m = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})/.exec(String(stamp || ""));
+  if (!m) return "";
+  const t = Date.parse(m[1] + "T" + m[2] + "Z");
+  if (Number.isNaN(t)) return "";
+  return new Date(t + n * 1000).toISOString().slice(0, 19).replace("T", " ");
+}
+
 // ── Time-travel (reconstruct) ─────────────────────────────────────────────────
 
 function renderTimetravel(params) {
-  // Landed on /timetravel but reconstruct is gated off (direct URL or Back).
-  // Redirect by REWRITING the URL (replaceState) then re-dispatching — calling
+  // Merged into Restore (#1298). Rewrite the URL then re-dispatch: calling
   // navigate(push=false) here would leave the URL on /timetravel and re-resolve
   // straight back into this guard (infinite recursion).
-  if (!capsCache.reconstruct) { history.replaceState({}, "", "/overview"); renderRoute(); return; }
+  history.replaceState({}, "", "/recover");
+  renderRoute();
+  return;
   const v = VIEW(); clear(v);
   const sub = el("p", { class: "page-sub" },
     "See what a row looked like at any moment in the past — your latest full snapshot plus every change since. Pick a row and a time to see its value then, or see its entire history.");

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -60,16 +60,12 @@
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h13M8 12h13M8 18h13"/><circle cx="3.5" cy="6" r="1.2"/><circle cx="3.5" cy="12" r="1.2"/><circle cx="3.5" cy="18" r="1.2"/></svg></span>
             <span>Events</span>
           </a>
-          <a class="nav-item" data-route="timetravel" href="/timetravel" data-capability="reconstruct" data-perm="reconstruct:execute">
-            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5v5h5"/><path d="M3.5 10a9 9 0 1 1-.7 4"/><path d="M12 8v4l3 2"/></svg></span>
-            <span>Time-travel</span>
-          </a>
         </div>
         <div class="nav-group">
           <div class="nav-label">Resolve</div>
           <a class="nav-item" data-route="recover" href="/recover" data-perm="recover:execute">
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M3 13a9 9 0 1 0 3-7.7L3 8"/></svg></span>
-            <span>Recover</span>
+            <span>Restore</span>
           </a>
           <!-- SQL panel: opt-in (BINTRAIL_CONSOLE_SQL_PANEL) and per-server
                gated on capsCache.sql, so hidden unless the daemon enabled it

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1119,6 +1119,23 @@ button { font-family: inherit; }
 [data-accent="warm"] .ev-row.cursor { box-shadow: inset 2px 0 0 var(--orange-2); }
 .ev-row.cursor .ev-caret { opacity: 1; color: var(--accent); }
 
+/* Restore: the folded-in row-state panel (#1298). Reads as a section of the
+   page rather than a second form — the whole point of the merge is that the
+   target above is entered once. */
+.state-section {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  padding: 18px 20px 20px;
+  box-shadow: var(--panel-shadow);
+  margin-bottom: 26px;
+}
+.state-title { font-size: 15px; font-weight: 600; color: var(--ink); margin: 0 0 6px; }
+.state-note { color: var(--ink-3); font-size: 13px; max-width: 72ch; margin: 0 0 14px; }
+.state-bar { display: flex; flex-wrap: wrap; gap: 16px 18px; align-items: flex-end; }
+.state-actions { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; margin-top: 14px; }
+.state-actions-note { color: var(--ink-3); font-size: 12.5px; }
+
 /* responsive-ish */
 @media (max-width: 880px) {
   #app { grid-template-columns: 1fr; }

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -723,73 +723,106 @@ try {
     ? ok("cascade: script re-inserts both cascade-deleted children")
     : bad("cascade: script re-inserts both cascade-deleted children", cas.sql.slice(0, 200));
 
-  // Scenario 14 — Time-travel over the fixture baseline (#970). First pin the
-  // gate itself: this server must report reconstruct (a baseline is
-  // configured), and a server WITHOUT it must be rerouted off /timetravel.
+  // Scenario 14 — the row-state half over the fixture baseline (#970), now
+  // inside Restore (#1298). Pin the merge itself first: /timetravel must fold
+  // into /recover (old bookmarks and Back entries), and a server WITHOUT a
+  // baseline must still render the panel with an explanation instead of
+  // silently dropping it — an operator who cannot find it has no way to learn
+  // that a baseline is what is missing.
   const ttGate = await page.evaluate(() => {
     const had = !!capsCache.reconstruct;
-    capsCache.reconstruct = false;
     navigate("timetravel");
-    const rerouted = location.pathname === "/overview";
+    const merged = location.pathname === "/recover";
+    capsCache.reconstruct = false;
+    navigate("recover");
+    const sec = document.querySelector(".state-section");
+    const explains = !!sec && !document.querySelector('[name="state_at"]') && !!sec.querySelector(".state-note");
     capsCache.reconstruct = had;
-    return { had, rerouted };
+    return { had, merged, explains };
   });
-  ttGate.had ? ok("timetravel: a baseline-configured server reports the reconstruct capability") : bad("timetravel: a baseline-configured server reports the reconstruct capability", "capsCache.reconstruct falsy on byo-idx");
-  ttGate.rerouted ? ok("timetravel: gated-off navigation reroutes to overview") : bad("timetravel: gated-off navigation reroutes to overview", "landed on /timetravel without the capability");
+  ttGate.had ? ok("restore: a baseline-configured server reports the reconstruct capability") : bad("restore: a baseline-configured server reports the reconstruct capability", "capsCache.reconstruct falsy on byo-idx");
+  ttGate.merged ? ok("restore: /timetravel folds into /recover") : bad("restore: /timetravel folds into /recover", "did not land on /recover");
+  ttGate.explains ? ok("restore: no baseline explains itself instead of vanishing") : bad("restore: no baseline explains itself instead of vanishing", "panel absent or still offering controls");
 
-  await page.evaluate(() => navigate("timetravel"));
-  await page.waitForSelector("#tt-form", { timeout: 8000 });
+  await page.evaluate(() => navigate("recover"));
+  await page.waitForSelector("#recover-form", { timeout: 8000 });
   await page.waitForFunction((FIX) => {
-    const f = document.getElementById("tt-form");
+    const f = document.getElementById("recover-form");
     return f && Array.from(f.elements.schema.options).some((o) => o.value === FIX);
   }, FIX, { timeout: 8000 });
   // pk=1: baseline row (status new) + a later UPDATE (status shipped) — the
   // event fold half. email only ever existed in the baseline's full row image.
+  // The target is entered ONCE, on the undo form — that single target driving
+  // both halves is the merge (#1298).
   await page.evaluate(async ({ FIX, TT_AT }) => {
-    const f = document.getElementById("tt-form");
+    const f = document.getElementById("recover-form");
     f.elements.schema.value = FIX;
     await loadTables(f);
     f.elements.table.value = "orders";
     f.elements.pk.value = "1";
-    if (TT_AT) f.elements.at.value = TT_AT;
-    f.requestSubmit();
+    const at = document.querySelector('[name="state_at"]');
+    if (TT_AT && at) at.value = TT_AT;
+    await runState(f, false);
   }, { FIX, TT_AT });
-  await page.waitForSelector("#tt-out .statetable", { timeout: 10000 });
+  await page.waitForSelector("#state-out .statetable", { timeout: 10000 });
   const tt1 = await page.evaluate(() => {
     const cells = {};
-    document.querySelectorAll("#tt-out .statetable tr").forEach((tr) => {
+    document.querySelectorAll("#state-out .statetable tr").forEach((tr) => {
       cells[tr.querySelector("th").textContent] = tr.querySelector("td").textContent;
     });
-    return { cells, meta: (document.querySelector("#tt-out .meta-line") || {}).textContent || "" };
+    return { cells, meta: (document.querySelector("#state-out .meta-line") || {}).textContent || "" };
   });
   (tt1.cells.status === "shipped" && tt1.cells.email === "a@example.com")
-    ? ok("timetravel: reconstructed row folds the event over the baseline")
-    : bad("timetravel: reconstructed row folds the event over the baseline", JSON.stringify(tt1.cells));
-  /baseline /.test(tt1.meta) ? ok("timetravel: meta line names the baseline anchor") : bad("timetravel: meta line names the baseline anchor", tt1.meta);
+    ? ok("restore: reconstructed row folds the event over the baseline")
+    : bad("restore: reconstructed row folds the event over the baseline", JSON.stringify(tt1.cells));
+  /baseline /.test(tt1.meta) ? ok("restore: meta line names the baseline anchor") : bad("restore: meta line names the baseline anchor", tt1.meta);
 
   // pk=4: exists ONLY in the baseline (no events) — a binlog-only reconstruct
   // cannot resolve it, so this pins the baseline half of baseline+deltas.
-  await page.evaluate(() => { const f = document.getElementById("tt-form"); f.elements.pk.value = "4"; f.requestSubmit(); });
-  await page.waitForFunction(() => /d@example\.com/.test((document.getElementById("tt-out") || {}).textContent || ""), { timeout: 10000 });
+  await page.evaluate(async () => { const f = document.getElementById("recover-form"); f.elements.pk.value = "4"; await runState(f, false); });
+  await page.waitForFunction(() => /d@example\.com/.test((document.getElementById("state-out") || {}).textContent || ""), { timeout: 10000 });
   const tt4 = await page.evaluate(() => {
     const cells = {};
-    document.querySelectorAll("#tt-out .statetable tr").forEach((tr) => {
+    document.querySelectorAll("#state-out .statetable tr").forEach((tr) => {
       cells[tr.querySelector("th").textContent] = tr.querySelector("td").textContent;
     });
     return cells;
   });
   (tt4.status === "new" && tt4.email === "d@example.com")
-    ? ok("timetravel: a never-touched row resolves from the baseline alone")
-    : bad("timetravel: a never-touched row resolves from the baseline alone", JSON.stringify(tt4));
+    ? ok("restore: a never-touched row resolves from the baseline alone")
+    : bad("restore: a never-touched row resolves from the baseline alone", JSON.stringify(tt4));
 
   // pk=2: in the baseline, then DELETEd — must render the deleted note, not an
   // empty table and not the stale baseline value.
-  await page.evaluate(() => { const f = document.getElementById("tt-form"); f.elements.pk.value = "2"; f.requestSubmit(); });
-  await page.waitForFunction(() => !!document.querySelector("#tt-out .deleted-note"), { timeout: 10000 });
-  const tt2 = await page.evaluate(() => (document.querySelector("#tt-out .deleted-note") || {}).textContent || "");
+  await page.evaluate(async () => { const f = document.getElementById("recover-form"); f.elements.pk.value = "2"; await runState(f, false); });
+  await page.waitForFunction(() => !!document.querySelector("#state-out .deleted-note"), { timeout: 10000 });
+  const tt2 = await page.evaluate(() => (document.querySelector("#state-out .deleted-note") || {}).textContent || "");
   /Row was deleted/.test(tt2)
-    ? ok("timetravel: a deleted row renders the deleted note")
-    : bad("timetravel: a deleted row renders the deleted note", tt2);
+    ? ok("restore: a deleted row renders the deleted note")
+    : bad("restore: a deleted row renders the deleted note", tt2);
+
+  // The bridge that makes the two halves one errand: the state on screen
+  // becomes the undo window that produces it. since = at + 1s reverses
+  // precisely the events AFTER `at`, because reconstruct applies <= at while
+  // recover reverses >= since. Passing `at` itself would be off by every event
+  // sharing that second — these indexes routinely carry dozens.
+  const bridge = await page.evaluate(async () => {
+    const f = document.getElementById("recover-form");
+    f.elements.pk.value = "1";
+    await runState(f, false);
+    const btn = document.querySelector(".state-actions .btn-primary");
+    if (!btn) return { err: "no Restore-to-this-state button on a found row" };
+    const at = (document.querySelector("#state-out .meta-line") || {}).textContent || "";
+    btn.click();
+    return { since: f.elements.since.value, until: f.elements.until.value, at };
+  });
+  {
+    const m = /as of (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/.exec(bridge.at || "");
+    const want = m ? new Date(Date.parse(m[1].replace(" ", "T") + "Z") + 1000).toISOString().slice(0, 19).replace("T", " ") : null;
+    (want && bridge.since === want && bridge.until === "")
+      ? ok("restore: 'Restore to this state' sets the undo window to at+1s")
+      : bad("restore: 'Restore to this state' sets the undo window to at+1s", JSON.stringify({ ...bridge, want }));
+  }
 
   // Scenario 15 — Overview window honesty (#686): fixture-drive the REAL
   // buildOverview with a status.coverage spanning far more history than the


### PR DESCRIPTION
Refs #1298 — the merge itself. The timeline control (slice 2 of the re-cut plan) is not in here.

## Why

Two nav entries opened near-identical schema/table/PK forms and read as the same feature twice. They were two halves of one errand: read a timestamp off Events, retype the target into Time-travel, look, then retype the same target into Recover. Seeing a row's earlier state is not a separate product — it is the preview of a restore.

## What changed

**One destination.** Recover keeps its route and becomes **Restore**, gaining a *Row at a point in time* panel driven by the target already on the page — so the target is entered once. Time-travel's nav entry is retired and `/timetravel` rewrites to `/recover`, so old bookmarks and Back entries land on the merged page rather than Overview. `renderStateAt` / `renderTimeline` / `stateTable` are reused unchanged.

**The bridge — and the arithmetic that makes it honest.** *Restore to this state* turns the state on screen into the undo window that produces it:

- `reconstruct` applies events timestamped `<= at`.
- `recover` reverses events timestamped `>= since`, leaving the row before the earliest of them.
- So `since = at + 1s` reverses precisely the events **after** `at`, landing the row on the state displayed. `event_timestamp` is `DATETIME(0)`, so nothing can hide between `at` and `at+1s`.

Passing `at` itself would be off by every event sharing that second, and these indexes routinely carry dozens from one write burst — the live install shows a dozen at `17:47:32`. `until` is cleared for the same reason it gets set by the Undo bridge: a leftover upper bound would quietly drop the newest damage out of the window.

**It degrades instead of disappearing.** With no baseline the panel still renders and says a baseline is what is missing — an operator who cannot find the panel has no way to learn why — while the undo half keeps working, since it needs no baseline. Under a scoped session it carries `data-perm="reconstruct:execute"` and is hidden by the same `gatePermissions` pass the nav uses, so a session holding only `recover:execute` still gets a working page.

## Verification

Rendered in Chrome against the real assets:

| check | result |
|---|---|
| `shiftSeconds` — midnight, year boundary, ISO input, garbage, empty | 6/6 |
| stable under a non-UTC browser (offset +300) | yes — a local parse would shift the window by the browser's offset |
| `/timetravel` | resolves to a page titled **Restore** |
| nav | no Time-travel entry; Recover renamed Restore |
| bridge | `at=2026-08-09 17:47:32` → `since=17:47:33`, `until` cleared |
| no baseline | panel present, explains the baseline, no controls |
| `reconstruct:execute` denied | panel `perm-off`; undo form still present |

`go test ./internal/console/... ./consoleapp/...` green.

## Not in scope

The timeline control that replaces the typed instant — the remaining friction, and the piece that stops the operator leaving to read a time off Events. Tracked in #1298.
