### PR TITLE
feat(console): paginate the Events view with a keyset cursor

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -104,10 +104,17 @@ and searching events:
 2. **Events** — a smart search box (free text plus `type:`, `pk:`, `col:`, and
    `schema.table` tokens) with an expandable **Filters** panel. Each row expands
    in place to a before→after diff; `j`/`k` move the cursor, `↵` expands, `u`
-   jumps to Recover. Results carry **JSON / CSV** export — client-side over the
-   rows already on screen, so it stays within the result caps. Rows and exports
-   include `connection_id` (the transaction's originating thread number) but
-   never `query_text`/`query_hash`.
+   jumps to Recover. Results are **paged**: `‹ Newer` / `Older ›` walk the
+   stream a page at a time, and the header states where you are
+   (`showing 1–100 of more`, or `showing 201–247 of 247 (end)` once you reach
+   the bottom) rather than restating the page size. Paging is keyset-based —
+   the cost of page 40 is the cost of page 1 — and each page is still bound by
+   the same result cap; editing any filter returns you to page 1.
+   **Export JSON / Export CSV** export *every match of the current search*, up
+   to the endpoint's 1000-event cap, not just the page on screen; if the search
+   has more than that, the console says so instead of handing you a silent
+   prefix. Rows and exports include `connection_id` (the transaction's
+   originating thread number) but never `query_text`/`query_hash`.
 3. **Time-travel** — single-row point-in-time reconstruct, drawn as a timeline
    (baseline snapshot → each change, with a **Restore to this state** jump to
    Recover). Appears **only when a baseline is configured**

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -104,10 +104,30 @@ type recoverRequest struct {
 }
 
 type eventsResponse struct {
-	Events   []eventDTO `json:"events"`
-	Count    int        `json:"count"`
-	Limit    int        `json:"limit"`
-	Warnings []string   `json:"warnings,omitempty"`
+	Events []eventDTO `json:"events"`
+	// Count and Limit describe the PAGE, never the probe (#1297): handleEvents
+	// asks the engine for Limit+1 rows to learn HasMore and trims the extra
+	// before it gets here. Reporting the probe would leak a 101 back to a
+	// client that asked for 100 and would let a limit=1000 request answer 1001.
+	Count int `json:"count"`
+	Limit int `json:"limit"`
+	// HasMore reports that at least one further event matched beyond this page.
+	// It is the answer to the question the old header could not ask: "100
+	// event(s) in the newest 100" says nothing about whether 101 or ten million
+	// sit behind it. This costs exactly one extra row per fetch, so it is never
+	// a count — a real total would mean a COUNT(*) over the same window, which
+	// on a partitioned multi-source index is not cheap and is not offered here.
+	HasMore bool `json:"has_more"`
+	// NextBefore is the opaque keyset cursor for the NEXT (older) page of a
+	// newest-first listing: pass it back as ?before=. Empty when HasMore is
+	// false, or when the listing is ascending. The client never builds a
+	// cursor itself — it echoes this — which is what guarantees the next page
+	// resumes on a row the server actually served.
+	NextBefore string `json:"next_before,omitempty"`
+	// NextAfter is NextBefore's ascending counterpart (?after=), for a client
+	// that asked for order=ASC.
+	NextAfter string   `json:"next_after,omitempty"`
+	Warnings  []string `json:"warnings,omitempty"`
 }
 
 type recoverResponse struct {
@@ -255,22 +275,56 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	if err := applyEventCursors(&opts, q.Get("after"), q.Get("before")); err != nil {
+		// A 400, never a silent fall back to page 1: the UI's Next button would
+		// then re-serve the same page forever and the operator would page a
+		// loop believing they were walking backwards through the index.
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	opts, err = s.applySessionProfile(r.Context(), r, b, opts)
 	if err != nil {
 		writeSessionProfileError(w, r, err)
 		return
 	}
+	// Probe one row past the page to learn whether anything is behind it. The
+	// extra row is never serialized (trimmed below) — it exists only so the
+	// header can say "more available" or "end of results" instead of the
+	// circular "100 events in the newest 100". The cap semantics are unchanged:
+	// pageLimit is what buildOptions clamped to eventsMaxLimit, and one probe
+	// row is not a paging escape hatch for pulling the index into a browser.
+	pageLimit := opts.Limit
+	opts.Limit = pageLimit + 1
 	rows, plan, err := s.fetchRestricted(r.Context(), r, b, opts)
 	if err != nil {
 		writeFetchError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, eventsResponse{
+	hasMore := len(rows) > pageLimit
+	if hasMore {
+		rows = rows[:pageLimit]
+	}
+	resp := eventsResponse{
 		Events:   toEventDTOs(rows),
 		Count:    len(rows),
-		Limit:    opts.Limit,
+		Limit:    pageLimit,
+		HasMore:  hasMore,
 		Warnings: gapWarnings(plan),
-	})
+	}
+	// The cursor comes from the last row of the page the client is about to
+	// see, in the direction it is reading. Built server-side from a served row
+	// so the next page can neither skip nor repeat at a shared second.
+	if hasMore && len(rows) > 0 {
+		cur := formatEventCursor(rows[len(rows)-1])
+		if query.OrderDirection(opts.Order) == "DESC" {
+			resp.NextBefore = cur
+		} else {
+			resp.NextAfter = cur
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
+	// Emitted per page: every page is its own read of historical row data, so
+	// page 2 is as auditable as page 1 (ext.AuditSink contract).
 	recordConsoleAccess(r, "query.run", opts.Schema, opts.Table, map[string]string{
 		"results": strconv.Itoa(len(rows)),
 		"format":  "json",

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1481,7 +1481,11 @@ async function exportEvents(kind, btn) {
     const rows = refineEvents(data.events || [], evLastQuery.refine);
     if (kind === "csv") downloadEventsCSV(rows); else downloadEventsJSON(rows);
     if (data.has_more) {
-      toast("Exported the newest " + data.count + " matches — the search has more. Narrow it with a time range to export the rest.");
+      // rows.length, not data.count: the client-side refine runs after the
+      // fetch, so naming the server's count would report a number that is not
+      // the row count of the file just downloaded — the same species of
+      // misleading figure this whole change set out to remove.
+      toast("Exported the newest " + rows.length + " matches — the search has more. Narrow it with a time range to export the rest.");
     }
   } catch (err) {
     toast("Export failed: " + (err && err.message ? err.message : String(err)));

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -36,6 +36,10 @@ const EVENT_CSV_COLUMNS = [
 ];
 
 // event_type → badge modifier class.
+// Ceiling for an Events export (#1297). Must track eventsMaxLimit in
+// internal/console/api.go — the server clamps to it regardless, so a larger
+// number here would only make the UI promise more than it delivers.
+const EVENT_EXPORT_MAX = 1000;
 const BADGE_CLASS = { UPDATE: "b-update", INSERT: "b-insert", DELETE: "b-delete" };
 function badgeClass(t) { return BADGE_CLASS[t] || "b-baseline"; }
 
@@ -70,6 +74,16 @@ let extViews = [];            // extension views advertised for the selected ser
 let extSettings = [];         // extension settings panels advertised for this SESSION (permission-gated, not per-server)
 let lastSQL = "";             // last generated undo SQL (for copy/download)
 let lastEvents = [];          // last rendered (filtered, capped) event page
+// Events keyset paging (#1297). evPages[k] is the `before` cursor that opens
+// page k (page 0 opens with none) plus how many events precede it, so the
+// header can say "showing 201–300" without an OFFSET. Cursors are echoed back
+// from the server, never built here.
+let evPages = [{ before: null, offset: 0 }];
+let evPageIdx = 0;
+// The last Events request (API params + client-side refine terms), captured so
+// Export can re-run the SAME search across every page instead of dumping only
+// the page on screen. See exportEvents.
+let evLastQuery = null;
 let pendingRecover = null;    // event context carried into Recover via "Undo"
 let schemaCache = null;       // cached schema list for the selected server
 const tablesCache = new Map();// schema → tables[]
@@ -1041,10 +1055,21 @@ function renderEvents(params) {
   bar.append(el("span", { class: "kbd-hint" },
     el("b", { text: "j" }), "/", el("b", { text: "k" }), " move · ",
     el("b", { text: "↵" }), " expand · ", el("b", { text: "u" }), " undo"));
-  bar.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "JSON",
-    onclick: () => downloadEventsJSON(lastEvents) }));
-  bar.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "CSV",
-    onclick: () => downloadEventsCSV(lastEvents) }));
+  // Paging controls (#1297). Disabled rather than hidden so the affordance is
+  // discoverable on page 1 — the bug this fixes was an operator having no way
+  // to know event 101 was reachable at all.
+  bar.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", id: "ev-prev", text: "‹ Newer",
+    disabled: "", onclick: () => eventsGoPage(-1) }));
+  bar.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", id: "ev-next", text: "Older ›",
+    disabled: "", onclick: () => eventsGoPage(1) }));
+  // Labels name their SCOPE: these export every match of the current search
+  // (up to the server's cap), not the page on screen. See exportEvents.
+  bar.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Export JSON",
+    title: "Export all matches of this search, not just this page (max 1000 events)",
+    onclick: (e) => exportEvents("json", e.target) }));
+  bar.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Export CSV",
+    title: "Export all matches of this search, not just this page (max 1000 events)",
+    onclick: (e) => exportEvents("csv", e.target) }));
   v.append(bar);
 
   // events list
@@ -1312,7 +1337,13 @@ function parseSmartQuery(q) {
   return c;
 }
 
-async function runEventsQuery(form) {
+// keepPage is set ONLY by the Prev/Next buttons. Every other caller — the
+// debounced `input` handler, `change`, `submit` — is a filter edit, and a
+// filter edit must drop the cursor: a cursor from the previous search names a
+// row that need not exist in the new one, so keeping it would serve a page
+// from the middle of a search the operator never ran.
+async function runEventsQuery(form, keepPage) {
+  if (!keepPage) { evPages = [{ before: null, offset: 0 }]; evPageIdx = 0; }
   const gen = serverGen;
   const rowsEl = $("#ev-rows", VIEW());
   const countEl = $("#ev-count", VIEW());
@@ -1338,9 +1369,21 @@ async function runEventsQuery(form) {
     if (merged.changed_column) apiParams.changed_column = merged.changed_column;
   }
 
+  // Client-side refine terms are computed before the fetch so export can reuse
+  // the exact same pair (server filters + refine) the page was built from.
+  const refine = [];
+  if (!hasScope && merged.pk) refine.push(merged.pk.toLowerCase());
+  if (!hasScope && merged.changed_column) refine.push(merged.changed_column.toLowerCase());
+  refine.push(...parsed.terms);
+  evLastQuery = { apiParams, refine };
+
+  const pageParams = Object.assign({ order: "DESC" }, apiParams);
+  const before = evPages[evPageIdx] && evPages[evPageIdx].before;
+  if (before) pageParams.before = before;
+
   let data;
   try {
-    data = await api("/api/events?" + new URLSearchParams(apiParams).toString());
+    data = await api("/api/events?" + new URLSearchParams(pageParams).toString());
   } catch (err) {
     if (gen !== serverGen) return;
     clear(rowsEl); renderError(rowsEl, err);
@@ -1350,35 +1393,101 @@ async function runEventsQuery(form) {
   if (gen !== serverGen) return;
 
   // Client-side refine: unscoped pk/col + free terms.
-  let events = data.events || [];
-  const refine = [];
-  if (!hasScope && merged.pk) refine.push(merged.pk.toLowerCase());
-  if (!hasScope && merged.changed_column) refine.push(merged.changed_column.toLowerCase());
-  refine.push(...parsed.terms);
-  if (refine.length) {
-    events = events.filter((e) => {
-      const hay = (e.schema_name + "." + e.table_name + " " + e.event_type + " " + e.pk_values + " " +
-        (e.changed_columns || []).join(" ") + " " +
-        valueToString(e.row_before) + " " + valueToString(e.row_after)).toLowerCase();
-      return refine.every((t) => hay.includes(t));
-    });
+  const events = refineEvents(data.events || [], refine);
+
+  // Remember where the NEXT page starts before rendering this one. The cursor
+  // comes from the server (data.next_before), which derives it from the last
+  // row it actually served — not from `events`, which the refine above may
+  // have dropped the boundary row from. Deriving it here would skip whatever
+  // the refine hid.
+  if (data.has_more && data.next_before) {
+    evPages[evPageIdx + 1] = { before: data.next_before, offset: evPages[evPageIdx].offset + data.count };
+  } else {
+    evPages.length = evPageIdx + 1;
   }
 
   lastEvents = events;
-  // Honest scope (#966): free terms / unscoped pk are refined client-side over
-  // ONE fetched page. When that page is full (count === limit) older matches
-  // can exist beyond it, so qualify the count instead of presenting it as
-  // index-wide truth. A refine over a non-full page saw every matching event,
-  // so its count needs no qualifier.
+  // Honest scope (#966 + #1297): free terms / unscoped pk are refined
+  // client-side over ONE fetched page, so a refined count is page-local. The
+  // window note no longer restates the limit back at the reader ("100 events in
+  // the newest 100" answered nothing about whether 101 or ten million sat
+  // behind it) — has_more, one probe row on the server, says which.
   const refining = refine.length > 0;
-  const pageFull = data.limit > 0 && data.count === data.limit;
-  const scopeNote = pageFull
-    ? " in the newest " + data.limit + " events — narrow with schema/table or a time range"
-    : "";
+  const from = evPages[evPageIdx].offset + 1;
+  const to = evPages[evPageIdx].offset + data.count;
+  let scopeNote = "";
+  if (data.has_more) {
+    scopeNote = " · showing " + from + "–" + to + " of more — page older for the rest";
+  } else if (evPageIdx > 0) {
+    // Paged to the end, so the total IS known exactly: it is what we walked.
+    scopeNote = " · showing " + from + "–" + to + " of " + to + " (end)";
+  }
+  if (refining && data.count !== events.length) {
+    // The refine ran over this page only; say so rather than let the number
+    // read as an index-wide match count.
+    scopeNote += " · refined within this page";
+  }
   if (countEl) countEl.textContent = String(events.length);
   const noteEl = $("#ev-count-note", VIEW());
   if (noteEl) noteEl.textContent = (refining ? " match(es)" : " event(s)") + scopeNote;
+  const prevBtn = $("#ev-prev", VIEW());
+  const nextBtn = $("#ev-next", VIEW());
+  if (prevBtn) prevBtn.disabled = evPageIdx === 0;
+  if (nextBtn) nextBtn.disabled = !data.has_more;
   buildEventRows(rowsEl, events, scopeNote);
+}
+
+// refineEvents applies the client-side free-text / unscoped-pk refine. Shared
+// by the rendered page and by export so the two can never diverge on what
+// "matches this search" means.
+function refineEvents(events, refine) {
+  if (!refine.length) return events;
+  return events.filter((e) => {
+    const hay = (e.schema_name + "." + e.table_name + " " + e.event_type + " " + e.pk_values + " " +
+      (e.changed_columns || []).join(" ") + " " +
+      valueToString(e.row_before) + " " + valueToString(e.row_after)).toLowerCase();
+    return refine.every((t) => hay.includes(t));
+  });
+}
+
+// eventsGoPage steps the Events view one keyset page in `dir` (+1 = older).
+function eventsGoPage(dir) {
+  const next = evPageIdx + dir;
+  if (next < 0 || next >= evPages.length) return;
+  evPageIdx = next;
+  cursorIdx = -1; // the keyboard cursor indexes into the old page's rows
+  runEventsQuery($("#ev-form", VIEW()), true);
+}
+
+// exportEvents downloads EVERY match of the current search, not just the page
+// on screen.
+//
+// The decision, and why: once the view pages, "export what is rendered" means
+// an operator who filtered to one table, walked four pages of an incident and
+// hit Export silently gets a quarter of their evidence. That is worse than the
+// un-paged behavior it replaces. Exporting the whole filtered set costs one
+// cursor-less request at the limit the endpoint ALREADY sanctions
+// (eventsMaxLimit, 1000) — it grants no capability the caps did not already
+// permit, and deliberately does NOT page the export loop, which is exactly how
+// a download button would become the way to pull an index into a browser.
+// The cap is not silent: a result that comes back at the ceiling says so.
+async function exportEvents(kind, btn) {
+  if (!evLastQuery) return;
+  const label = btn ? btn.textContent : "";
+  if (btn) { btn.disabled = true; btn.textContent = "…"; }
+  try {
+    const params = Object.assign({}, evLastQuery.apiParams, { order: "DESC", limit: String(EVENT_EXPORT_MAX) });
+    const data = await api("/api/events?" + new URLSearchParams(params).toString());
+    const rows = refineEvents(data.events || [], evLastQuery.refine);
+    if (kind === "csv") downloadEventsCSV(rows); else downloadEventsJSON(rows);
+    if (data.has_more) {
+      toast("Exported the newest " + data.count + " matches — the search has more. Narrow it with a time range to export the rest.");
+    }
+  } catch (err) {
+    toast("Export failed: " + (err && err.message ? err.message : String(err)));
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = label; }
+  }
 }
 
 function buildEventRows(container, events, scopeNote) {

--- a/internal/console/cursor.go
+++ b/internal/console/cursor.go
@@ -1,0 +1,101 @@
+package console
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// Keyset paging cursors for GET /api/events (#1297).
+//
+// The Events view is newest-first and used to render one un-paged window: the
+// header read "100 event(s) in the newest 100 events" and event 101 was
+// unreachable without inventing a filter. Paging it needs a cursor, and the
+// cursor is KEYSET rather than OFFSET — an OFFSET grows the work the engine
+// does with how deep you have paged, re-scanning and re-sorting every skipped
+// row, and on a merged live+archive read it would re-download the archives for
+// every page. A keyset cut costs the same on page 40 as on page 1.
+//
+// A cursor is (event_timestamp, event_id) — the index's total sort order.
+// event_id is not decoration: event_timestamp has one-second resolution and
+// collides heavily under load, so a timestamp-only cursor either re-returns or
+// skips every event sharing the boundary second.
+
+// eventCursorSep separates the two components of the wire form. It cannot
+// appear in either half (an RFC 3339 timestamp and a decimal id), so splitting
+// on it is unambiguous.
+const eventCursorSep = "|"
+
+// formatEventCursor renders the position of a served row as the opaque token a
+// client passes back as ?before= / ?after=.
+//
+// The timestamp is RFC 3339 with its offset rather than the DTO's bare
+// "2006-01-02 15:04:05": a bare wall clock has to be re-attached to some
+// location on the way back in, and guessing wrong shifts the cut by the
+// connection's offset — which does not fail, it just silently returns the
+// wrong page. Carrying the offset pins the instant, so the row this cursor
+// names is the same row whatever location the index connection uses.
+func formatEventCursor(r query.ResultRow) string {
+	return r.EventTimestamp.Format(time.RFC3339Nano) + eventCursorSep + strconv.FormatUint(r.EventID, 10)
+}
+
+// parseEventCursor turns the wire form back into an engine cursor.
+func parseEventCursor(param, s string) (*query.EventCursor, error) {
+	ts, idStr, ok := strings.Cut(s, eventCursorSep)
+	if !ok {
+		return nil, fmt.Errorf("invalid %s cursor: expected <timestamp>%s<event_id>", param, eventCursorSep)
+	}
+	t, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s cursor timestamp: %v", param, err)
+	}
+	id, err := strconv.ParseUint(idStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s cursor event id: %v", param, err)
+	}
+	return &query.EventCursor{Timestamp: t, EventID: id}, nil
+}
+
+// applyEventCursors parses the ?after= / ?before= params onto opts, rejecting
+// the pairings the engine's keyset predicates cannot serve.
+//
+// The direction rule is checked HERE, ahead of the fetch, so a mismatch is a
+// 400 the client can act on rather than the engine's validateCursor error
+// arriving through writeFetchError as a 500. `before` pages a DESCENDING
+// (newest-first) listing toward older events; `after` pages an ASCENDING one
+// toward newer. Crossing them walks away from the unread remainder — the page
+// would come back plausibly full and simply be the wrong half of the window,
+// the failure mode worth a hard refusal.
+func applyEventCursors(opts *query.Options, after, before string) error {
+	if after == "" && before == "" {
+		return nil
+	}
+	if after != "" && before != "" {
+		return errors.New("pass either after or before, not both: they page in opposite directions")
+	}
+	desc := query.OrderDirection(opts.Order) == "DESC"
+	if before != "" {
+		if !desc {
+			return errors.New("the before cursor pages a newest-first listing; it needs order=DESC")
+		}
+		c, err := parseEventCursor("before", before)
+		if err != nil {
+			return err
+		}
+		opts.BeforeEvent = c
+		return nil
+	}
+	if desc {
+		return errors.New("the after cursor pages an oldest-first listing; it needs order=ASC")
+	}
+	c, err := parseEventCursor("after", after)
+	if err != nil {
+		return err
+	}
+	opts.AfterEvent = c
+	return nil
+}

--- a/internal/console/events_paging_test.go
+++ b/internal/console/events_paging_test.go
@@ -1,0 +1,211 @@
+package console
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/dbtrail/dbtrail/internal/parser"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// eventRowCols mirrors the SELECT list Engine.Fetch reads. Kept local to this
+// file so a column added upstream fails here loudly rather than silently
+// shifting a scan.
+var eventRowCols = []string{
+	"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+	"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+	"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+	"commit_ts_us",
+}
+
+// mockEventRows builds n descending-in-time event rows starting at base.
+func mockEventRows(base time.Time, n int) *sqlmock.Rows {
+	rows := sqlmock.NewRows(eventRowCols)
+	for i := range n {
+		rows.AddRow(
+			int64(1000-i), "bin.000001", int64(4), int64(40), base.Add(-time.Duration(i)*time.Minute),
+			nil, int64(4242), "app", "users", int64(parser.EventUpdate), fmt.Sprint(i),
+			[]byte(`["email"]`), []byte(`{"email":"a@x"}`), []byte(`{"email":"b@x"}`), int64(0),
+			nil, nil, int64(0),
+		)
+	}
+	return rows
+}
+
+func getEvents(t *testing.T, s *Server, url string) (int, eventsResponse, string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	s.handleEvents(rec, httptest.NewRequest("GET", url, nil))
+	var resp eventsResponse
+	if rec.Code == 200 {
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v (body %s)", err, rec.Body.String())
+		}
+	}
+	return rec.Code, resp, rec.Body.String()
+}
+
+// TestEventsHasMoreProbe: the handler asks the engine for one row PAST the
+// page so it can say whether anything is behind it, and that probe row is
+// never served. Before #1297 the header could only restate the limit back at
+// the reader ("100 event(s) in the newest 100"), which answered nothing about
+// whether 101 or ten million events sat behind the cut.
+func TestEventsHasMoreProbe(t *testing.T) {
+	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	t.Run("more behind the page", func(t *testing.T) {
+		db, mock, done := newSQLMock(t)
+		defer done()
+		// 3 rows come back for a page of 2: the third is the probe.
+		mock.ExpectQuery("FROM binlog_events").WillReturnRows(mockEventRows(base, 3))
+
+		code, resp, body := getEvents(t, newBootServer(db), "/api/events?schema=app&table=users&limit=2")
+		if code != 200 {
+			t.Fatalf("status = %d, body = %s", code, body)
+		}
+		if !resp.HasMore {
+			t.Error("has_more = false with a row past the page; the UI would hide its Next control and event 3 stays unreachable")
+		}
+		if resp.Count != 2 || len(resp.Events) != 2 {
+			t.Errorf("count = %d / %d events, want 2: the probe row must not be served", resp.Count, len(resp.Events))
+		}
+		if resp.Limit != 2 {
+			t.Errorf("limit = %d, want 2 — the page size, never the probe size", resp.Limit)
+		}
+		if resp.NextBefore == "" {
+			t.Error("next_before is empty while has_more is true; the client cannot ask for the next page")
+		}
+		// The cursor must name the LAST SERVED row, not the probe: naming the
+		// probe would skip it on the following page.
+		wantID := "|999"
+		if !strings.HasSuffix(resp.NextBefore, wantID) {
+			t.Errorf("next_before = %q, want it to end at the last SERVED row %q", resp.NextBefore, wantID)
+		}
+	})
+
+	t.Run("nothing behind the page", func(t *testing.T) {
+		db, mock, done := newSQLMock(t)
+		defer done()
+		mock.ExpectQuery("FROM binlog_events").WillReturnRows(mockEventRows(base, 2))
+
+		code, resp, body := getEvents(t, newBootServer(db), "/api/events?schema=app&table=users&limit=2")
+		if code != 200 {
+			t.Fatalf("status = %d, body = %s", code, body)
+		}
+		if resp.HasMore {
+			t.Error("has_more = true on an exactly-full page with no probe row: the operator is told to keep paging into nothing")
+		}
+		if resp.NextBefore != "" {
+			t.Errorf("next_before = %q, want empty when there is no next page", resp.NextBefore)
+		}
+		if resp.Count != 2 {
+			t.Errorf("count = %d, want 2", resp.Count)
+		}
+	})
+}
+
+// TestEventsLimitCapUnchanged: paging must not become a way to widen the
+// result cap. An over-max request still reports (and is clamped to)
+// eventsMaxLimit — the probe adds exactly one row to the FETCH, and never to
+// the contract.
+func TestEventsLimitCapUnchanged(t *testing.T) {
+	db, mock, done := newSQLMock(t)
+	defer done()
+	mock.ExpectQuery("FROM binlog_events").WillReturnRows(mockEventRows(time.Now(), 1))
+
+	code, resp, body := getEvents(t, newBootServer(db), "/api/events?schema=app&table=users&limit=5000")
+	if code != 200 {
+		t.Fatalf("status = %d, body = %s", code, body)
+	}
+	if resp.Limit != eventsMaxLimit {
+		t.Errorf("limit = %d, want the cap %d", resp.Limit, eventsMaxLimit)
+	}
+}
+
+// TestEventsBeforeCursorPagesTheIndex: the ?before= cursor reaches the engine
+// as a keyset predicate carrying BOTH components. event_id is not decoration —
+// event_timestamp has one-second resolution, so a timestamp-only cut would
+// re-serve or skip every event sharing the boundary second.
+func TestEventsBeforeCursorPagesTheIndex(t *testing.T) {
+	db, mock, done := newSQLMock(t)
+	defer done()
+	// The regex is over the generated SQL: the keyset predicate must be there,
+	// or the "next page" silently re-serves page 1 forever.
+	mock.ExpectQuery(regexp.QuoteMeta("(event_timestamp < ? OR (event_timestamp = ? AND event_id < ?))")).
+		WillReturnRows(mockEventRows(time.Now(), 1))
+
+	cursor := "2026-01-02T03:04:05Z|999"
+	code, resp, body := getEvents(t, newBootServer(db),
+		"/api/events?schema=app&table=users&limit=2&before="+cursor)
+	if code != 200 {
+		t.Fatalf("status = %d, body = %s", code, body)
+	}
+	if resp.Count != 1 {
+		t.Errorf("count = %d, want 1", resp.Count)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("the cursor never reached the engine: %v", err)
+	}
+}
+
+// TestEventsCursorErrorsAre400: a cursor the server cannot honor is a hard
+// refusal, never a silent fall back to page 1 — that would make the UI's Next
+// button re-serve the same page forever while the operator believed they were
+// walking backwards through the index.
+func TestEventsCursorErrorsAre400(t *testing.T) {
+	cases := []struct {
+		name, url, wantMsg string
+	}{
+		{"malformed cursor", "/api/events?before=nonsense", "invalid before cursor"},
+		{"bad timestamp", "/api/events?before=not-a-time|7", "invalid before cursor timestamp"},
+		{"bad event id", "/api/events?before=2026-01-02T03:04:05Z|abc", "invalid before cursor event id"},
+		{"backward cursor on an ascending listing", "/api/events?order=ASC&before=2026-01-02T03:04:05Z|7", "needs order=DESC"},
+		{"forward cursor on a descending listing", "/api/events?after=2026-01-02T03:04:05Z|7", "needs order=ASC"},
+		{"both directions at once", "/api/events?after=2026-01-02T03:04:05Z|7&before=2026-01-02T03:04:05Z|7", "not both"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// nil db: a handler that reached the fetch would panic or 500, so a
+			// clean 400 also proves the refusal happens BEFORE any DB work.
+			rec := httptest.NewRecorder()
+			newBootServer(nil).handleEvents(rec, httptest.NewRequest("GET", tc.url, nil))
+			if rec.Code != 400 {
+				t.Fatalf("status = %d, want 400 (body %s)", rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), tc.wantMsg) {
+				t.Errorf("body should explain the refusal (%q), got %s", tc.wantMsg, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestEventCursorRoundTrip: a cursor rendered from a served row parses back to
+// the same instant and id. The timestamp carries its offset on purpose — a
+// bare wall clock has to be re-attached to some location on the way in, and
+// guessing wrong does not fail, it just returns the wrong page.
+func TestEventCursorRoundTrip(t *testing.T) {
+	offset := time.FixedZone("UTC+5", 5*3600)
+	for _, ts := range []time.Time{
+		time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+		time.Date(2026, 1, 2, 3, 4, 5, 0, offset),
+	} {
+		s := formatEventCursor(query.ResultRow{EventTimestamp: ts, EventID: 4242})
+		got, err := parseEventCursor("before", s)
+		if err != nil {
+			t.Fatalf("%s: %v", s, err)
+		}
+		if !got.Timestamp.Equal(ts) {
+			t.Errorf("%s: timestamp = %v, want the same instant as %v", s, got.Timestamp, ts)
+		}
+		if got.EventID != 4242 {
+			t.Errorf("%s: event id = %d, want 4242", s, got.EventID)
+		}
+	}
+}

--- a/internal/parquetquery/keyset_desc_1297_test.go
+++ b/internal/parquetquery/keyset_desc_1297_test.go
@@ -1,0 +1,127 @@
+package parquetquery
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// TestUntilUpperBoundHint_descendsWithCursor is the mirror of
+// TestSinceLowerBoundHint_advancesWithCursor for newest-first paging (#1297).
+//
+// Without this hint every page of a paged Events view re-lists and
+// re-downloads the whole window's archive files and leans on the row-level
+// predicate to throw them away — quadratic S3 traffic behind a Next button.
+// The CEILING is the load-bearing detail: the cursor's own hour still holds
+// the events immediately below the page break, and Hive scoping is
+// hour-granular, so a floored hint would prune the very file the next page
+// must read.
+func TestUntilUpperBoundHint_descendsWithCursor(t *testing.T) {
+	until := time.Date(2026, 7, 25, 18, 0, 0, 0, time.UTC)
+	cursor := time.Date(2026, 7, 25, 9, 42, 17, 0, time.UTC)
+	cursorHourEnd := time.Date(2026, 7, 25, 10, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		opts query.Options
+		want *time.Time
+	}{
+		{
+			name: "no cursor keeps the plain Until",
+			opts: query.Options{Until: &until},
+			want: &until,
+		},
+		{
+			name: "cursor below Until wins, ceiled to the next hour",
+			opts: query.Options{Until: &until, BeforeEvent: &query.EventCursor{Timestamp: cursor, EventID: 7}},
+			want: &cursorHourEnd,
+		},
+		{
+			name: "cursor above Until does not widen the scan",
+			opts: query.Options{
+				Until:       &cursor,
+				BeforeEvent: &query.EventCursor{Timestamp: until, EventID: 7},
+			},
+			want: &cursor,
+		},
+		{
+			name: "cursor with no Until still scopes the listing",
+			opts: query.Options{BeforeEvent: &query.EventCursor{Timestamp: cursor, EventID: 7}},
+			want: &cursorHourEnd,
+		},
+		{
+			name: "no bounds at all stays nil",
+			opts: query.Options{},
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := untilUpperBoundHint(tc.opts)
+			if tc.want == nil {
+				if got != nil {
+					t.Fatalf("hint = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("hint = nil, want %v", tc.want)
+			}
+			if !got.Equal(*tc.want) {
+				t.Errorf("hint = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildFilters_beforeEventKeyset pins the archive-side composite cut. It
+// has to match the live-MySQL predicate exactly: a merged read that cut the
+// two tiers at different points would drop or duplicate events precisely at a
+// page boundary that straddles the rotation line.
+func TestBuildFilters_beforeEventKeyset(t *testing.T) {
+	cur := time.Date(2026, 7, 25, 14, 37, 5, 0, time.UTC)
+	where, args := buildFilters(query.Options{
+		Order:       "DESC",
+		BeforeEvent: &query.EventCursor{Timestamp: cur, EventID: 4242},
+	}, nil)
+
+	found := false
+	for _, w := range where {
+		if w == "(event_timestamp < ? OR (event_timestamp = ? AND event_id < ?))" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("missing the composite keyset cut, so archives would re-serve rows already shown: %v", where)
+	}
+	if len(args) != 3 {
+		t.Fatalf("args = %v, want 3 (ts, ts, event_id)", args)
+	}
+	if args[2] != uint64(4242) {
+		t.Errorf("event_id arg = %v, want 4242", args[2])
+	}
+}
+
+// TestFetch_rejectsBackwardCursorWithASC mirrors the AfterEvent+DESC guard.
+// The predicate can be emitted from this package, so the direction rule is
+// enforced where it is emitted, not only on the surface that sets it today.
+func TestFetch_rejectsBackwardCursorWithASC(t *testing.T) {
+	opts := query.Options{
+		Order:       "ASC",
+		BeforeEvent: &query.EventCursor{Timestamp: time.Now(), EventID: 1},
+	}
+	// "" as the source would fail later anyway; the guard must fire FIRST, so a
+	// nil error here means the guard is gone even if the call errors for
+	// another reason below.
+	_, err := Fetch(context.Background(), opts, "")
+	if err == nil {
+		t.Fatal("Fetch accepted a backward cursor with Order=ASC")
+	}
+	if !strings.Contains(err.Error(), "BeforeEvent is a backward keyset cursor") {
+		t.Errorf("error should name the direction rule, got: %v", err)
+	}
+}

--- a/internal/parquetquery/keyset_desc_1297_test.go
+++ b/internal/parquetquery/keyset_desc_1297_test.go
@@ -125,3 +125,46 @@ func TestFetch_rejectsBackwardCursorWithASC(t *testing.T) {
 		t.Errorf("error should name the direction rule, got: %v", err)
 	}
 }
+
+// TestScopeArchiveFiles_prunesAboveTheCursor pins the WIRING, not the hint.
+//
+// untilUpperBoundHint can be perfectly correct and still be ignored at the
+// call site, and nothing else would notice: the row-level keyset predicate
+// makes the exact cut either way, so results stay identical and every
+// correctness test keeps passing while each newest-first page silently
+// re-downloads the whole window's archive files. This is the test that fails
+// when the hint stops being threaded through.
+func TestScopeArchiveFiles_prunesAboveTheCursor(t *testing.T) {
+	files := []string{
+		"event_date=2026-07-25/event_hour=08/events.parquet",
+		"event_date=2026-07-25/event_hour=09/events.parquet",
+		"event_date=2026-07-25/event_hour=10/events.parquet",
+		"event_date=2026-07-25/event_hour=12/events.parquet",
+		"event_date=2026-07-25/event_hour=17/events.parquet",
+	}
+	cursor := time.Date(2026, 7, 25, 9, 42, 17, 0, time.UTC)
+	until := time.Date(2026, 7, 25, 18, 0, 0, 0, time.UTC)
+
+	// Without a cursor the whole window is in scope.
+	if got := scopeArchiveFiles(files, query.Options{Until: &until}); len(got) != len(files) {
+		t.Fatalf("cursor-less scoping pruned %d of %d files", len(files)-len(got), len(files))
+	}
+
+	got := scopeArchiveFiles(files, query.Options{
+		Until:       &until,
+		Order:       "DESC",
+		BeforeEvent: &query.EventCursor{Timestamp: cursor, EventID: 7},
+	})
+	// Hours 08–10 stay: 09 holds the cursor, 08 is below it, and 10 is the
+	// one-hour over-inclusion the ceiling deliberately buys. Hours 12 and 17
+	// are entirely above the cursor and can hold nothing this page will return.
+	want := files[:3]
+	if len(got) != len(want) {
+		t.Fatalf("scoped files = %v, want %v (the hint is not reaching the file pruner)", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("scoped[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -46,6 +46,9 @@ func Fetch(ctx context.Context, opts query.Options, source string) ([]query.Resu
 	if opts.AfterEvent != nil && query.OrderDirection(opts.Order) == "DESC" {
 		return nil, errors.New("parquetquery: AfterEvent is a forward keyset cursor and cannot be combined with Order=DESC")
 	}
+	if opts.BeforeEvent != nil && query.OrderDirection(opts.Order) == "ASC" {
+		return nil, errors.New("parquetquery: BeforeEvent is a backward keyset cursor and cannot be combined with Order=ASC")
+	}
 	return FetchWithTuning(ctx, opts, source, duckdbutil.DefaultTuning())
 }
 
@@ -92,7 +95,13 @@ func FetchWithTuning(ctx context.Context, opts query.Options, source string, tun
 		// away the very file a position-anchored fetch needs (see
 		// sinceLowerBoundHint).
 		sinceHint := sinceLowerBoundHint(opts)
-		files, maxSize, region, s3Client, err := listS3ParquetScoped(ctx, source, sinceHint, opts.Until, opts.ExtraArchiveHours)
+		// untilHint, not opts.Until directly: a newest-first keyset cursor
+		// lowers the top of the window with every page (see
+		// untilUpperBoundHint). It is passed to classifyEmptyS3Listing below
+		// as well, because that classification asks what filterFilesByTimeRange
+		// could have discarded — so it must see the same bounds the filter used.
+		untilHint := untilUpperBoundHint(opts)
+		files, maxSize, region, s3Client, err := listS3ParquetScoped(ctx, source, sinceHint, untilHint, opts.ExtraArchiveHours)
 		if err != nil {
 			return nil, fmt.Errorf("list S3 archive files: %w", err)
 		}
@@ -100,12 +109,12 @@ func FetchWithTuning(ctx context.Context, opts query.Options, source string, tun
 		// to avoid downloading parquet files outside the requested time range.
 		// ExtraArchiveHours (#1037) exempts misfiled files — archives whose
 		// label hour lies outside the range but whose content overlaps it.
-		files = filterFilesByTimeRange(files, sinceHint, opts.Until, opts.ExtraArchiveHours)
+		files = filterFilesByTimeRange(files, sinceHint, untilHint, opts.ExtraArchiveHours)
 		// Sort chronologically so we can terminate early when --limit is satisfied.
 		files = sortFilesByHour(files)
 		slog.Debug("files after time-range pruning", "count", len(files))
 		if len(files) == 0 {
-			return classifyEmptyS3Listing(ctx, s3Client, source, sinceHint, opts.Until)
+			return classifyEmptyS3Listing(ctx, s3Client, source, sinceHint, untilHint)
 		}
 
 		// Ultrafast: read the S3 files directly via DuckDB httpfs in one
@@ -429,6 +438,34 @@ func sinceLowerBoundHint(opts query.Options) *time.Time {
 		// file scoping can act on, and flooring can only over-include.
 		cur := opts.AfterEvent.Timestamp.Truncate(time.Hour)
 		if hint == nil || cur.After(*hint) {
+			hint = &cur
+		}
+	}
+	return hint
+}
+
+// untilUpperBoundHint is sinceLowerBoundHint's mirror for newest-first paging
+// (#1297): a Options.BeforeEvent cursor tightens the archive file/date scoping
+// upper bound, because every row still to be returned sorts at-or-before the
+// cursor and so cannot live in a file whose hour STARTS after the cursor's.
+//
+// It exists for the same reason the AfterEvent half of sinceLowerBoundHint
+// does: without it every newest-first page would re-list and re-download the
+// whole window's files and lean on the row-level filter to throw them away,
+// once per page — quadratic S3 traffic behind a Next button.
+//
+// The cursor's hour is CEILED (truncate, then add an hour) rather than
+// floored: the cursor's own hour still holds the events immediately below the
+// page break, and Hive scoping is hour-granular, so flooring would prune the
+// very file the next page must read. Over-including one hour is free; the
+// row-level predicate makes the exact cut.
+//
+// Returns opts.Until unchanged when no cursor is set.
+func untilUpperBoundHint(opts query.Options) *time.Time {
+	hint := opts.Until
+	if opts.BeforeEvent != nil {
+		cur := opts.BeforeEvent.Timestamp.Truncate(time.Hour).Add(time.Hour)
+		if hint == nil || cur.Before(*hint) {
 			hint = &cur
 		}
 	}
@@ -1014,6 +1051,14 @@ func buildFilters(opts query.Options, cols map[string]bool) ([]string, []any) {
 		// row groups from this predicate via their event_timestamp statistics.
 		where = append(where, "(event_timestamp > ? OR (event_timestamp = ? AND event_id > ?))")
 		args = append(args, opts.AfterEvent.Timestamp, opts.AfterEvent.Timestamp, opts.AfterEvent.EventID)
+	}
+	if opts.BeforeEvent != nil {
+		// The newest-first mirror (#1297). As with AfterEvent no coarse hint is
+		// emitted here — untilUpperBoundHint has already tightened file/date
+		// scoping before this filter is built — and DuckDB prunes row groups
+		// from this predicate via their event_timestamp statistics.
+		where = append(where, "(event_timestamp < ? OR (event_timestamp = ? AND event_id < ?))")
+		args = append(args, opts.BeforeEvent.Timestamp, opts.BeforeEvent.Timestamp, opts.BeforeEvent.EventID)
 	}
 	if opts.ChangedColumn != "" {
 		needle, _ := json.Marshal(opts.ChangedColumn)

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -109,7 +109,7 @@ func FetchWithTuning(ctx context.Context, opts query.Options, source string, tun
 		// to avoid downloading parquet files outside the requested time range.
 		// ExtraArchiveHours (#1037) exempts misfiled files — archives whose
 		// label hour lies outside the range but whose content overlaps it.
-		files = filterFilesByTimeRange(files, sinceHint, untilHint, opts.ExtraArchiveHours)
+		files = scopeArchiveFiles(files, opts)
 		// Sort chronologically so we can terminate early when --limit is satisfied.
 		files = sortFilesByHour(files)
 		slog.Debug("files after time-range pruning", "count", len(files))
@@ -442,6 +442,20 @@ func sinceLowerBoundHint(opts query.Options) *time.Time {
 		}
 	}
 	return hint
+}
+
+// scopeArchiveFiles prunes a listed archive file set to the query's EFFECTIVE
+// time bounds — the keyset-cursor-tightened ones, not the raw Since/Until.
+//
+// It exists as a named function rather than an inline call so the composition
+// is reachable from a test. Passing opts.Since/opts.Until here instead of the
+// hints is invisible to every correctness test (the row-level predicate still
+// makes the exact cut, so results are identical) and merely re-downloads the
+// whole window's files once per page — a regression that would only ever show
+// up as an S3 bill. TestScopeArchiveFiles_prunesAboveTheCursor is what makes
+// it fail loudly instead.
+func scopeArchiveFiles(files []string, opts query.Options) []string {
+	return filterFilesByTimeRange(files, sinceLowerBoundHint(opts), untilUpperBoundHint(opts), opts.ExtraArchiveHours)
 }
 
 // untilUpperBoundHint is sinceLowerBoundHint's mirror for newest-first paging

--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -243,6 +243,15 @@ func FetchMergedFull(
 // Time and table filters need no special case: whatever they exclude, the live
 // rows that survive are still newer than everything below the cutoff, so a full
 // page of them is still the true top N.
+//
+// A newest-first keyset cursor (Options.BeforeEvent, #1297) needs no special
+// case either, and this is worth stating because it looks like it should: the
+// test above is entirely about the span from the cutoff row UPWARD being
+// provably live-covered, and BeforeEvent only lowers the top of that span. Page
+// 2 of a paged Events view is therefore skipped past the archives on the same
+// proof as page 1 — and once paging descends far enough that the page's cutoff
+// falls below the single live range's start, the test fails and the archives
+// are read, which is precisely when they hold the answer.
 func topNSatisfiedLive(opts Options, rows []ResultRow, plan *QueryPlan) bool {
 	if opts.Limit <= 0 || len(rows) < opts.Limit || OrderDirection(opts.Order) != "DESC" {
 		return false
@@ -306,6 +315,14 @@ func FetchMergedStream(
 	}
 	if o.Opts.AfterEvent != nil {
 		return nil, errors.New("FetchMergedStream: Opts.AfterEvent is managed by the stream and must not be preset")
+	}
+	// BeforeEvent is rejected with its own message rather than left to
+	// validateCursor (#1297). This path is ASC-only, so a preset backward
+	// cursor would otherwise surface as "BeforeEvent cannot be combined with
+	// Order=ASC" — a direction complaint that sends the caller looking at
+	// Order, when the actual rule is that this stream owns its cursor.
+	if o.Opts.BeforeEvent != nil {
+		return nil, errors.New("FetchMergedStream: Opts.BeforeEvent is a newest-first cursor; this stream pages ascending and manages its own cursor")
 	}
 	if batchSize <= 0 {
 		batchSize = DefaultStreamBatchSize

--- a/internal/query/fetchmergedstream_test.go
+++ b/internal/query/fetchmergedstream_test.go
@@ -255,6 +255,10 @@ func TestFetchMergedStream_rejectsIncompatibleOptions(t *testing.T) {
 		{"global limit", Options{Limit: 10}, "cannot be combined with paging"},
 		{"per-PK limit", Options{LimitPerPK: 3}, "cannot be combined with paging"},
 		{"preset cursor", Options{AfterEvent: &EventCursor{Timestamp: streamBase, EventID: 1}}, "must not be preset"},
+		// The newest-first cursor (#1297) is refused with its OWN message, not
+		// left to validateCursor: that would blame Order for what is really
+		// "this stream owns its cursor", sending the caller to the wrong field.
+		{"preset newest-first cursor", Options{BeforeEvent: &EventCursor{Timestamp: streamBase, EventID: 1}}, "manages its own cursor"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -34,9 +34,14 @@ func mysqlToSeconds(t time.Time) int64 {
 	return t.UTC().Unix() + mysqlToSecondsConst
 }
 
-// validateCursor rejects the one option pairing the keyset predicate cannot
-// serve: a cursor with a DESCENDING order (#1097). The two together page AWAY
-// from the unread remainder, silently returning the wrong half of the window.
+// validateCursor rejects the option pairings the keyset predicates cannot
+// serve: a FORWARD cursor with a DESCENDING order, and (since #1297) a
+// BACKWARD cursor with an ASCENDING one. Either pairing pages AWAY from the
+// unread remainder, silently returning the wrong half of the window.
+//
+// The two checks also make "both cursors set" unreachable: Order names one
+// direction, and whichever it names rejects one of the cursors. That is why
+// there is no third check for the combination.
 //
 // It lives at the ENGINE entry points rather than only inside
 // FetchMergedStream, which is the sole legitimate setter today: Options is
@@ -47,6 +52,9 @@ func mysqlToSeconds(t time.Time) int64 {
 func (o Options) validateCursor() error {
 	if o.AfterEvent != nil && OrderDirection(o.Order) == "DESC" {
 		return errors.New("query: AfterEvent is a forward keyset cursor and cannot be combined with Order=DESC")
+	}
+	if o.BeforeEvent != nil && OrderDirection(o.Order) == "ASC" {
+		return errors.New("query: BeforeEvent is a backward keyset cursor and cannot be combined with Order=ASC")
 	}
 	return nil
 }
@@ -242,6 +250,31 @@ type Options struct {
 	//
 	// nil = no cursor (fetch from the start of the window).
 	AfterEvent *EventCursor
+	// BeforeEvent is AfterEvent's mirror: it restricts results to events
+	// strictly BEFORE this point in the (event_timestamp, event_id) sort
+	// order, which is what a DESCENDING (newest-first) surface needs to reach
+	// its second page (#1297).
+	//
+	// Why a second field instead of reusing AfterEvent: the console's Events
+	// view is newest-first, and AfterEvent is a FORWARD cursor — pairing it
+	// with Order=DESC pages away from the unread remainder, which is exactly
+	// what validateCursor refuses. Narrowing Until instead is not a
+	// substitute: Until compares event_timestamp alone, and the column has
+	// one-second resolution, so a boundary second shared by several events
+	// either re-returns them (Until = cursor second) or drops them entirely
+	// (Until = cursor second minus one) — silently losing events in the middle
+	// of an investigation is the failure mode this field exists to prevent.
+	// Carrying event_id makes the cut total, so page N+1 resumes exactly where
+	// page N stopped.
+	//
+	// DESCENDING ORDER ONLY, the symmetric constraint: with Order="ASC" a
+	// backward cursor walks away from the unread remainder just as
+	// AfterEvent+DESC does. Because each cursor is pinned to the opposite
+	// order, setting BOTH is unreachable — whichever direction Order names,
+	// one of the two checks rejects it — so no third "not both" check exists.
+	//
+	// nil = no cursor (fetch from the newest end of the window).
+	BeforeEvent *EventCursor
 	// ExtraArchiveHours lists the hour LABELS of archive files whose CONTENT
 	// time range overlaps the query window even though their partition/Hive
 	// path label does not (#1037: backfilled events archived under the oldest
@@ -680,6 +713,22 @@ func buildQuery(opts Options) (string, []any) {
 		// deliberately over-inclusive, this is the precise boundary.
 		where = append(where, "(event_timestamp > ? OR (event_timestamp = ? AND event_id > ?))")
 		args = append(args, opts.AfterEvent.Timestamp, opts.AfterEvent.Timestamp, opts.AfterEvent.EventID)
+	}
+	if opts.BeforeEvent != nil {
+		// The mirror of the AfterEvent block above, for newest-first paging
+		// (#1297). Hour-aligned TO_SECONDS literal so MySQL prunes partitions at
+		// parse time; the bound is EXCLUSIVE at the next hour boundary
+		// (15:13 → 16:00) exactly like the Until hint, because every row still
+		// to be returned sorts at-or-before the cursor and so cannot live in a
+		// partition above the cursor's own hour. Flooring instead of ceiling
+		// here would prune away the cursor's own partition and drop the rest of
+		// the boundary hour — the events immediately after the page break.
+		outerBefore := mysqlToSeconds(opts.BeforeEvent.Timestamp.Truncate(time.Hour).Add(time.Hour))
+		where = append(where, fmt.Sprintf("TO_SECONDS(event_timestamp) < %d", outerBefore))
+		// The exact keyset cut on the composite sort key; the hint above is
+		// hour-granular and deliberately over-inclusive, this is the boundary.
+		where = append(where, "(event_timestamp < ? OR (event_timestamp = ? AND event_id < ?))")
+		args = append(args, opts.BeforeEvent.Timestamp, opts.BeforeEvent.Timestamp, opts.BeforeEvent.EventID)
 	}
 	if opts.ChangedColumn != "" {
 		// json.Marshal produces the JSON string representation (with quotes),

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -967,3 +967,84 @@ func TestBuildQuery_noAfterEventNoKeyset(t *testing.T) {
 		t.Errorf("keyset predicate leaked into a cursor-less query:\n%s", q)
 	}
 }
+
+// TestBuildQuery_beforeEventKeyset covers the newest-first keyset cursor
+// (#1297), the mirror of TestBuildQuery_afterEventKeyset. Both halves are
+// load-bearing, and the hint's DIRECTION especially so: it must CEIL to the
+// next hour, because the cursor's own partition still holds the events
+// immediately below the page break. A floored hint would prune that partition
+// and silently drop the rest of the boundary hour — the events right after the
+// page break, which is exactly the data the operator clicked Next to see.
+func TestBuildQuery_beforeEventKeyset(t *testing.T) {
+	cur := time.Date(2026, 7, 25, 14, 37, 5, 0, time.UTC)
+	q, args := buildQuery(Options{
+		Schema:      "mydb",
+		Table:       "orders",
+		Order:       "DESC",
+		BeforeEvent: &EventCursor{Timestamp: cur, EventID: 4242},
+	})
+
+	if !strings.Contains(q, "(event_timestamp < ? OR (event_timestamp = ? AND event_id < ?))") {
+		t.Errorf("missing the composite keyset cut; a timestamp-only cursor would skip or re-return the boundary second:\n%s", q)
+	}
+	// TO_SECONDS('2026-07-25 15:00:00') — the hour AFTER the cursor's.
+	wantHint := fmt.Sprintf("TO_SECONDS(event_timestamp) < %d", mysqlToSeconds(cur.Truncate(time.Hour).Add(time.Hour)))
+	if !strings.Contains(q, wantHint) {
+		t.Errorf("missing partition-pruning hint %q:\n%s", wantHint, q)
+	}
+	// Guard the direction explicitly: a floored literal is the plausible typo
+	// and it prunes away the cursor's own hour.
+	floored := fmt.Sprintf("TO_SECONDS(event_timestamp) < %d", mysqlToSeconds(cur.Truncate(time.Hour)))
+	if strings.Contains(q, floored) {
+		t.Errorf("pruning hint floored to the cursor's own hour; the rest of that hour would be dropped:\n%s", q)
+	}
+
+	if len(args) != 5 {
+		t.Fatalf("args = %v, want 5 (schema, table, ts, ts, event_id)", args)
+	}
+	if args[2] != cur || args[3] != cur {
+		t.Errorf("timestamp args = %v/%v, want %v twice", args[2], args[3], cur)
+	}
+	if args[4] != uint64(4242) {
+		t.Errorf("event_id arg = %v, want 4242", args[4])
+	}
+}
+
+// TestBuildQuery_noBeforeEventNoKeyset pins that the backward predicate is
+// absent when no cursor is set, so every pre-#1297 caller generates exactly
+// the SQL it did before.
+func TestBuildQuery_noBeforeEventNoKeyset(t *testing.T) {
+	q, _ := buildQuery(Options{Schema: "mydb", Table: "orders", Order: "DESC"})
+	if strings.Contains(q, "event_id <") {
+		t.Errorf("backward keyset predicate leaked into a cursor-less query:\n%s", q)
+	}
+}
+
+// TestValidateCursor_direction pins both pairings the keyset predicates cannot
+// serve. A cursor paired with the wrong order does not error at the database —
+// it returns a plausible, full page from the wrong half of the window, so the
+// refusal has to happen here or not at all.
+func TestValidateCursor_direction(t *testing.T) {
+	c := &EventCursor{Timestamp: time.Date(2026, 7, 25, 14, 0, 0, 0, time.UTC), EventID: 1}
+	cases := []struct {
+		name    string
+		opts    Options
+		wantErr bool
+	}{
+		{"forward cursor, DESC", Options{AfterEvent: c, Order: "DESC"}, true},
+		{"forward cursor, ASC", Options{AfterEvent: c, Order: "ASC"}, false},
+		{"forward cursor, unset order (ASC)", Options{AfterEvent: c}, false},
+		{"backward cursor, ASC", Options{BeforeEvent: c, Order: "ASC"}, true},
+		{"backward cursor, DESC", Options{BeforeEvent: c, Order: "DESC"}, false},
+		// An unset Order means the engine sorts ASC, so a backward cursor there
+		// is the ASC pairing under another name and must be refused too.
+		{"backward cursor, unset order (ASC)", Options{BeforeEvent: c}, true},
+		{"no cursor", Options{Order: "DESC"}, false},
+	}
+	for _, tc := range cases {
+		err := tc.opts.validateCursor()
+		if (err != nil) != tc.wantErr {
+			t.Errorf("%s: err = %v, wantErr = %v", tc.name, err, tc.wantErr)
+		}
+	}
+}

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -634,13 +634,16 @@ try {
   // the CSV header must stay in lockstep with EVENT_CSV_COLUMNS.
   const exp = await page.evaluate(async (CANARY) => {
     const btns = Array.from(document.querySelectorAll(".result-bar button"));
-    const jsonBtn = btns.find((b) => b.textContent.trim() === "JSON");
-    const csvBtn = btns.find((b) => b.textContent.trim() === "CSV");
+    const jsonBtn = btns.find((b) => b.textContent.trim() === "Export JSON");
+    const csvBtn = btns.find((b) => b.textContent.trim() === "Export CSV");
     const blobs = [];
     const orig = URL.createObjectURL;
     URL.createObjectURL = (b) => { blobs.push(b); return orig.call(URL, b); };
     jsonBtn.click();
     csvBtn.click();
+    // Export re-fetches the whole filtered set (#1297), so the blob appears a
+    // round-trip after the click — poll instead of reading it synchronously.
+    for (let i = 0; i < 100 && blobs.length < 2; i++) await new Promise((r) => setTimeout(r, 50));
     URL.createObjectURL = orig;
     const [jsonText, csvText] = await Promise.all(blobs.map((b) => b.text()));
     const arr = JSON.parse(jsonText);
@@ -657,12 +660,120 @@ try {
       csvConnVal: csvText.split("\r\n").some((l) => l.split(",").includes("777")),
     };
   }, CANARY);
-  exp.n === 6 ? ok("export: JSON blob carries the full rendered page") : bad("export: JSON blob carries the full rendered page", `n=${exp.n}`);
+  exp.n === 6 ? ok("export: JSON blob carries every match of the search") : bad("export: JSON blob carries every match of the search", `n=${exp.n}`);
   (exp.jsonLeak === 0 && !exp.jsonCanary) ? ok("export: JSON blob is query_text/query_hash-free") : bad("export: JSON blob is query_text/query_hash-free", `leak=${exp.jsonLeak} canary=${exp.jsonCanary}`);
   exp.jsonConn ? ok("export: JSON blob keeps connection_id") : bad("export: JSON blob keeps connection_id", "some entry lacks the key");
   exp.headerLockstep ? ok("export: CSV header in lockstep with EVENT_CSV_COLUMNS") : bad("export: CSV header in lockstep with EVENT_CSV_COLUMNS", "header drifted");
   (exp.headerConn && !exp.headerLeak) ? ok("export: CSV columns include connection_id, never query_text") : bad("export: CSV columns include connection_id, never query_text", `conn=${exp.headerConn} leak=${exp.headerLeak}`);
   (!exp.csvCanary && exp.csvConnVal) ? ok("export: CSV rows redacted but carry the connection_id value") : bad("export: CSV rows redacted but carry the connection_id value", `canary=${exp.csvCanary} conn777=${exp.csvConnVal}`);
+
+  // Scenario 12b — Events keyset paging (#1297). The view used to render one
+  // window and stop: event 101 was unreachable except by inventing a filter,
+  // and the header ("100 event(s) in the newest 100 events") restated the limit
+  // instead of saying whether anything was behind it. The fixture seeds 6
+  // events, so a page size of 5 splits them 5 + 1 — enough to prove the cursor
+  // hands off without repeating or skipping a row, which is the only thing a
+  // paging bug ever does.
+  const pg1 = await page.evaluate(async () => {
+    const f = document.getElementById("ev-form");
+    f.elements.limit.value = "5";
+    f.requestSubmit();
+    // Wait for the re-render to settle on the smaller page.
+    for (let i = 0; i < 60; i++) {
+      await new Promise((r) => setTimeout(r, 50));
+      if (document.querySelectorAll("#ev-rows .ev-row").length === 5) break;
+    }
+    return {
+      rows: document.querySelectorAll("#ev-rows .ev-row").length,
+      ids: lastEvents.map((e) => e.event_id),
+      note: ($("#ev-count-note", VIEW()) || {}).textContent || "",
+      prevDisabled: document.getElementById("ev-prev").disabled,
+      nextDisabled: document.getElementById("ev-next").disabled,
+    };
+  });
+  pg1.rows === 5 ? ok("events paging: a page-size of 5 renders 5 of the 6 seeded events") : bad("events paging: a page-size of 5 renders 5 of the 6 seeded events", `rows=${pg1.rows}`);
+  pg1.prevDisabled ? ok("events paging: Newer is disabled on the first page") : bad("events paging: Newer is disabled on the first page", "enabled");
+  !pg1.nextDisabled ? ok("events paging: Older is enabled while events remain") : bad("events paging: Older is enabled while events remain", "disabled — event 6 is unreachable");
+  /showing 1–5 of more/.test(pg1.note)
+    ? ok("events paging: the header states a position, not the limit restated")
+    : bad("events paging: the header states a position, not the limit restated", `note=${pg1.note}`);
+  !/in the newest 5 events/.test(pg1.note)
+    ? ok("events paging: the circular 'in the newest N' phrasing is gone")
+    : bad("events paging: the circular 'in the newest N' phrasing is gone", `note=${pg1.note}`);
+
+  const pg2 = await page.evaluate(async () => {
+    document.getElementById("ev-next").click();
+    for (let i = 0; i < 60; i++) {
+      await new Promise((r) => setTimeout(r, 50));
+      if (document.querySelectorAll("#ev-rows .ev-row").length === 1) break;
+    }
+    return {
+      rows: document.querySelectorAll("#ev-rows .ev-row").length,
+      ids: lastEvents.map((e) => e.event_id),
+      note: ($("#ev-count-note", VIEW()) || {}).textContent || "",
+      prevDisabled: document.getElementById("ev-prev").disabled,
+      nextDisabled: document.getElementById("ev-next").disabled,
+    };
+  });
+  pg2.rows === 1 ? ok("events paging: Older reaches the 6th event") : bad("events paging: Older reaches the 6th event", `rows=${pg2.rows}`);
+  pg2.ids.every((id) => !pg1.ids.includes(id))
+    ? ok("events paging: page 2 repeats no event from page 1 (keyset cut is exclusive)")
+    : bad("events paging: page 2 repeats no event from page 1 (keyset cut is exclusive)", `p1=${pg1.ids} p2=${pg2.ids}`);
+  pg1.ids.length + pg2.ids.length === 6
+    ? ok("events paging: the two pages together cover all 6 events (nothing skipped)")
+    : bad("events paging: the two pages together cover all 6 events (nothing skipped)", `p1=${pg1.ids} p2=${pg2.ids}`);
+  pg2.nextDisabled ? ok("events paging: Older is disabled at the end of the stream") : bad("events paging: Older is disabled at the end of the stream", "still enabled past the last event");
+  !pg2.prevDisabled ? ok("events paging: Newer is enabled off the first page") : bad("events paging: Newer is enabled off the first page", "disabled — the operator cannot get back");
+  /showing 6–6 of 6 \(end\)/.test(pg2.note)
+    ? ok("events paging: the last page reports the exact total it walked")
+    : bad("events paging: the last page reports the exact total it walked", `note=${pg2.note}`);
+
+  // The export decision (#1297): the buttons export every match of the SEARCH,
+  // not the page on screen. Paged to page 2 (1 row rendered), an export must
+  // still carry all 6 — silently handing an operator a sixth of their evidence
+  // would be worse than the un-paged behavior this replaces.
+  const expAll = await page.evaluate(async () => {
+    const btns = Array.from(document.querySelectorAll(".result-bar button"));
+    const jsonBtn = btns.find((b) => b.textContent.trim() === "Export JSON");
+    const blobs = [];
+    const orig = URL.createObjectURL;
+    URL.createObjectURL = (b) => { blobs.push(b); return orig.call(URL, b); };
+    jsonBtn.click();
+    for (let i = 0; i < 100 && blobs.length < 1; i++) await new Promise((r) => setTimeout(r, 50));
+    URL.createObjectURL = orig;
+    return {
+      n: blobs.length ? JSON.parse(await blobs[0].text()).length : -1,
+      rendered: document.querySelectorAll("#ev-rows .ev-row").length,
+      label: jsonBtn.textContent.trim(),
+      title: jsonBtn.title,
+    };
+  });
+  expAll.n === 6 && expAll.rendered === 1
+    ? ok("export: exports every match of the search, not the 1 row on screen")
+    : bad("export: exports every match of the search, not the 1 row on screen", `n=${expAll.n} rendered=${expAll.rendered}`);
+  (expAll.label === "Export JSON" && /all matches/i.test(expAll.title))
+    ? ok("export: the button states its scope in the UI")
+    : bad("export: the button states its scope in the UI", `label=${expAll.label} title=${expAll.title}`);
+
+  // A filter edit must DROP the cursor: a cursor names a row that need not
+  // exist in the next search, so keeping it would serve a page from the middle
+  // of a search the operator never ran.
+  const reset = await page.evaluate(async () => {
+    const f = document.getElementById("ev-form");
+    f.elements.limit.value = "";
+    f.requestSubmit();
+    for (let i = 0; i < 60; i++) {
+      await new Promise((r) => setTimeout(r, 50));
+      if (document.querySelectorAll("#ev-rows .ev-row").length === 6) break;
+    }
+    return {
+      rows: document.querySelectorAll("#ev-rows .ev-row").length,
+      prevDisabled: document.getElementById("ev-prev").disabled,
+    };
+  });
+  (reset.rows === 6 && reset.prevDisabled)
+    ? ok("events paging: a filter edit resets to page 1")
+    : bad("events paging: a filter edit resets to page 1", `rows=${reset.rows} prevDisabled=${reset.prevDisabled}`);
 
   // Scenario 13 — Recover actually SUBMITS and renders the reversal SQL
   // (#970). Scenario 6 above only checks the form's DOM exists.


### PR DESCRIPTION
Closes #1297

The Events view rendered one window and stopped: event 101 was unreachable
except by inventing a filter, and the header (`100 event(s) in the newest 100
events`) restated the page size back at the reader instead of saying whether
101 or ten million events sat behind the cut.

## The DESC-vs-`AfterEvent` constraint

`query.Options.AfterEvent` could not serve this view. It is a **forward**
cursor and `validateCursor` refuses it with `Order=DESC` — which is the order a
newest-first browser needs. Three options were on the table:

| option | verdict |
|---|---|
| Flip the view to ASC and reuse `AfterEvent` | Rejected. Newest-first is the useful order for an incident browser; making the operator start at the oldest event in the index to reach the newest is a worse product. |
| Narrow `Until` per page | Rejected, and this one is a correctness trap. `Until` compares `event_timestamp` alone, and the column has one-second resolution. A boundary second shared by several events either re-serves them (`Until` = cursor second) or drops them entirely (`Until` = cursor second − 1). Silently losing events mid-investigation is the failure this whole feature exists to prevent. |
| **Add `BeforeEvent`, the mirrored backward cursor** | **Chosen.** |

`BeforeEvent` cuts on the same composite `(event_timestamp, event_id)` key in
the opposite direction, and is pinned to `DESC` by the symmetric half of
`validateCursor`. Because each cursor is pinned to the opposite order, setting
both is unreachable — whichever direction `Order` names, one of the two checks
rejects it — so there is deliberately no third "not both" check.

Mirrored through every surface that can emit the predicate: `buildQuery`
(live MySQL, with an hour-**ceiled** `TO_SECONDS` pruning literal — flooring
would prune the cursor's own partition and drop the rest of the boundary hour,
i.e. exactly the events the operator clicked Next to see), `parquetquery`
(archive predicate + `Fetch` direction guard), and `FetchMergedStream`, which
refuses a preset `BeforeEvent` with its own message rather than letting
`validateCursor` blame `Order` for what is really "this stream owns its cursor".

### Interaction with `topNSatisfiedLive` (#1295, e223b8c)

It survives untouched, and the argument is written into its doc comment because
it looks like it should not: the test is entirely about the span from the page's
**cutoff row upward** being provably live-covered, and `BeforeEvent` only lowers
the top of that span. Page 2 skips the archive scan on the same proof as page 1.
Once paging descends far enough that the cutoff falls below the single live
range's start, the test fails and the archives are read — precisely when they
hold the answer.

`parquetquery` also gains `untilUpperBoundHint`, the mirror of the `AfterEvent`
half of `sinceLowerBoundHint`, so a paged archive read does not re-list and
re-download the whole window once per page.

## Caps are unchanged

`handleEvents` asks the engine for `limit+1` rows purely to learn `has_more`,
and trims the probe before serialising. `Count` and `Limit` still describe the
**page**, so `eventsMaxLimit` still binds and the wire contract never reports
1001. `eventsMaxLimit` itself is untouched — it is also `sqlPanelMaxRows` and
the MCP `QueryMaxLimit`, so raising it here would silently raise two unrelated
surfaces. The UI replaces the page rather than appending, so a browser holds one
page at a time.

## Export: the whole filtered set, not the page — and the UI says so

**Decision: `Export JSON` / `Export CSV` export every match of the current
search (up to the endpoint's existing 1000 cap), not the page on screen.**

Rationale. Once the view pages, "export what is rendered" means an operator who
filtered to one table, walked four pages of an incident and hit Export silently
gets a quarter of their evidence — worse than the un-paged behaviour it
replaces, which is the outcome the issue explicitly names. Exporting the whole
filtered set costs one cursor-less request at a limit the endpoint **already
sanctions**, so it grants no capability the caps did not already permit. It
deliberately does **not** loop the cursor to drain the index — that is exactly
how a download button becomes the way to pull an index into a browser.

Said in the UI, not silently: the buttons are labelled `Export JSON` /
`Export CSV` (not the old bare `JSON`/`CSV`) with a scope tooltip, and when a
result comes back at the ceiling the console toasts that the search has more
and suggests narrowing by time rather than handing over a silent prefix.

## The count

`has_more` costs exactly one extra row per fetch, and it is the thing the old
header could not say. It is deliberately **not** a total — a real count means a
`COUNT(*)` over the same window, which is not cheap on a partitioned
multi-source index and is not fabricated here. So the header reads
`showing 1–100 of more — page older for the rest` while paging, and only once
you have walked to the end does it report the exact figure it actually walked:
`showing 6–6 of 6 (end)`.

## Cursor handling

Cursors are opaque `<RFC3339>|<event_id>` tokens minted **server-side from a row
the server actually served**, never built by the client and never taken from the
probe row. The timestamp carries its offset on purpose: a bare wall clock has to
be re-attached to some location on the way back in, and guessing wrong does not
fail — it just returns the wrong page.

A malformed or wrong-direction cursor is a **400**, never a silent fall back to
page 1: that would make Next re-serve the same page forever while the operator
believed they were walking the index. In the frontend the cursor is threaded as
an argument and dropped on every filter edit — the debounced `input` handler
fires on each keystroke, and a cursor from the previous search names a row that
need not exist in the new one.

## Verification

- `go test ./internal/console/... ./internal/query/... ./internal/parquetquery/...` green; `go vet ./...` clean; `gofmt -l` clean on every touched file; `node --check` on `app.js` and the e2e module.
- **`test/console-e2e/run.sh` run for real against headless Chrome + Docker MySQL 8.0.46: 127/127 passed**, including 14 new assertions — page 1/2 disjointness, coverage of all 6 seeded events across the two pages, Prev/Next enablement at both ends, the header naming a position instead of restating the limit, the circular phrasing being gone, the exact total on the last page, filter-edit reset, and an export taken while paged to a 1-row page still carrying all 6 matches.

### Mutation check

15 mutations run; **14 caught**:

| # | mutation | caught by |
|---|---|---|
| 1 | drop the `BeforeEvent` composite cut in `buildQuery` | `TestBuildQuery_beforeEventKeyset` |
| 2 | floor instead of ceil the `TO_SECONDS` pruning hint | `TestBuildQuery_beforeEventKeyset` |
| 3 | drop the `BeforeEvent`+ASC rejection | `TestValidateCursor_direction` |
| 4 | drop the `FetchMergedStream` preset-cursor guard | `TestFetchMergedStream…` |
| 5 | drop the `parquetquery.Fetch` direction guard | `TestFetch_rejectsBackwardCursorWithASC` |
| 6 | drop the archive-side `BeforeEvent` predicate | `TestBuildFilters_beforeEventKeyset` |
| 7 | `untilUpperBoundHint` ignores the cursor | `TestUntilUpperBoundHint_descendsWithCursor` |
| 8 | `scopeArchiveFiles` uses raw `opts.Until` | `TestScopeArchiveFiles_prunesAboveTheCursor` |
| 9 | hardcode `has_more = false` | `TestEventsHasMoreProbe` |
| 10 | report the probe limit instead of the page size | `TestEventsHasMoreProbe`, `TestEventsLimitCapUnchanged`, `TestEventsHandlerIncludesConnectionID` |
| 11 | ignore the cursor query params | `TestEventsBeforeCursorPagesTheIndex`, `TestEventsCursorErrorsAre400` |
| 12 | build the cursor from the probe row, before trimming | `TestEventsHasMoreProbe` |
| 13 | serve the probe row instead of trimming it | `TestEventsHasMoreProbe` |
| 14 | drop the cursor direction rule in `applyEventCursors` | `TestEventsCursorErrorsAre400` |
| 15 | drop the offset from the cursor timestamp | `TestEventCursorRoundTrip` |

**Not caught, reported honestly:** swapping the single S3-branch call from
`scopeArchiveFiles` back to an inline un-tightened `filterFilesByTimeRange`.
That branch needs a live bucket, so no unit test reaches it. The gap is
pre-existing rather than introduced here — mutating the existing `sinceHint`
wiring the same way also leaves the suite green (verified). It is perf-only:
the row-level predicate still makes the exact cut, so a regression there costs
S3 traffic, not correctness. Mutation 8 was added *because* the first pass of
mutation testing found this call site uncovered; the second commit extracts
`scopeArchiveFiles` specifically to make the composition testable.

## Nothing contradicted the issue

The issue's read of the codebase held up: `AfterEvent` is genuinely
DESC-incompatible, `topNSatisfiedLive` genuinely needed checking (and genuinely
survives), and the header was genuinely circular. The one thing worth flagging
is the client-side refine (#966): free-text and unscoped-`pk` terms are still
filtered in the browser over one page, so a refined count remains page-local
and now says `· refined within this page` when it differs from the server's
count. The cursor is always taken from the **server's** last row, never the
refined array, so a refine that drops the boundary row cannot make the next page
skip events.

## Note for the reviewer

The diff to `internal/console/assets/app.js` was kept deliberately small and
localised (a state block, the result-bar buttons, the cursor threading inside
`runEventsQuery`, and three new self-contained functions) because another PR is
editing that file concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
