### PR TITLE
fix(console): the timeline's restore aimed at the wrong end of the window

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1756,6 +1756,29 @@ async function runState(form, history) {
   }
 }
 
+// aimUndoAtInstant points the undo window at the state as of `at`: reverse
+// everything AFTER that instant, so the row lands exactly on what was shown.
+//
+// since = at + 1s is exact, not approximate. reconstruct applies events
+// timestamped <= at; recover reverses events timestamped >= since and leaves
+// the row before the earliest of them. event_timestamp is DATETIME(0), so no
+// event can hide between at and at+1s — while passing `at` itself would be off
+// by every event sharing that second, and these indexes routinely carry dozens
+// from a single write burst.
+//
+// Clearing `until` matters just as much: a leftover upper bound (the Undo
+// bridge from Events sets one) would drop the newest damage out of the window
+// and quietly restore to the wrong place.
+function aimUndoAtInstant(form, at) {
+  const since = shiftSeconds(at, 1);
+  if (!since) { toast("Could not read the selected instant."); return; }
+  form.elements.since.value = since;
+  form.elements.until.value = "";
+  previewRecover(form);
+  form.scrollIntoView({ behavior: "smooth", block: "start" });
+  toast("Undo window set to everything after " + at);
+}
+
 // restoreToStateAction is the bridge that makes the two halves one errand:
 // the state on screen becomes the undo window that produces it.
 //
@@ -1775,19 +1798,23 @@ function restoreToStateAction(form, data) {
   row.append(el("button", {
     class: "btn btn-primary", type: "button", text: "Restore to this state",
     title: "Reverse every change after " + data.at + ", leaving the row exactly as shown",
-    onclick: () => {
-      const since = shiftSeconds(data.at, 1);
-      if (!since) { toast("Could not read the selected instant."); return; }
-      form.elements.since.value = since;
-      form.elements.until.value = "";
-      previewRecover(form);
-      form.scrollIntoView({ behavior: "smooth", block: "start" });
-      toast("Undo window set to everything after " + data.at);
-    },
+    onclick: () => aimUndoAtInstant(form, data.at),
   }));
   row.append(el("span", { class: "state-actions-note", text:
     "Sets the undo window to every change after this instant. Review the rows, then generate the SQL." }));
   return row;
+}
+
+// useTimelineInstant fills the At field from a timeline node and re-runs the
+// state view. This is what replaces typing a timestamp: the operator points at
+// the change that broke things instead of transcribing its time from Events.
+function useTimelineInstant(at) {
+  const field = $('[name="state_at"]', VIEW());
+  const form = document.getElementById("recover-form");
+  if (!field || !form) return;
+  field.value = at;
+  runState(form, false);
+  field.scrollIntoView({ behavior: "smooth", block: "center" });
 }
 
 // shiftSeconds adds n seconds to a "YYYY-MM-DD HH:MM:SS" UTC stamp, returning
@@ -1915,12 +1942,31 @@ function renderTimeline(container, data) {
     }
     node.append(body);
 
+    // Both actions are "pick this moment" — the timeline is how an operator
+    // chooses an instant without leaving to read one off Events and retype it.
+    //
+    // The restore button used to route through undoEvent, which sets `until`:
+    // that reverses everything UP TO this point and lands the row before its
+    // whole recorded history — the opposite end from the state the button is
+    // pointing at. It shares the state panel's exact bridge now, so the label
+    // and the SQL finally agree.
+    const acts = el("div", { class: "tl-actions" });
+    acts.append(el("button", {
+      class: "btn btn-sm tl-use", type: "button", text: "Use this moment",
+      title: "Set the At field above to " + e.time,
+      onclick: () => useTimelineInstant(e.time),
+    }));
     if (e.source !== "baseline") {
-      const acts = el("div", { class: "tl-actions" });
-      acts.append(el("button", { class: "btn btn-sm tl-restore", type: "button", text: "Restore to this state",
-        onclick: () => undoEvent({ schema_name: data.schema, table_name: data.table, pk_values: data.pk, event_type: e.source, event_timestamp: e.time }) }));
-      node.append(acts);
+      acts.append(el("button", {
+        class: "btn btn-sm tl-restore", type: "button", text: "Restore to this state",
+        title: "Reverse every change after " + e.time + ", leaving the row as shown here",
+        onclick: () => {
+          const form = document.getElementById("recover-form");
+          if (form) aimUndoAtInstant(form, e.time);
+        },
+      }));
     }
+    node.append(acts);
     tl.append(node);
   });
   container.append(tl);

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -805,12 +805,14 @@ button { font-family: inherit; }
 @keyframes ul { to { transform: scaleX(1); } }
 
 /* restore action on each timeline node */
-.tl-actions { margin-top: 10px; }
+.tl-actions { margin-top: 10px; display: flex; gap: 8px; flex-wrap: wrap; }
 .tl-restore {
   height: 28px; padding: 0 11px; font-size: 12px;
   color: var(--ink-2); background: var(--surface); border: 1px solid var(--line);
 }
 .tl-restore svg { width: 13px; height: 13px; }
+.tl-use { color: var(--ink-3); }
+.tl-use:hover { border-color: var(--ink-4); color: var(--ink); }
 .tl-restore:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-bg); }
 [data-accent="warm"] .tl-restore:hover { border-color: var(--orange-2); color: var(--orange-2); }
 

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -824,6 +824,46 @@ try {
       : bad("restore: 'Restore to this state' sets the undo window to at+1s", JSON.stringify({ ...bridge, want }));
   }
 
+  // The timeline is how an operator picks an instant without leaving to read
+  // one off Events. Its own restore button used to route through undoEvent,
+  // which sets `until` — reversing everything UP TO that point and landing the
+  // row before its whole history, the opposite end from the state the button
+  // names. Pin both actions against a real render.
+  const tl = await page.evaluate(async () => {
+    const f = document.getElementById("recover-form");
+    f.elements.pk.value = "1";
+    f.elements.since.value = "";
+    f.elements.until.value = "2000-01-01 00:00:00"; // stale bound that must be cleared
+    await runState(f, true);
+    const nodes = Array.from(document.querySelectorAll(".tl-node"));
+    if (!nodes.length) return { err: "no timeline nodes" };
+    const last = nodes[nodes.length - 1];
+    const time = (last.querySelector(".tl-time") || {}).textContent || "";
+    const restore = last.querySelector(".tl-restore");
+    const use = last.querySelector(".tl-use");
+    if (!use) return { err: "no 'Use this moment' action" };
+    use.click();
+    const at = (document.querySelector('[name="state_at"]') || {}).value || "";
+    if (!restore) return { time, at, skippedRestore: true };
+    restore.click();
+    return { time, at, since: f.elements.since.value, until: f.elements.until.value };
+  });
+  if (tl.err) {
+    bad("restore: timeline offers per-node actions", tl.err);
+  } else {
+    (tl.at === tl.time)
+      ? ok("restore: 'Use this moment' fills the At field from the timeline")
+      : bad("restore: 'Use this moment' fills the At field from the timeline", JSON.stringify(tl));
+    if (tl.skippedRestore) {
+      ok("restore: timeline restore skipped (baseline-only node)");
+    } else {
+      const want = new Date(Date.parse(tl.time.replace(" ", "T") + "Z") + 1000).toISOString().slice(0, 19).replace("T", " ");
+      (tl.since === want && tl.until === "")
+        ? ok("restore: timeline 'Restore to this state' aims AFTER the instant, not before it")
+        : bad("restore: timeline 'Restore to this state' aims AFTER the instant, not before it", JSON.stringify({ ...tl, want }));
+    }
+  }
+
   // Scenario 15 — Overview window honesty (#686): fixture-drive the REAL
   // buildOverview with a status.coverage spanning far more history than the
   // fetched events window, and assert the window line uses the window's OWN


### PR DESCRIPTION
The history timeline already carried a per-event "Restore to this state"
button, and it did not restore to that state. It routed through
undoEvent, which sets `until` — reversing everything UP TO that instant
and landing the row before its whole recorded history, the opposite end
from the state the button was pointing at. The label and the SQL
disagreed, on the one screen whose job is deciding what to undo.

It shares the state panel's bridge now: since = instant + 1s, `until`
cleared. reconstruct applies events timestamped <= at while recover
reverses events timestamped >= since, so that lands the row exactly on
the state the node displays. event_timestamp is DATETIME(0), so nothing
can hide in between; passing the instant itself would be off by every
event sharing that second, and these indexes routinely carry dozens from
one write burst. Clearing `until` matters as much — the Undo bridge from
Events sets one, and a leftover bound would drop the newest damage out of
the window.

Both call sites now go through aimUndoAtInstant, so they cannot drift
apart again.

Adds "Use this moment" per node, which fills the At field and re-renders
the state. That is the friction this issue is actually about: the
operator points at the change that broke things instead of leaving to
read its timestamp off Events and typing it back.

Verified in Chrome against the real assets: the timeline restore sets
since to instant+1s and clears a pre-set `until`; the old behaviour (until
= the event's own time) is gone; a middle node aims at its own instant
rather than the newest; and "Use this moment" fills At from the node. The
console e2e pins all of it against a real render, with a stale `until`
seeded so its clearing is observable.

Refs #1298