### PR TITLE
feat(ext): settings-surface seam + a registry instead of one view slot

### DIFF
--- a/ext/consolepolicy.go
+++ b/ext/consolepolicy.go
@@ -37,8 +37,15 @@ const (
 	// PermServersDelete — remove a server registry entry.
 	PermServersDelete Permission = "servers:delete"
 	// PermSettingsRead — reach the settings/administration surfaces (storage and
-	// baseline listings, telemetry opt-out, the managed MCP token).
+	// baseline listings, telemetry opt-out, the managed MCP token) and READ an
+	// installed settings panel's data routes.
 	PermSettingsRead Permission = "settings:read"
+	// PermSettingsWrite — MUTATE through a settings surface. Split from
+	// PermSettingsRead because an administration panel (ConsoleSettingsProvider)
+	// can change configuration for everyone, so a session that may inspect the
+	// settings surface must not thereby be able to rewrite it — the read-only
+	// auditor role is the case this exists for.
+	PermSettingsWrite Permission = "settings:write"
 	// PermExtViewRead — reach an installed extension view's data routes.
 	PermExtViewRead Permission = "extview:read"
 )
@@ -56,6 +63,7 @@ var allPermissions = []Permission{
 	PermServersWrite,
 	PermServersDelete,
 	PermSettingsRead,
+	PermSettingsWrite,
 	PermExtViewRead,
 }
 

--- a/ext/consolesettings.go
+++ b/ext/consolesettings.go
@@ -1,0 +1,150 @@
+package ext
+
+import (
+	"net/http"
+	"slices"
+)
+
+// ConsoleSettingsContext is what a ConsoleSettingsProvider's data handler gets
+// about the CALLING SESSION: who it is and what it may do. It deliberately
+// carries no index access — a settings panel administers process-scoped
+// configuration, so handing it the selected server's ConsoleQueryContext would
+// imply a per-server semantics that does not exist, and would make a panel look
+// like it changes meaning when the operator switches servers in the UI.
+//
+// It exists so a panel can enforce its OWN invariants server-side (the concrete
+// case: refusing a self-demotion, which needs both the caller's identity and
+// what the caller currently holds). Client-side checks are not enforcement.
+type ConsoleSettingsContext struct {
+	// Identity is the session's verified login identity — the string the auth
+	// provider passed to ConsoleSessionIssuer. EMPTY for the static automation
+	// token and for a session minted without one, so a panel that keys an
+	// invariant on identity must treat "" as "unknown caller" and decide
+	// explicitly (refuse, or allow as an unattributed operator) rather than
+	// comparing "" against a stored record and matching the wrong row.
+	Identity string
+	// Permissions is a COPY of the effective permission set this session holds.
+	// A copy on purpose: the live slice belongs to the session store and is
+	// shared across every request that session makes, so a provider appending to
+	// it would rewrite another request's grants.
+	//
+	// For a full-access session (see FullAccess) this is every permission the
+	// core defines today. Prefer Allows over reading the slice.
+	Permissions []Permission
+	// FullAccess reports that the session carries NO access policy at all — the
+	// static token, the built-in password login, and every OSS session. Such a
+	// session also holds permissions the core adds in LATER releases, which a
+	// materialized list cannot express: without this flag a full-access operator
+	// would start being denied each newly defined permission until the panel was
+	// rebuilt against the new core.
+	FullAccess bool
+}
+
+// Allows reports whether the session may exercise perm. Use it rather than
+// scanning Permissions, so the full-access case (a policy-less session, which
+// holds everything including permissions defined after this build) stays correct.
+func (c ConsoleSettingsContext) Allows(perm Permission) bool {
+	return c.FullAccess || slices.Contains(c.Permissions, perm)
+}
+
+// ConsoleSettingsContextFunc resolves the calling session's identity and grants
+// for a request. It cannot fail: the console has already authenticated the
+// request (the settings data routes mount behind the bearer middleware) and the
+// answer is read off the request context, so there is no error to report and no
+// error case a provider could mishandle by ignoring.
+type ConsoleSettingsContextFunc func(r *http.Request) ConsoleSettingsContext
+
+// ConsoleSettingsProvider injects one administration panel into the web
+// console's Settings surface: a nav item under Settings, a capability entry, an
+// authenticated data API, and a frontend module that renders the panel. It is
+// the sibling of ConsoleViewProvider for surfaces that administer local
+// configuration instead of reading captured row data.
+//
+// The two seams differ in exactly one way that matters, and it is the reason
+// this is a separate interface rather than a wider version of the other: an
+// extension VIEW is refused outright (403) whenever an RBAC data profile is
+// active, because the console cannot verify a third-party handler honors
+// table-deny and column-redaction on the raw *sql.DB it is handed. A settings
+// panel is handed no database at all, so that reasoning does not apply — and
+// applying it anyway would lock out precisely the profile-carrying administrator
+// who needs to administer. A settings panel is therefore gated by PERMISSION,
+// the mechanism intended for it:
+//
+//   - Static assets at "/ext-settings/<ID>/" — served UNAUTHENTICATED behind the
+//     host guard and security headers only, exactly like index.html and app.js.
+//     Code always ships; only DATA is gated. A browser must be able to load the
+//     module before it has authenticated.
+//   - Data routes at "/api/ext-settings/<ID>/" — behind the console's
+//     bearer-token middleware, then the per-session authorization middleware,
+//     which requires PermSettingsRead for GET/HEAD and PermSettingsWrite for
+//     every other method. Method-based because the core cannot let a provider
+//     classify its own routes; see the console's route table for what that
+//     cannot catch (a provider that mutates on GET).
+type ConsoleSettingsProvider interface {
+	// ID is a STABLE, lowercase, URL-safe key for this panel. It is used three
+	// ways — as the capability key, as the "/ext-settings/<ID>/" +
+	// "/api/ext-settings/<ID>/" mount segment, and as the SPA route
+	// "extset-<ID>" — so it must match ^[a-z0-9-]+$ (see ValidConsoleViewID,
+	// shared with the view seam: the constraint is on the URL/DOM segment, not on
+	// the kind of provider). It must not change across releases: the operator's
+	// bookmarks and the SPA route both key on it. A provider whose ID fails
+	// validation, or collides with a panel already mounted, is skipped by the
+	// console (logged, not mounted) so a typo degrades to "no panel" instead of a
+	// broken route or a duplicate-pattern panic at startup.
+	ID() string
+	// Label is the human-readable nav text for the panel, shown in the console's
+	// Settings group.
+	Label() string
+	// Script is the URL of an ES module the SPA import()s and then calls
+	// render(mount, {apiBase, api}) on. Same-origin, same document — NOT an
+	// iframe (X-Frame-Options: DENY is global). Serve it from this provider's own
+	// StaticHandler subtree (e.g. "/ext-settings/<ID>/panel.js").
+	Script() string
+	// StaticHandler serves the panel's frontend assets. The console mounts it at
+	// prefix ("/ext-settings/<ID>/") UNAUTHENTICATED — it must expose only
+	// static, non-secret files (the module named by Script and whatever it
+	// loads). The handler sees requests whose path still carries prefix.
+	StaticHandler(prefix string) http.Handler
+	// DataHandler serves the panel's authenticated data routes. The console
+	// mounts it at prefix ("/api/ext-settings/<ID>/") behind the bearer-token and
+	// authorization middleware described above. session yields the calling
+	// session's identity and grants; the handler calls it to enforce its own
+	// invariants (the permission floor is already enforced before the handler
+	// runs, but a panel-specific rule — "an admin may not remove their own admin
+	// role" — is the panel's to enforce). The handler sees requests whose path
+	// still carries prefix.
+	DataHandler(prefix string, session ConsoleSettingsContextFunc) http.Handler
+}
+
+// registeredConsoleSettings holds the installed settings-panel providers. A
+// registry from the start, not a slot: the whole point of this seam is that a
+// build can contribute a panel without displacing one another build already
+// installed. Empty in the OSS build — the console ships no settings panels, so
+// its behavior is unchanged.
+var registeredConsoleSettings []ConsoleSettingsProvider
+
+// RegisterConsoleSettings installs a console settings-panel provider. Additive:
+// two calls install two panels. Call from main() before command dispatch — the
+// console reads the registry when the server is constructed, so a later install
+// is never picked up. A nil provider is ignored rather than appended, so an
+// unconditional call in a build that computed no provider cannot produce a
+// nil-dereference at mount time.
+//
+// IDs are neither validated nor deduplicated here (a setter that panicked on a
+// caller's typo would take down the daemon at startup); the console skips an
+// invalid or already-mounted ID at mount time and logs it.
+func RegisterConsoleSettings(p ConsoleSettingsProvider) {
+	if p == nil {
+		return
+	}
+	registeredConsoleSettings = append(registeredConsoleSettings, p)
+}
+
+// ConsoleSettings returns every installed settings-panel provider, in install
+// order, as a fresh slice the caller may keep. Empty in the OSS build. The order
+// is stable so the console's Settings nav items do not shuffle between restarts.
+func ConsoleSettings() []ConsoleSettingsProvider {
+	out := make([]ConsoleSettingsProvider, len(registeredConsoleSettings))
+	copy(out, registeredConsoleSettings)
+	return out
+}

--- a/ext/consolesettings_test.go
+++ b/ext/consolesettings_test.go
@@ -1,0 +1,107 @@
+package ext
+
+import (
+	"net/http"
+	"slices"
+	"testing"
+)
+
+type stubSettings struct {
+	id    string
+	label string
+}
+
+func (p stubSettings) ID() string                      { return p.id }
+func (p stubSettings) Label() string                   { return p.label }
+func (p stubSettings) Script() string                  { return "/ext-settings/" + p.id + "/panel.js" }
+func (stubSettings) StaticHandler(string) http.Handler { return http.NotFoundHandler() }
+func (stubSettings) DataHandler(string, ConsoleSettingsContextFunc) http.Handler {
+	return http.NotFoundHandler()
+}
+
+func TestConsoleSettingsEmptyByDefault(t *testing.T) {
+	t.Cleanup(ResetForTest)
+	if got := ConsoleSettings(); len(got) != 0 {
+		t.Fatalf("ConsoleSettings() = %v, want empty — the OSS build installs no settings panel", got)
+	}
+}
+
+// Additive is the whole point of the registry: a second install must not
+// displace the first (the single-slot seam it replaces silently kept whichever
+// call ran last, so wiring order decided which panel existed).
+func TestRegisterConsoleSettingsIsAdditive(t *testing.T) {
+	t.Cleanup(ResetForTest)
+	RegisterConsoleSettings(stubSettings{id: "users", label: "Users"})
+	RegisterConsoleSettings(stubSettings{id: "keys", label: "Keys"})
+
+	got := ConsoleSettings()
+	if len(got) != 2 {
+		t.Fatalf("ConsoleSettings() has %d providers, want 2 (a second install must not replace the first)", len(got))
+	}
+	if got[0].ID() != "users" || got[1].ID() != "keys" {
+		t.Errorf("ConsoleSettings() ids = %q,%q — install order must be preserved so nav items don't shuffle", got[0].ID(), got[1].ID())
+	}
+}
+
+// A nil install must be dropped, not appended: the console would otherwise
+// dereference it at mount time and take the daemon down at startup.
+func TestRegisterConsoleSettingsIgnoresNil(t *testing.T) {
+	t.Cleanup(ResetForTest)
+	RegisterConsoleSettings(nil)
+	if got := ConsoleSettings(); len(got) != 0 {
+		t.Fatalf("ConsoleSettings() = %v after registering nil, want empty", got)
+	}
+}
+
+// The returned slice must not alias the registry — a caller appending to it
+// would otherwise install a panel nobody registered.
+func TestConsoleSettingsReturnsCopy(t *testing.T) {
+	t.Cleanup(ResetForTest)
+	RegisterConsoleSettings(stubSettings{id: "users", label: "Users"})
+	got := ConsoleSettings()
+	got[0] = stubSettings{id: "hijacked", label: "Hijacked"}
+	if ConsoleSettings()[0].ID() != "users" {
+		t.Error("mutating the ConsoleSettings() result changed the registry")
+	}
+}
+
+// The setters do not validate IDs — validation belongs to the console at mount
+// time, so a caller's typo degrades to "no panel" instead of panicking the
+// daemon during startup wiring.
+func TestRegisterConsoleSettingsDoesNotValidateID(t *testing.T) {
+	t.Cleanup(ResetForTest)
+	RegisterConsoleSettings(stubSettings{id: "Bad ID/../x"})
+	if len(ConsoleSettings()) != 1 {
+		t.Fatal("RegisterConsoleSettings rejected an invalid ID; validation belongs to the console, not the setter")
+	}
+}
+
+func TestConsoleSettingsContextAllows(t *testing.T) {
+	scoped := ConsoleSettingsContext{
+		Identity:    "ops@example.com",
+		Permissions: []Permission{PermSettingsRead},
+	}
+	if !scoped.Allows(PermSettingsRead) {
+		t.Error("Allows(settings:read) = false for a session that holds it")
+	}
+	if scoped.Allows(PermSettingsWrite) {
+		t.Error("Allows(settings:write) = true for a session that does NOT hold it")
+	}
+
+	// A policy-less session holds everything — including permissions defined
+	// after this build, which is why FullAccess is a flag and not just a longer
+	// list. A panel must not start refusing a full-access operator the day the
+	// core defines a new permission.
+	full := ConsoleSettingsContext{Permissions: nil, FullAccess: true}
+	if !full.Allows(PermSettingsWrite) || !full.Allows(Permission("some:future-permission")) {
+		t.Error("a FullAccess context denied a permission; a policy-less session holds every permission, present and future")
+	}
+}
+
+// settings:write must be a permission the core defines, or a route table / policy
+// referencing it would silently never match a granted permission.
+func TestSettingsWriteIsAKnownPermission(t *testing.T) {
+	if !slices.Contains(AllPermissions(), PermSettingsWrite) {
+		t.Errorf("AllPermissions() omits %q — a permission missing from the list is never reported to the SPA nor guarded by the route-table tests", PermSettingsWrite)
+	}
+}

--- a/ext/consoleview.go
+++ b/ext/consoleview.go
@@ -120,22 +120,66 @@ var consoleViewIDRE = regexp.MustCompile(`^[a-z0-9-]+$`)
 // provider that fails, rather than mounting a malformed route.
 func ValidConsoleViewID(id string) bool { return consoleViewIDRE.MatchString(id) }
 
-// consoleView is nil in the OSS build — the console ships no extension views.
+// consoleView is the ORIGINAL single-provider slot, kept because an embedding
+// build already calls SetConsoleView. Nil in the OSS build — the console ships
+// no extension views.
 var consoleView ConsoleViewProvider
 
-// SetConsoleView installs the process-wide console extension-view provider.
-// Call once from main() before command dispatch, like SetConsoleAuth: the
-// console reads it when the server is constructed, so a later install is never
-// picked up. A bad ID is not rejected here — the console validates it at mount
-// time and skips the provider — so this setter cannot panic on a caller's typo.
+// registeredConsoleViews holds the providers installed additively through
+// RegisterConsoleView. Separate from the slot above so SetConsoleView keeps its
+// documented replace-the-slot behavior (an existing caller that installs twice
+// must not suddenly mount two copies) while a new caller can install alongside
+// one without knowing whether the slot is taken. Empty in the OSS build.
+var registeredConsoleViews []ConsoleViewProvider
+
+// SetConsoleView installs the process-wide console extension-view provider in
+// the legacy single slot, replacing whatever was there (nil clears it). Call
+// once from main() before command dispatch, like SetConsoleAuth: the console
+// reads it when the server is constructed, so a later install is never picked
+// up. A bad ID is not rejected here — the console validates it at mount time and
+// skips the provider — so this setter cannot panic on a caller's typo.
+//
+// Prefer RegisterConsoleView for new code: this setter can hold exactly one
+// provider, so two independent installs silently reduce to whichever ran last.
 func SetConsoleView(p ConsoleViewProvider) {
 	consoleView = p
 }
 
-// ConsoleView returns the installed provider, or nil when none is installed
-// (the OSS build).
+// ConsoleView returns the provider installed in the legacy slot, or nil when
+// none is (the OSS build). It does NOT see providers installed with
+// RegisterConsoleView — a caller that must act on every installed view (the
+// console's mount and capabilities paths do) must range over ConsoleViews.
 func ConsoleView() ConsoleViewProvider {
 	return consoleView
+}
+
+// RegisterConsoleView installs an additional console extension-view provider.
+// Additive by contract: two calls install two views, which is the whole reason
+// this exists next to SetConsoleView. Call from main() before command dispatch
+// — the console reads the registry when the server is constructed. A nil
+// provider is ignored rather than appended, so an unconditional call in a build
+// that computed no provider cannot produce a nil-dereference at mount time.
+//
+// IDs are neither validated nor deduplicated here (a setter that panicked on a
+// caller's typo would take down the daemon at startup); the console skips an
+// invalid or already-mounted ID at mount time and logs it.
+func RegisterConsoleView(p ConsoleViewProvider) {
+	if p == nil {
+		return
+	}
+	registeredConsoleViews = append(registeredConsoleViews, p)
+}
+
+// ConsoleViews returns every installed extension-view provider — the legacy slot
+// first, then the registered ones in install order — as a fresh slice the caller
+// may keep. Empty in the OSS build. The order is stable so the console's nav
+// items do not shuffle between restarts.
+func ConsoleViews() []ConsoleViewProvider {
+	out := make([]ConsoleViewProvider, 0, len(registeredConsoleViews)+1)
+	if consoleView != nil {
+		out = append(out, consoleView)
+	}
+	return append(out, registeredConsoleViews...)
 }
 
 // Content-Security-Policy invariant: the console sets NO Content-Security-Policy

--- a/ext/consoleview_test.go
+++ b/ext/consoleview_test.go
@@ -63,6 +63,62 @@ func TestSetConsoleViewDoesNotValidateID(t *testing.T) {
 	}
 }
 
+func TestConsoleViewsEmptyByDefault(t *testing.T) {
+	t.Cleanup(ResetForTest)
+	if got := ConsoleViews(); len(got) != 0 {
+		t.Fatalf("ConsoleViews() = %v, want empty — the OSS build installs no extension view", got)
+	}
+}
+
+// The registry must be additive AND must keep the legacy slot working: an
+// embedding build that already calls SetConsoleView keeps its view, and a build
+// that also registers one gets both rather than whichever wiring ran last.
+func TestConsoleViewsRegistryIsAdditiveAndKeepsTheLegacySlot(t *testing.T) {
+	t.Cleanup(ResetForTest)
+	SetConsoleView(stubConsoleView{id: "legacy"})
+	t.Cleanup(func() { SetConsoleView(nil) })
+	RegisterConsoleView(stubConsoleView{id: "first"})
+	RegisterConsoleView(stubConsoleView{id: "second"})
+
+	got := ConsoleViews()
+	if len(got) != 3 {
+		t.Fatalf("ConsoleViews() has %d providers, want 3 (legacy slot + two registered)", len(got))
+	}
+	// Order is part of the contract: the nav must not shuffle between restarts.
+	for i, want := range []string{"legacy", "first", "second"} {
+		if got[i].ID() != want {
+			t.Errorf("ConsoleViews()[%d].ID() = %q, want %q", i, got[i].ID(), want)
+		}
+	}
+	// The legacy accessor keeps reporting the slot only — an existing caller's
+	// meaning must not shift under it.
+	if p := ConsoleView(); p == nil || p.ID() != "legacy" {
+		t.Errorf("ConsoleView() = %v, want the legacy-slot provider", p)
+	}
+}
+
+// With nothing in the legacy slot the registry stands alone — a build that only
+// ever calls RegisterConsoleView must not need SetConsoleView first.
+func TestConsoleViewsRegistryWithoutLegacySlot(t *testing.T) {
+	t.Cleanup(ResetForTest)
+	RegisterConsoleView(stubConsoleView{id: "only"})
+	got := ConsoleViews()
+	if len(got) != 1 || got[0].ID() != "only" {
+		t.Fatalf("ConsoleViews() = %v, want exactly the registered provider", got)
+	}
+	if ConsoleView() != nil {
+		t.Error("ConsoleView() reports a provider that was never installed in the slot")
+	}
+}
+
+func TestRegisterConsoleViewIgnoresNil(t *testing.T) {
+	t.Cleanup(ResetForTest)
+	RegisterConsoleView(nil)
+	if got := ConsoleViews(); len(got) != 0 {
+		t.Fatalf("ConsoleViews() = %v after registering nil, want empty", got)
+	}
+}
+
 func TestValidConsoleViewID(t *testing.T) {
 	valid := []string{"a", "example", "my-view", "view2", "0", "a-b-c-1"}
 	for _, id := range valid {

--- a/ext/testing.go
+++ b/ext/testing.go
@@ -1,13 +1,20 @@
 package ext
 
 // ResetForTest clears every extension registry (doctor checks, source jobs,
-// agent commands) so tests in other packages can register fixtures without
-// polluting later tests in the same binary. Test helper ONLY — the
-// registries are startup-only by contract (set once from main(), never
-// mutated during command execution), and production code must never call
-// this.
+// agent commands, console views and settings panels) so tests in other packages
+// can register fixtures without polluting later tests in the same binary. Test
+// helper ONLY — the registries are startup-only by contract (set once from
+// main(), never mutated during command execution), and production code must
+// never call this.
+//
+// It does NOT touch the single-provider slots (SetConsoleView, SetConsoleAuth,
+// SetAuditSink): those have their own setters a test undoes by passing nil, and
+// clearing them here would silently uninstall a fixture a test installed with
+// the setter it is exercising.
 func ResetForTest() {
 	doctorChecks = nil
 	sourceJobs = nil
 	agentCommands = map[string]AgentCommandFunc{}
+	registeredConsoleViews = nil
+	registeredConsoleSettings = nil
 }

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -67,6 +67,7 @@ let serverGen = 0;            // bumped on every server switch (staleness guard)
 let viewGen = 0;              // bumped on every route render (staleness guard)
 let capsCache = {};           // last /api/capabilities for the selected server
 let extViews = [];            // extension views advertised for the selected server (embedding builds)
+let extSettings = [];         // extension settings panels advertised for this SESSION (permission-gated, not per-server)
 let lastSQL = "";             // last generated undo SQL (for copy/download)
 let lastEvents = [];          // last rendered (filtered, capped) event page
 let pendingRecover = null;    // event context carried into Recover via "Undo"
@@ -620,6 +621,11 @@ function viewEnter() { const v = VIEW(); v.classList.remove("view-enter"); void 
 // caller redirects to overview), the same gating Time-travel/Storage get.
 function isKnownRoute(route) {
   if (ROUTES.includes(route)) return true;
+  // "extset-<id>" is checked first: it does NOT start with "ext-" (the fourth
+  // character is "s", not "-"), so the two families never claim each other's
+  // routes, and a panel the session may not reach is unknown here exactly like
+  // an unadvertised view.
+  if (route.startsWith("extset-")) return extSettings.some((p) => "extset-" + p.id === route);
   return route.startsWith("ext-") && extViews.some((v) => "ext-" + v.id === route);
 }
 
@@ -664,6 +670,10 @@ function renderRoute() {
   // Extension views (embedding builds): "ext-<id>" dispatches to the provider's
   // frontend module. routeFromLocation already redirected an unknown/ungated
   // ext route to overview, so a match here is always a live view.
+  if (route.startsWith("extset-")) {
+    const panel = extSettings.find((p) => "extset-" + p.id === route);
+    return panel ? renderExtensionSettings(panel) : renderOverview();
+  }
   if (route.startsWith("ext-")) {
     const view = extViews.find((v) => "ext-" + v.id === route);
     return view ? renderExtensionView(view) : renderOverview();
@@ -3422,7 +3432,9 @@ async function gateCapabilities() {
   // stock binary and under any active profile — the backend omits them there).
   // Rebuild the nav before the route renders so a deep-linked ext route resolves.
   extViews = Array.isArray(capsCache.extension_views) ? capsCache.extension_views : [];
+  extSettings = Array.isArray(capsCache.extension_settings) ? capsCache.extension_settings : [];
   syncExtNav();
+  syncExtSettingsNav();
   $all("[data-capability]").forEach((node) => node.classList.toggle("cap-on", !!capsCache[node.dataset.capability]));
   gatePermissions();
   applyAuthGate();
@@ -3504,6 +3516,55 @@ function syncExtNav() {
 // captured before the dynamic import and re-checked after: a server switch
 // mid-import abandons the render (no cross-server paint), matching every other
 // async view here.
+// syncExtSettingsNav rebuilds the extension settings-panel nav items inside the
+// existing Settings group (not a group of their own: a panel administers the
+// console, so it belongs where Connect AI and Storage already are). Idempotent —
+// the previously injected items are removed first, so a capabilities refresh
+// after a server switch or a re-login never accumulates duplicates.
+function syncExtSettingsNav() {
+  $all("[data-extset-nav]").forEach((n) => n.remove());
+  if (!extSettings.length) return;
+  const anchor = $('.nav-item[data-route="connect"]');
+  const group = anchor ? anchor.closest(".nav-group") : null;
+  if (!group) return;
+  for (const p of extSettings) {
+    const route = "extset-" + p.id;
+    group.append(el("a", {
+      class: "nav-item",
+      "data-extset-nav": "1",
+      "data-route": route,
+      href: "/" + route,
+      onclick: (e) => { e.preventDefault(); pendingRecover = null; navigate(route); },
+    }, icon("ext", "ni-icon"), el("span", { text: p.label })));
+  }
+}
+
+// renderExtensionSettings mounts a settings panel's ES module. Same contract as
+// renderExtensionView, with the panel's own data prefix — the two surfaces are
+// authorized differently server-side (settings:read/write vs extview:read), so
+// handing a panel the view's apiBase would send its requests through the wrong
+// gate and 403.
+async function renderExtensionSettings(panel) {
+  const gen = serverGen;
+  const v = VIEW();
+  clear(v);
+  v.append(pageHead(panel.label, null));
+  const mount = el("div", { class: "ext-view-mount" });
+  v.append(mount);
+  try {
+    const mod = await import(panel.script);
+    if (gen !== serverGen) return;
+    if (!mod || typeof mod.render !== "function") {
+      renderError(mount, "This settings panel did not export a render() function.");
+      return;
+    }
+    mod.render(mount, { apiBase: "/api/ext-settings/" + panel.id + "/", api });
+  } catch (err) {
+    if (gen !== serverGen) return;
+    renderError(mount, err);
+  }
+}
+
 async function renderExtensionView(view) {
   const gen = serverGen;
   const v = VIEW();

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -3533,6 +3533,13 @@ function syncExtSettingsNav() {
       class: "nav-item",
       "data-extset-nav": "1",
       "data-route": route,
+      // settings:read is the visibility floor server-side, so the item hides
+      // under a session that lacks it — the same data-perm contract every
+      // built-in nav item uses. Without this the link stays lit for a scoped
+      // operator and the panel's first request answers 403. syncExtSettingsNav
+      // runs immediately before gatePermissions(), so these nodes are in the
+      // DOM when the sweep reads [data-perm].
+      "data-perm": "settings:read",
       href: "/" + route,
       onclick: (e) => { e.preventDefault(); pendingRecover = null; navigate(route); },
     }, icon("ext", "ni-icon"), el("span", { text: p.label })));

--- a/internal/console/authz.go
+++ b/internal/console/authz.go
@@ -41,8 +41,9 @@ type routePerm struct {
 // a route with a literal segment where another has a placeholder must be listed
 // FIRST (e.g. POST /api/servers/test before a hypothetical POST /api/servers/{}).
 // TestRouteTableCompleteness pins that every registered /api route appears here;
-// TestRoutePermFirstMatchWins pins the ordering invariant. The /api/ext/ subtree
-// is NOT here — it is matched by prefix in permForRoute (its depth is unbounded).
+// TestRoutePermFirstMatchWins pins the ordering invariant. The /api/ext/ and
+// /api/ext-settings/ subtrees are NOT here — they are matched by prefix in
+// permForRoute (their depth is unbounded).
 //
 // Permission tiers (an EE build's roles map onto these): status:read and
 // servers:read are the read-only floor; query/reconstruct read data; recover and
@@ -116,12 +117,49 @@ var apiRoutePerms = []routePerm{
 // row. rbacViewGuard additionally refuses it under an active data profile.
 const extAPIPrefix = "/api/ext/"
 
+// extSettingsAPIPrefix is the mount prefix for an installed settings panel's
+// data routes (see ext.ConsoleSettingsProvider). Like the view subtree its depth
+// is unbounded, so it is prefix-matched rather than given apiRoutePerms rows —
+// but unlike the view subtree it is NOT wrapped in rbacViewGuard: a panel is
+// handed no database, so the "a third-party handler may not honor redaction"
+// reasoning that withholds the view surface under a data profile does not reach
+// it, and blanket-refusing it would lock out the profile-carrying administrator
+// the panel exists for. Permission is the gate here, per method (see
+// extSettingsPerm).
+const extSettingsAPIPrefix = "/api/ext-settings/"
+
+// extSettingsPerm classifies a settings-panel data route by HTTP METHOD: GET and
+// HEAD need settings:read, every other method needs settings:write. The core
+// classifies rather than asking the provider because a provider cannot be
+// trusted to declare its own routes read-only, and the method is the one thing
+// the core can see without running the handler. Anything not explicitly a read
+// falls to the write permission — the same fail-closed posture as an
+// unclassified route, so a method nobody thought about (PATCH, a WebDAV verb)
+// is never the cheap way to mutate with a read-only grant.
+//
+// What this CANNOT catch: a provider that mutates state on GET. That is a bug in
+// the provider, invisible to the core, and the seam's doc comment says so.
+func extSettingsPerm(method string) ext.Permission {
+	if method == http.MethodGet || method == http.MethodHead {
+		return ext.PermSettingsRead
+	}
+	return ext.PermSettingsWrite
+}
+
 // permForRoute returns the permission a (method, path) requires and whether the
 // route is classified at all. An unclassified route (classified=false) is a
 // programming error — every registered /api route must appear in apiRoutePerms
-// or under the ext prefix — and authzMiddleware fails it CLOSED for a policy
-// session rather than granting it.
+// or under one of the ext prefixes — and authzMiddleware fails it CLOSED for a
+// policy session rather than granting it.
 func permForRoute(method, path string) (perm ext.Permission, classified bool) {
+	// Checked before extAPIPrefix would be: "/api/ext-settings/" does not share
+	// that prefix today ("/api/ext/" ends in a slash), but the two live one
+	// character apart, so ordering them explicitly keeps a future edit to either
+	// constant from silently routing every settings write through the view
+	// permission.
+	if strings.HasPrefix(path, extSettingsAPIPrefix) {
+		return extSettingsPerm(method), true
+	}
 	if strings.HasPrefix(path, extAPIPrefix) {
 		return ext.PermExtViewRead, true
 	}

--- a/internal/console/extsettings.go
+++ b/internal/console/extsettings.go
@@ -1,0 +1,79 @@
+package console
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/dbtrail/dbtrail/ext"
+)
+
+// consoleSettingsContext resolves what an installed ext.ConsoleSettingsProvider
+// learns about the calling session: its verified identity and its effective
+// permission set. Deliberately NOT the per-server ConsoleQueryContext an
+// extension VIEW gets — a settings panel administers process-scoped
+// configuration, so handing it the selected server's index would imply a
+// per-server semantics that does not exist.
+//
+// It cannot fail: the settings data routes mount behind tokenMiddleware, so the
+// request is already authenticated and both values are read off its context.
+func (s *Server) consoleSettingsContext(r *http.Request) ext.ConsoleSettingsContext {
+	pol := policyFrom(r.Context())
+	if pol == nil {
+		// No policy = full access (the static token, the password login, every OSS
+		// session). FullAccess is reported as its own flag rather than only as a
+		// materialized list, so a permission the core defines in a LATER release is
+		// still granted to such a session instead of silently starting to deny it.
+		return ext.ConsoleSettingsContext{
+			Identity:    identityFrom(r.Context()),
+			Permissions: ext.AllPermissions(),
+			FullAccess:  true,
+		}
+	}
+	// COPY the policy's slice: it is owned by the session store and shared across
+	// every request that session makes, so handing the provider the live slice
+	// would let an append inside a third-party handler rewrite another request's
+	// grants.
+	perms := make([]ext.Permission, len(pol.Permissions))
+	copy(perms, pol.Permissions)
+	return ext.ConsoleSettingsContext{
+		Identity:    identityFrom(r.Context()),
+		Permissions: perms,
+	}
+}
+
+// mountableExtensions filters a provider registry down to the entries the
+// console will actually mount: a valid route ID, and the FIRST provider claiming
+// a given ID. Both skips are load-bearing — an ID that is not ^[a-z0-9-]+$ flows
+// into a URL path and a DOM route (broken or injectable mount), and a duplicate
+// ID would hit http.ServeMux.Handle with a pattern already registered, which
+// PANICS and takes the daemon down at construction.
+//
+// The mount path calls it with logSkips true; the capabilities path calls it
+// with false (the same request is served over and over, and an operator does not
+// need the same warning on every poll). Sharing one function is what keeps the
+// advertised set and the mounted set from drifting into "advertised but 404s".
+func mountableExtensions[T interface{ ID() string }](providers []T, kind string, logSkips bool) []T {
+	if len(providers) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(providers))
+	out := make([]T, 0, len(providers))
+	for _, p := range providers {
+		id := p.ID()
+		if !ext.ValidConsoleViewID(id) {
+			if logSkips {
+				slog.Error("console: ignoring extension "+kind+" with an invalid id (must match ^[a-z0-9-]+$)", "id", id)
+			}
+			continue
+		}
+		if seen[id] {
+			if logSkips {
+				slog.Error("console: ignoring extension "+kind+" with a duplicate id (the first one installed is mounted)", "id", id)
+			}
+			continue
+		}
+		seen[id] = true
+		out = append(out, p)
+	}
+	return out
+}

--- a/internal/console/extsettings_test.go
+++ b/internal/console/extsettings_test.go
@@ -1,0 +1,450 @@
+package console
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/ext"
+)
+
+// These tests mutate the process-global ext extension registries, so none may
+// run in parallel; every install is undone with ext.ResetForTest. buildHandler
+// reads the registries at construction time (route mount), so providers are
+// always installed BEFORE the server is built.
+
+// stubSettingsProvider is a minimal ext.ConsoleSettingsProvider. dataHit records
+// whether its DATA handler actually ran, so a test can prove a denial happened
+// BEFORE the provider's handler (not merely that the response carried a 403),
+// and seen captures the session context the console handed it.
+type stubSettingsProvider struct {
+	id      string
+	dataHit *bool
+	seen    *ext.ConsoleSettingsContext
+}
+
+func (p *stubSettingsProvider) ID() string     { return p.id }
+func (p *stubSettingsProvider) Label() string  { return "Example Panel" }
+func (p *stubSettingsProvider) Script() string { return "/ext-settings/" + p.id + "/panel.js" }
+
+func (p *stubSettingsProvider) StaticHandler(string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		_, _ = io.WriteString(w, "export function render(){}")
+	})
+}
+
+func (p *stubSettingsProvider) DataHandler(_ string, session ext.ConsoleSettingsContextFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if p.dataHit != nil {
+			*p.dataHit = true
+		}
+		sc := session(r)
+		if p.seen != nil {
+			*p.seen = sc
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	})
+}
+
+// newSettingsServer installs providers and builds a real server with a static
+// token and a session store (so a test can mint a scoped session).
+func newSettingsServer(t *testing.T, settings []ext.ConsoleSettingsProvider, views []ext.ConsoleViewProvider) *Server {
+	t.Helper()
+	t.Cleanup(ext.ResetForTest)
+	for _, p := range settings {
+		ext.RegisterConsoleSettings(p)
+	}
+	for _, p := range views {
+		ext.RegisterConsoleView(p)
+	}
+	srv, err := New(Config{Listen: "127.0.0.1:8090", Token: "static-tok", AuthPath: filepath.Join(t.TempDir(), "auth.yaml")})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return srv
+}
+
+func reqPath(t *testing.T, srv *Server, method, path, bearer string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, "http://127.0.0.1:8090"+path, nil)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+// scopedSession mints a session carrying exactly perms (and profile, which may
+// be "" for none).
+func scopedSession(t *testing.T, srv *Server, profile string, perms ...ext.Permission) string {
+	t.Helper()
+	tok, _, err := srv.sessions.IssueWithPolicy("ops@example.com",
+		&ext.AccessPolicy{Permissions: perms, Profile: profile})
+	if err != nil {
+		t.Fatalf("IssueWithPolicy: %v", err)
+	}
+	return tok
+}
+
+func capsFor(t *testing.T, srv *Server, bearer string) map[string]any {
+	t.Helper()
+	rec := reqPath(t, srv, "GET", "/api/capabilities", bearer)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/capabilities = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var caps map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &caps); err != nil {
+		t.Fatalf("unmarshal capabilities: %v", err)
+	}
+	return caps
+}
+
+func settingsIDs(t *testing.T, caps map[string]any) []string {
+	t.Helper()
+	raw, ok := caps["extension_settings"]
+	if !ok {
+		return nil
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("extension_settings = %v, want a list", raw)
+	}
+	ids := make([]string, 0, len(list))
+	for _, e := range list {
+		m, _ := e.(map[string]any)
+		id, _ := m["id"].(string)
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// The OSS build installs nothing: neither subtree exists, so a probe 404s rather
+// than reaching a surface the stock binary never ships.
+func TestSettingsPanelRoutesAbsentWithoutProvider(t *testing.T) {
+	srv := newSettingsServer(t, nil, nil)
+	if rec := reqPath(t, srv, "GET", "/api/ext-settings/users/list", "static-tok"); rec.Code != http.StatusNotFound {
+		t.Errorf("data route with no provider = %d, want 404 (route absent)", rec.Code)
+	}
+	if rec := reqPath(t, srv, "GET", "/ext-settings/users/panel.js", ""); rec.Code != http.StatusNotFound {
+		t.Errorf("static asset with no provider = %d, want 404 (route absent)", rec.Code)
+	}
+	if ids := settingsIDs(t, capsFor(t, srv, "static-tok")); len(ids) != 0 {
+		t.Errorf("capabilities advertises %v with no provider installed", ids)
+	}
+}
+
+// Static assets ship unauthenticated (code always ships, only data is gated);
+// data routes require the bearer.
+func TestSettingsPanelStaticUnauthenticatedDataAuthenticated(t *testing.T) {
+	hit := false
+	srv := newSettingsServer(t, []ext.ConsoleSettingsProvider{&stubSettingsProvider{id: "users", dataHit: &hit}}, nil)
+
+	if rec := reqPath(t, srv, "GET", "/ext-settings/users/panel.js", ""); rec.Code != http.StatusOK {
+		t.Errorf("static asset without a bearer = %d, want 200", rec.Code)
+	}
+	if rec := reqPath(t, srv, "GET", "/api/ext-settings/users/list", ""); rec.Code != http.StatusUnauthorized {
+		t.Errorf("data route without a bearer = %d, want 401", rec.Code)
+	}
+	if hit {
+		t.Fatal("provider data handler ran on an UNAUTHENTICATED request — tokenMiddleware did not gate it")
+	}
+	if rec := reqPath(t, srv, "GET", "/api/ext-settings/users/list", "static-tok"); rec.Code != http.StatusOK {
+		t.Errorf("data route with a bearer = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if !hit {
+		t.Error("provider data handler did not run on an authenticated request")
+	}
+	// The host guard (DNS-rebinding defense) still covers both new subtrees.
+	for _, path := range []string{"/ext-settings/users/panel.js", "/api/ext-settings/users/list"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "http://attacker.example"+path, nil)
+		req.Header.Set("Authorization", "Bearer static-tok")
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("%s with a domain Host = %d, want 403", path, rec.Code)
+		}
+	}
+}
+
+// Permission gating, read side: a session holding settings:read reaches the
+// panel; one holding an unrelated permission is refused BEFORE the handler runs.
+func TestSettingsPanelGatedBySettingsRead(t *testing.T) {
+	hit := false
+	srv := newSettingsServer(t, []ext.ConsoleSettingsProvider{&stubSettingsProvider{id: "users", dataHit: &hit}}, nil)
+
+	reader := scopedSession(t, srv, "", ext.PermSettingsRead)
+	if rec := reqPath(t, srv, "GET", "/api/ext-settings/users/list", reader); rec.Code != http.StatusOK {
+		t.Errorf("GET with settings:read = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if !hit {
+		t.Error("provider handler did not run for a session holding settings:read")
+	}
+
+	hit = false
+	stranger := scopedSession(t, srv, "", ext.PermStatusRead)
+	rec := reqPath(t, srv, "GET", "/api/ext-settings/users/list", stranger)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("GET without settings:read = %d, want 403", rec.Code)
+	}
+	if hit {
+		t.Error("provider handler ran for a session lacking settings:read — authz must refuse BEFORE it")
+	}
+	if ids := settingsIDs(t, capsFor(t, srv, stranger)); len(ids) != 0 {
+		t.Errorf("capabilities advertises %v to a session lacking settings:read (the nav item would 403)", ids)
+	}
+}
+
+// Permission gating, write side: a read-only administrator must not be able to
+// MUTATE through a panel. Method-classified, so a POST needs settings:write even
+// though the same session may GET the panel.
+func TestSettingsPanelMutationRequiresSettingsWrite(t *testing.T) {
+	hit := false
+	srv := newSettingsServer(t, []ext.ConsoleSettingsProvider{&stubSettingsProvider{id: "users", dataHit: &hit}}, nil)
+	reader := scopedSession(t, srv, "", ext.PermSettingsRead)
+
+	for _, method := range []string{"POST", "PUT", "DELETE", "PATCH"} {
+		hit = false
+		rec := reqPath(t, srv, method, "/api/ext-settings/users/roles", reader)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("%s with only settings:read = %d, want 403", method, rec.Code)
+		}
+		if hit {
+			t.Errorf("%s reached the provider handler with only settings:read", method)
+		}
+	}
+
+	writer := scopedSession(t, srv, "", ext.PermSettingsRead, ext.PermSettingsWrite)
+	hit = false
+	if rec := reqPath(t, srv, "POST", "/api/ext-settings/users/roles", writer); rec.Code != http.StatusOK {
+		t.Errorf("POST with settings:write = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	if !hit {
+		t.Error("provider handler did not run for a session holding settings:write")
+	}
+}
+
+// The point of the issue: a settings panel is gated by PERMISSION, not by the
+// data-profile guard that withholds an extension VIEW. An administrator whose
+// session carries a data profile must still be able to administer.
+func TestSettingsPanelReachableUnderAnActiveDataProfile(t *testing.T) {
+	hit := false
+	srv := newSettingsServer(t, []ext.ConsoleSettingsProvider{&stubSettingsProvider{id: "users", dataHit: &hit}}, nil)
+	profiled := scopedSession(t, srv, "sensitive", ext.PermSettingsRead, ext.PermSettingsWrite)
+
+	if rec := reqPath(t, srv, "GET", "/api/ext-settings/users/list", profiled); rec.Code != http.StatusOK {
+		t.Errorf("GET under a data profile = %d body=%s, want 200 — a panel serves no row data, so the profile must not withhold it", rec.Code, rec.Body.String())
+	}
+	if !hit {
+		t.Fatal("provider handler did not run for a profile-carrying session")
+	}
+	if ids := settingsIDs(t, capsFor(t, srv, profiled)); !slices.Contains(ids, "users") {
+		t.Errorf("capabilities omits the panel for a profile-carrying session (ids=%v); the nav item must stay visible", ids)
+	}
+}
+
+// The provider must learn WHO is calling and WHAT they hold, so it can enforce
+// its own invariants (refusing a self-demotion is the case this exists for).
+func TestSettingsPanelReceivesIdentityAndPermissions(t *testing.T) {
+	var seen ext.ConsoleSettingsContext
+	srv := newSettingsServer(t, []ext.ConsoleSettingsProvider{&stubSettingsProvider{id: "users", seen: &seen}}, nil)
+
+	reader := scopedSession(t, srv, "", ext.PermSettingsRead)
+	if rec := reqPath(t, srv, "GET", "/api/ext-settings/users/list", reader); rec.Code != http.StatusOK {
+		t.Fatalf("GET = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if seen.Identity != "ops@example.com" {
+		t.Errorf("Identity = %q, want the session's verified login identity", seen.Identity)
+	}
+	if seen.FullAccess {
+		t.Error("FullAccess = true for a policy-carrying session")
+	}
+	if !seen.Allows(ext.PermSettingsRead) || seen.Allows(ext.PermSettingsWrite) {
+		t.Errorf("Permissions = %v, want exactly the session's grants", seen.Permissions)
+	}
+
+	// The static token is policy-less: full access, no identity. A panel keying
+	// an invariant on identity must see "" rather than a wrong name.
+	seen = ext.ConsoleSettingsContext{}
+	if rec := reqPath(t, srv, "GET", "/api/ext-settings/users/list", "static-tok"); rec.Code != http.StatusOK {
+		t.Fatalf("GET with the static token = %d", rec.Code)
+	}
+	if !seen.FullAccess || seen.Identity != "" {
+		t.Errorf("static-token context = %+v, want FullAccess with an empty identity", seen)
+	}
+	if !seen.Allows(ext.PermSettingsWrite) {
+		t.Error("a full-access session was denied settings:write")
+	}
+}
+
+// A provider must not be able to rewrite another request's grants through the
+// slice it was handed.
+func TestSettingsContextPermissionsAreACopy(t *testing.T) {
+	srv := newSettingsServer(t, nil, nil)
+	pol := &ext.AccessPolicy{Permissions: []ext.Permission{ext.PermSettingsRead}}
+	r := httptest.NewRequest("GET", "http://127.0.0.1:8090/api/ext-settings/users/list", nil)
+	// Attach the policy the way tokenMiddleware does before the provider handler
+	// runs; the policy object is the one the session store keeps.
+	r = r.WithContext(context.WithValue(r.Context(), policyCtxKey{}, pol))
+
+	sc := srv.consoleSettingsContext(r)
+	sc.Permissions[0] = ext.PermServersDelete
+	if pol.Permissions[0] != ext.PermSettingsRead {
+		t.Error("mutating the context's Permissions rewrote the session's own policy — the slice must be copied")
+	}
+}
+
+// Two panels coexist — the registry is additive, so both mount and both are
+// advertised. This is what the single-slot seam could not do.
+func TestSettingsPanelsCoexist(t *testing.T) {
+	srv := newSettingsServer(t, []ext.ConsoleSettingsProvider{
+		&stubSettingsProvider{id: "users"},
+		&stubSettingsProvider{id: "keys"},
+	}, nil)
+
+	for _, id := range []string{"users", "keys"} {
+		if rec := reqPath(t, srv, "GET", "/api/ext-settings/"+id+"/list", "static-tok"); rec.Code != http.StatusOK {
+			t.Errorf("data route for %q = %d, want 200 (both panels must mount)", id, rec.Code)
+		}
+	}
+	ids := settingsIDs(t, capsFor(t, srv, "static-tok"))
+	if !slices.Contains(ids, "users") || !slices.Contains(ids, "keys") {
+		t.Errorf("capabilities advertises %v, want both panels", ids)
+	}
+}
+
+// Same for views, whose seam grew the registry: two providers coexist instead of
+// the second silently replacing the first.
+func TestExtensionViewsCoexist(t *testing.T) {
+	srv := newSettingsServer(t, nil, []ext.ConsoleViewProvider{
+		&stubViewProvider{id: "forensics"},
+		&stubViewProvider{id: "audit"},
+	})
+
+	rec := reqPath(t, srv, "GET", "/api/capabilities", "static-tok")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/capabilities = %d", rec.Code)
+	}
+	var caps struct {
+		Views []struct {
+			ID string `json:"id"`
+		} `json:"extension_views"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &caps); err != nil {
+		t.Fatal(err)
+	}
+	if len(caps.Views) != 2 || caps.Views[0].ID != "forensics" || caps.Views[1].ID != "audit" {
+		t.Errorf("extension_views = %v, want both providers in install order", caps.Views)
+	}
+	for _, id := range []string{"forensics", "audit"} {
+		if rec := reqPath(t, srv, "GET", "/ext/"+id+"/view.js", ""); rec.Code != http.StatusOK {
+			t.Errorf("static route for view %q = %d, want 200 (both views must mount)", id, rec.Code)
+		}
+	}
+}
+
+// An ID that is not ^[a-z0-9-]+$ flows into a URL path and a DOM route, so it is
+// skipped: not mounted, not advertised — two different code paths, both asserted.
+func TestSettingsPanelInvalidIDSkipped(t *testing.T) {
+	srv := newSettingsServer(t, []ext.ConsoleSettingsProvider{
+		&stubSettingsProvider{id: "Users"}, // uppercase
+		&stubSettingsProvider{id: "keys"},
+	}, nil)
+
+	if rec := reqPath(t, srv, "GET", "/api/ext-settings/Users/list", "static-tok"); rec.Code != http.StatusNotFound {
+		t.Errorf("data route for an invalid-id panel = %d, want 404 (not mounted)", rec.Code)
+	}
+	if rec := reqPath(t, srv, "GET", "/ext-settings/Users/panel.js", ""); rec.Code != http.StatusNotFound {
+		t.Errorf("static route for an invalid-id panel = %d, want 404 (not mounted)", rec.Code)
+	}
+	ids := settingsIDs(t, capsFor(t, srv, "static-tok"))
+	if slices.Contains(ids, "Users") {
+		t.Errorf("capabilities advertises an invalid-id panel: %v", ids)
+	}
+	if !slices.Contains(ids, "keys") {
+		t.Errorf("a valid sibling was dropped along with the invalid panel: %v", ids)
+	}
+}
+
+// A duplicate ID must be skipped, not mounted twice: http.ServeMux.Handle PANICS
+// on a repeated pattern, which would take the daemon down at construction.
+func TestSettingsPanelDuplicateIDSkipped(t *testing.T) {
+	first, second := false, false
+	srv := newSettingsServer(t, []ext.ConsoleSettingsProvider{
+		&stubSettingsProvider{id: "users", dataHit: &first},
+		&stubSettingsProvider{id: "users", dataHit: &second},
+	}, nil)
+
+	if rec := reqPath(t, srv, "GET", "/api/ext-settings/users/list", "static-tok"); rec.Code != http.StatusOK {
+		t.Fatalf("data route = %d, want 200", rec.Code)
+	}
+	if !first || second {
+		t.Errorf("mounted handler: first=%v second=%v — the FIRST provider installed must win", first, second)
+	}
+	if ids := settingsIDs(t, capsFor(t, srv, "static-tok")); len(ids) != 1 {
+		t.Errorf("capabilities advertises %v, want the duplicate collapsed to one entry", ids)
+	}
+}
+
+func TestExtensionViewDuplicateIDSkipped(t *testing.T) {
+	srv := newSettingsServer(t, nil, []ext.ConsoleViewProvider{
+		&stubViewProvider{id: "forensics"},
+		&stubViewProvider{id: "forensics"},
+	})
+	rec := reqPath(t, srv, "GET", "/ext/forensics/view.js", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("static route for a duplicated view id = %d, want 200 (first wins, second skipped)", rec.Code)
+	}
+}
+
+// A panel and a view may share an ID: their mounts differ in the FIRST path
+// segment, so neither shadows the other.
+func TestSettingsPanelAndViewMayShareAnID(t *testing.T) {
+	srv := newSettingsServer(t,
+		[]ext.ConsoleSettingsProvider{&stubSettingsProvider{id: "users"}},
+		[]ext.ConsoleViewProvider{&stubViewProvider{id: "users"}})
+
+	if rec := reqPath(t, srv, "GET", "/api/ext-settings/users/list", "static-tok"); rec.Code != http.StatusOK {
+		t.Errorf("panel data route = %d, want 200", rec.Code)
+	}
+	if rec := reqPath(t, srv, "GET", "/ext/users/view.js", ""); rec.Code != http.StatusOK {
+		t.Errorf("view static route = %d, want 200", rec.Code)
+	}
+}
+
+// The settings subtree must be classified by METHOD, and the view subtree must
+// keep its own permission — a shared prefix branch would send every panel write
+// through extview:read.
+func TestPermForRouteExtSettingsPrefix(t *testing.T) {
+	cases := []struct {
+		method, path string
+		want         ext.Permission
+	}{
+		{"GET", "/api/ext-settings/users/list", ext.PermSettingsRead},
+		{"HEAD", "/api/ext-settings/users/list", ext.PermSettingsRead},
+		{"POST", "/api/ext-settings/users/roles", ext.PermSettingsWrite},
+		{"DELETE", "/api/ext-settings/users/roles/7", ext.PermSettingsWrite},
+		{"PATCH", "/api/ext-settings/users", ext.PermSettingsWrite},
+		// An unknown verb falls to the WRITE permission, not the read one: an
+		// unclassified method must never be the cheap way to mutate.
+		{"PROPFIND", "/api/ext-settings/users", ext.PermSettingsWrite},
+		{"GET", "/api/ext/forensics/anything", ext.PermExtViewRead},
+	}
+	for _, c := range cases {
+		got, classified := permForRoute(c.method, c.path)
+		if !classified {
+			t.Errorf("%s %s: not classified", c.method, c.path)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("permForRoute(%s, %s) = %q, want %q", c.method, c.path, got, c.want)
+		}
+	}
+}

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -99,7 +99,16 @@ type capabilitiesResponse struct {
 	// nav item that would 403). The SPA reveals one nav item + route ("ext-<id>")
 	// per entry. Generic by construction — the core names no specific view.
 	ExtensionViews []extensionViewDTO `json:"extension_views,omitempty"`
-	Auth           authCapsInfo       `json:"auth"`
+	// ExtensionSettings lists administration panels contributed by an installed
+	// settings-panel provider. Omitted in the stock binary (no provider) and for a
+	// session whose policy lacks settings:read (its data routes would 403, so
+	// advertising the nav item would be a lie). NOT suppressed under a data
+	// profile, unlike ExtensionViews: a panel reads no row data, so the profile is
+	// not what gates it — the permission is. The SPA reveals one Settings nav item
+	// + route ("extset-<id>") per entry. Generic by construction — the core names
+	// no specific panel.
+	ExtensionSettings []extensionViewDTO `json:"extension_settings,omitempty"`
+	Auth              authCapsInfo       `json:"auth"`
 	// Permissions is this session's effective grant of every permission the core
 	// defines, for the SPA to gate its UI (hide tabs/buttons a scoped session
 	// cannot use). All-true for a policy-less session — the static token, the
@@ -137,10 +146,13 @@ type authCapsInfo struct {
 	AuthKind    string `json:"auth_kind"` // "token" | "session"
 }
 
-// extensionViewDTO is the wire view of one console view contributed by an
-// installed ext.ConsoleViewProvider. id keys the nav item, the SPA route
-// ("ext-"+id), and the "/api/ext/<id>/" data mount; script is the ES module the
-// SPA import()s and calls render(mount, {apiBase, api}) on.
+// extensionViewDTO is the wire view of one console surface contributed by an
+// installed ext provider — a data view (ext.ConsoleViewProvider) or an
+// administration panel (ext.ConsoleSettingsProvider); the two carry the same
+// three fields, and which list a DTO appears in tells the SPA which route and
+// data prefix to build. id keys the nav item, the SPA route ("ext-"+id or
+// "extset-"+id), and the matching data mount; script is the ES module the SPA
+// import()s and calls render(mount, {apiBase, api}) on.
 type extensionViewDTO struct {
 	ID     string `json:"id"`
 	Label  string `json:"label"`
@@ -227,9 +239,21 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	// routes would 403 (authzMiddleware), so advertising the nav item to such
 	// a session would be a lie. Allows is nil-safe (nil policy = full access),
 	// so OSS sessions are unaffected.
-	if p := ext.ConsoleView(); p != nil && !s.profileActiveFor(r) &&
-		policyFrom(r.Context()).Allows(ext.PermExtViewRead) && ext.ValidConsoleViewID(p.ID()) {
-		resp.ExtensionViews = []extensionViewDTO{{ID: p.ID(), Label: p.Label(), Script: p.Script()}}
+	if !s.profileActiveFor(r) && policyFrom(r.Context()).Allows(ext.PermExtViewRead) {
+		for _, p := range mountableExtensions(ext.ConsoleViews(), "view", false) {
+			resp.ExtensionViews = append(resp.ExtensionViews, extensionViewDTO{ID: p.ID(), Label: p.Label(), Script: p.Script()})
+		}
+	}
+	// Extension settings panels (ext seam): advertised on the SAME condition their
+	// data routes are reachable — the session holds settings:read — and NOT
+	// suppressed under a data profile, because a panel administers configuration
+	// rather than serving row data, so the profile gate that hides an extension
+	// view does not apply. A session holding neither settings permission simply
+	// sees no panel instead of a nav item that 403s.
+	if policyFrom(r.Context()).Allows(ext.PermSettingsRead) {
+		for _, p := range mountableExtensions(ext.ConsoleSettings(), "settings panel", false) {
+			resp.ExtensionSettings = append(resp.ExtensionSettings, extensionViewDTO{ID: p.ID(), Label: p.Label(), Script: p.Script()})
+		}
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -104,9 +104,12 @@ type capabilitiesResponse struct {
 	// session whose policy lacks settings:read (its data routes would 403, so
 	// advertising the nav item would be a lie). NOT suppressed under a data
 	// profile, unlike ExtensionViews: a panel reads no row data, so the profile is
-	// not what gates it — the permission is. The SPA reveals one Settings nav item
-	// + route ("extset-<id>") per entry. Generic by construction — the core names
-	// no specific panel.
+	// not what gates it — the permission is. settings:read is the VISIBILITY
+	// floor: a session granted settings:write alone could still POST to a panel
+	// (that route requires the write permission, and it holds it) but would never
+	// be shown the nav item, so a write-without-read role is not a supported
+	// shape. The SPA reveals one Settings nav item + route ("extset-<id>") per
+	// entry. Generic by construction — the core names no specific panel.
 	ExtensionSettings []extensionViewDTO `json:"extension_settings,omitempty"`
 	Auth              authCapsInfo       `json:"auth"`
 	// Permissions is this session's effective grant of every permission the core

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -555,24 +555,37 @@ func (s *Server) buildHandler() http.Handler {
 	if p := ext.ConsoleAuth(); p != nil {
 		root.Handle(extAuthPrefix, p.Handler(extAuthPrefix, s.extSessionIssuer()))
 	}
-	// Extension view (ext seam): an embedding distribution can contribute one
-	// additional console view. Its static assets mount UNAUTHENTICATED on root at
-	// /ext/<id>/ (behind hostGuard + securityHeaders only — code always ships,
-	// only data is gated), and its data routes mount on the inner api mux at
-	// /api/ext/<id>/ so they inherit tokenMiddleware, wrapped in rbacViewGuard so
-	// the whole surface is refused (403) while an RBAC profile is active. The id
-	// flows into both URL paths and a DOM route, so an invalid one is skipped
-	// (logged, not mounted) rather than producing a broken/injectable route.
-	if p := ext.ConsoleView(); p != nil {
-		id := p.ID()
-		if !ext.ValidConsoleViewID(id) {
-			slog.Error("console: ignoring extension view with an invalid id (must match ^[a-z0-9-]+$)", "id", id)
-		} else {
-			staticPrefix := "/ext/" + id + "/"
-			dataPrefix := "/api/ext/" + id + "/"
-			root.Handle(staticPrefix, p.StaticHandler(staticPrefix))
-			api.Handle(dataPrefix, s.rbacViewGuard(p.DataHandler(dataPrefix, s.consoleQueryContext)))
-		}
+	// Extension views (ext seam): an embedding distribution can contribute
+	// additional console views. Each one's static assets mount UNAUTHENTICATED on
+	// root at /ext/<id>/ (behind hostGuard + securityHeaders only — code always
+	// ships, only data is gated), and its data routes mount on the inner api mux
+	// at /api/ext/<id>/ so they inherit tokenMiddleware, wrapped in rbacViewGuard
+	// so the whole surface is refused (403) while an RBAC profile is active. The
+	// id flows into both URL paths and a DOM route, so an invalid or duplicate one
+	// is skipped by mountableExtensions (logged, not mounted) rather than
+	// producing a broken/injectable route or panicking this mux on a repeated
+	// pattern.
+	for _, p := range mountableExtensions(ext.ConsoleViews(), "view", true) {
+		staticPrefix := "/ext/" + p.ID() + "/"
+		dataPrefix := "/api/ext/" + p.ID() + "/"
+		root.Handle(staticPrefix, p.StaticHandler(staticPrefix))
+		api.Handle(dataPrefix, s.rbacViewGuard(p.DataHandler(dataPrefix, s.consoleQueryContext)))
+	}
+	// Extension settings panels (ext seam): the administration sibling of the
+	// views above, mounted at /ext-settings/<id>/ (static, unauthenticated) and
+	// /api/ext-settings/<id>/ (data, behind tokenMiddleware and then
+	// authzMiddleware, which requires settings:read to GET and settings:write to
+	// mutate). NOT wrapped in rbacViewGuard, unlike a view: a panel gets no
+	// database — only the caller's identity and grants — so the redaction concern
+	// that withholds the view surface under a data profile does not apply, and
+	// refusing it there would lock out the very administrator who carries a
+	// profile. The first segment differs from the view mounts, so a panel and a
+	// view may share an id without colliding.
+	for _, p := range mountableExtensions(ext.ConsoleSettings(), "settings panel", true) {
+		staticPrefix := "/ext-settings/" + p.ID() + "/"
+		dataPrefix := "/api/ext-settings/" + p.ID() + "/"
+		root.Handle(staticPrefix, p.StaticHandler(staticPrefix))
+		api.Handle(dataPrefix, p.DataHandler(dataPrefix, s.consoleSettingsContext))
 	}
 	// credential on all other /api/* (tokenMiddleware), then per-session
 	// authorization (authzMiddleware). authz is inert for policy-less sessions —


### PR DESCRIPTION
Closes #1299

The console could host exactly one extension view, and only a **data** view: `SetConsoleView` overwrote a single package variable (a second provider silently replaced the first depending on wiring order), and `/api/ext/<id>/` is refused with 403 whenever an RBAC data profile is active. That refusal is correct for a view handed a raw `*sql.DB` — the console cannot verify a third-party handler honors table-deny and column redaction — and backwards for an administration surface, where it locks out precisely the profile-carrying admin who needs to administer.

## Registry

`RegisterConsoleView` / `ConsoleViews` install additively. `SetConsoleView` / `ConsoleView` keep their exact meaning — the legacy slot an embedding build already uses, reported first and never displaced — so nothing existing breaks.

Mount and capabilities both go through one filter, `mountableExtensions`, which skips:

- an **invalid ID** (it flows into a URL path and a DOM route), and
- a **duplicate ID** — `http.ServeMux.Handle` PANICS on a repeated pattern, which would take the daemon down at construction.

Sharing that filter is what keeps the advertised set from drifting into "advertised but 404s".

## Settings seam

`ext.ConsoleSettingsProvider` is a sibling, not a widening of the view interface. A panel administers process-scoped configuration, so it gets **no** per-server `ConsoleQueryContext`; it receives a `ConsoleSettingsContext` carrying the session's verified identity and a **copy** of its effective permissions, so it can enforce its own invariants server-side (refusing a self-demotion is the case this exists for). The copy is load-bearing: the live slice belongs to the session store and is shared across every request that session makes. `FullAccess` is its own flag because a policy-less session also holds permissions the core defines in LATER releases, which a materialized list cannot express.

Mounts: `/ext-settings/<id>/` (static, unauthenticated — code always ships, only data is gated) and `/api/ext-settings/<id>/` (bearer middleware, then authz). **Not** wrapped in `rbacViewGuard`. The gate is PERMISSION, classified by METHOD: `GET`/`HEAD` need `settings:read`, everything else needs the new `settings:write`. The core classifies rather than asking the provider — a provider cannot be trusted to declare its own routes read-only — and an unrecognized method falls to the write permission, the same fail-closed posture an unclassified route gets. What it cannot catch (a provider that mutates on `GET`) is documented on the seam.

`settings:write` is registered in `allPermissions`; the subtree is prefix-matched in `permForRoute` like `/api/ext/` already is.

## SPA

Strictly additive: an `extension_settings` capability list, a Settings nav item and an `extset-<id>` route per advertised panel, mounted with its own `apiBase` (the two surfaces authorize differently, so reusing the view prefix would send a panel's requests through the wrong gate). No refactor of the existing ext-view JS.

The OSS build installs nothing, so behavior is unchanged.

## Tests, and the mutations run against them

`go build ./...`, `go vet ./...`, `go test ./ext/... ./internal/console/...` green; `gofmt -l` clean.

Every test was mutation-checked — the production code was broken and the covering test confirmed to FAIL:

| mutation | test that failed |
|---|---|
| `RegisterConsoleView` overwrites instead of appends | `TestConsoleViewsRegistryIsAdditiveAndKeepsTheLegacySlot`, `TestExtensionViewsCoexist` |
| `RegisterConsoleSettings` overwrites instead of appends | `TestRegisterConsoleSettingsIsAdditive`, `TestSettingsPanelsCoexist` |
| every settings method classified as `settings:read` | `TestSettingsPanelMutationRequiresSettingsWrite`, `TestPermForRouteExtSettingsPrefix` |
| settings prefix branch removed (routes unclassified) | `TestSettingsPanelGatedBySettingsRead`, `TestSettingsPanelReachableUnderAnActiveDataProfile` |
| ID validation dropped at mount | `TestSettingsPanelInvalidIDSkipped` |
| settings mount wrapped in `rbacViewGuard` | `TestSettingsPanelReachableUnderAnActiveDataProfile` |
| duplicate-ID skip removed | `TestSettingsPanelDuplicateIDSkipped`, `TestExtensionViewDuplicateIDSkipped` (panic, not a status) |
| a provider registered from `init()` (OSS installs something) | `TestConsoleSettingsEmptyByDefault`, `TestSettingsPanelRoutesAbsentWithoutProvider` |
| permissions slice handed out live instead of copied | `TestSettingsContextPermissionsAreACopy` |
| capabilities advertise without the `settings:read` check | `TestSettingsPanelGatedBySettingsRead` |
| identity never passed to the provider | `TestSettingsPanelReceivesIdentityAndPermissions` |

Every denial test also asserts the provider's handler **did not run** (the `dataHit` pattern from `extview_test.go`), so what is pinned is gate ordering, not just the status code.

## One clarification of the issue

The issue describes the 403 as coming from "the extension-view guard", but `/api/ext/` has **two** independent gates: `rbacViewGuard` (data profile) and `permForRoute` → `extview:read` (permission). The settings surface bypasses the first and uses `settings:read`/`settings:write` in the second. Authorization denials on the new subtree already emit `console`/`authz.denied` through `authzMiddleware`, so no audit-seam changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
