### PR TITLE
console: say what capture skipped, and make the remedy a button

### DIFF
--- a/consoleapp/monitor.go
+++ b/consoleapp/monitor.go
@@ -610,6 +610,45 @@ func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.
 	}
 }
 
+// ReloadSchema restarts the supervised stream for one entry so it loads the
+// newest schema snapshot (#1296). A stream swaps its metadata resolver only on
+// a DDL event, so a snapshot taken out of band is invisible to it until it
+// restarts — without this, a "refresh the schema snapshot" action would leave
+// capture skipping exactly the tables it was asked to fix.
+//
+// Deliberately NOT Stop+Start. Stop clears the durable gap-loss record as the
+// operator's acknowledgment of permanently lost events; routing a schema
+// refresh through it would erase a data-loss alarm as a side effect of pressing
+// an unrelated button. This cancels the job and relaunches it, leaving
+// stream_state.gap_lost_at untouched — Start then re-hydrates lost_position
+// from it, so the alarm survives.
+//
+// A server this process does not supervise is a no-op success: there is no
+// stream here to reload, and the snapshot it was called for is still valid.
+func (m *monitorSupervisor) ReloadSchema(ctx context.Context, e console.ServerEntry) error {
+	m.mu.Lock()
+	job, ok := m.jobs[e.ID]
+	if ok {
+		delete(m.jobs, e.ID)
+	}
+	m.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	job.cancel()
+	// Wait for the run goroutine to finish: its outermost defer closes done
+	// AFTER releasing the advisory lock, so starting before it lands would make
+	// the new job block on the old one's lock.
+	select {
+	case <-job.done:
+	case <-time.After(15 * time.Second):
+		return errors.New("stream did not stop within 15s; it will finish shutting down in the background — start it again to load the new schema snapshot")
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return m.Start(ctx, e)
+}
+
 // Stop implements console.MonitorController. Idempotent; waits briefly for
 // the stream to flush its final checkpoint. An explicit Stop is also the
 // operator's acknowledgment of a recorded data loss: it clears the durable

--- a/consoleapp/monitor.go
+++ b/consoleapp/monitor.go
@@ -85,6 +85,11 @@ var (
 	monitorBackoffBase  = 15 * time.Second
 	monitorBackoffCap   = 5 * time.Minute
 	monitorHealthyReset = 10 * time.Minute
+	// monitorReloadDrainTimeout: how long ReloadSchema waits for a cancelled
+	// stream to release its advisory lock before giving up. Start's GET_LOCK
+	// has a ZERO timeout, so relaunching early fails outright instead of
+	// queueing — waiting is the only way to hand the lock over.
+	monitorReloadDrainTimeout = 15 * time.Second
 )
 
 // monitorJob is one supervised stream.
@@ -623,9 +628,12 @@ func (m *monitorSupervisor) run(ctx context.Context, job *monitorJob, e console.
 // stream_state.gap_lost_at untouched — Start then re-hydrates lost_position
 // from it, so the alarm survives.
 //
-// A server this process does not supervise is a no-op success: there is no
-// stream here to reload, and the snapshot it was called for is still valid.
-func (m *monitorSupervisor) ReloadSchema(ctx context.Context, e console.ServerEntry) error {
+// reloaded is false with a nil error when this process does not supervise the
+// entry: there is no stream here to reload, which is not an error (the snapshot
+// it was called for is still valid) but must never be reported as a restart —
+// the entry may well be captured by another process, still decoding against the
+// old snapshot.
+func (m *monitorSupervisor) ReloadSchema(ctx context.Context, e console.ServerEntry) (reloaded bool, err error) {
 	m.mu.Lock()
 	job, ok := m.jobs[e.ID]
 	if ok {
@@ -633,20 +641,44 @@ func (m *monitorSupervisor) ReloadSchema(ctx context.Context, e console.ServerEn
 	}
 	m.mu.Unlock()
 	if !ok {
-		return nil
+		return false, nil
+	}
+	// restore re-publishes the job on the paths that do not relaunch. Being
+	// absent from m.jobs is not merely a wrong Status: ActiveJobs feeds the
+	// rotation provider, so a dropped entry stops having its per-source index
+	// archived and pruned — silently, with not even the per-cycle warning a
+	// terminally-failed job keeps producing.
+	restore := func() {
+		m.mu.Lock()
+		if _, taken := m.jobs[e.ID]; !taken {
+			m.jobs[e.ID] = job
+		}
+		m.mu.Unlock()
 	}
 	job.cancel()
-	// Wait for the run goroutine to finish: its outermost defer closes done
-	// AFTER releasing the advisory lock, so starting before it lands would make
-	// the new job block on the old one's lock.
+	// Wait for the run goroutine to finish before relaunching. Its outermost
+	// defer closes done AFTER closing lockDB, and Start takes the advisory lock
+	// with GET_LOCK(name, 0) — a zero timeout. Starting early would therefore
+	// not queue behind the dying stream, it would FAIL to get the lock and mark
+	// the new job terminally failed, with no retry loop to converge later.
+	//
+	// The two non-success branches leave this entry's capture STOPPED: the job
+	// is already cancelled and unpublished, and nothing here restarts it. That
+	// is reported, not smoothed over — an operator who pressed a refresh button
+	// must not be left believing capture is running when it is not.
 	select {
 	case <-job.done:
-	case <-time.After(15 * time.Second):
-		return errors.New("stream did not stop within 15s; it will finish shutting down in the background — start it again to load the new schema snapshot")
+	case <-time.After(monitorReloadDrainTimeout):
+		restore()
+		return false, errors.New("the stream did not stop in time, so capture for this server is now stopping and was NOT restarted; it is still shutting down in the background — press Start once it has, to resume on the new schema snapshot")
 	case <-ctx.Done():
-		return ctx.Err()
+		restore()
+		return false, fmt.Errorf("capture for this server was stopped and could not be restarted: %w", ctx.Err())
 	}
-	return m.Start(ctx, e)
+	if err := m.Start(ctx, e); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // Stop implements console.MonitorController. Idempotent; waits briefly for

--- a/consoleapp/schema_snapshot.go
+++ b/consoleapp/schema_snapshot.go
@@ -1,0 +1,164 @@
+package consoleapp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+)
+
+// schemaSnapshotSupervisor implements console.SchemaSnapshotController: it
+// re-reads a monitored source's column layout into that source's index and then
+// puts the running capture stream onto the result (#1296).
+//
+// The reload half is the point. A stream holds its metadata resolver in memory
+// and swaps it only when it decodes a DDL event, so a snapshot written into the
+// index underneath a running stream changes NOTHING — the stream keeps decoding
+// against the layout it loaded at startup and keeps skipping the same table. A
+// "refresh" button without the reload would look like a fix and be a no-op,
+// which is a worse failure than the missing button this replaces.
+type schemaSnapshotSupervisor struct {
+	ctx context.Context // daemon lifecycle; bounds the snapshot query
+
+	// reload restarts the supervised stream for one entry so it loads the
+	// snapshot just written. nil is allowed (tests, and any wiring with no
+	// control plane) and reports StreamReloaded=false rather than pretending.
+	reload func(ctx context.Context, entryID string) error
+
+	// snapshotFn takes the snapshot itself — a seam, like monitorSupervisor's
+	// streamFn: production connects to both DSNs and calls
+	// metadata.TakeSnapshotExcludingInvalid, tests substitute a stub so the
+	// reload contract can be exercised without a live MySQL.
+	snapshotFn func(req console.SchemaSnapshotRequest) (metadata.SnapshotStats, error)
+
+	mu   sync.Mutex
+	jobs map[string]*console.SchemaSnapshotStatus
+}
+
+// reloadStreamSchema binds the snapshot supervisor's reload hook to the monitor
+// supervisor. The lookup happens at reload time, not at wiring time: the entry
+// may have been edited (or deleted) between the daemon starting and the button
+// being pressed, and Start needs the CURRENT entry.
+func reloadStreamSchema(sup *monitorSupervisor, reg *console.Registry) func(context.Context, string) error {
+	return func(ctx context.Context, entryID string) error {
+		e, ok := reg.Get(entryID)
+		if !ok {
+			return fmt.Errorf("server %q is no longer in the registry", entryID)
+		}
+		return sup.ReloadSchema(ctx, e)
+	}
+}
+
+func newSchemaSnapshotSupervisor(ctx context.Context, reload func(context.Context, string) error) *schemaSnapshotSupervisor {
+	return &schemaSnapshotSupervisor{
+		ctx:        ctx,
+		reload:     reload,
+		snapshotFn: takeSchemaSnapshot,
+		jobs:       make(map[string]*console.SchemaSnapshotStatus),
+	}
+}
+
+// takeSchemaSnapshot is the production snapshot step: connect to the source and
+// the entry's index, then re-read the column layout.
+//
+// ExcludingInvalid matches the stream's own DDL hook: one PK-less table must not
+// reject the whole snapshot and leave capture running on the stale one. The
+// excluded names come back in the stats so the caller can report them — a
+// "succeeded" that silently omits the tables that will KEEP being skipped is
+// the same half-truth this issue is about.
+func takeSchemaSnapshot(req console.SchemaSnapshotRequest) (metadata.SnapshotStats, error) {
+	sourceDB, err := config.Connect(req.SourceDSN)
+	if err != nil {
+		return metadata.SnapshotStats{}, err
+	}
+	defer sourceDB.Close()
+	indexDB, err := config.Connect(req.IndexDSN)
+	if err != nil {
+		return metadata.SnapshotStats{}, err
+	}
+	defer indexDB.Close()
+	return metadata.TakeSnapshotExcludingInvalid(sourceDB, indexDB, req.Schemas)
+}
+
+// Trigger starts a snapshot in the background; returns
+// console.ErrSchemaSnapshotRunning when one is already in flight for this
+// server. One at a time per server: two concurrent runs would race to restart
+// the same stream.
+func (s *schemaSnapshotSupervisor) Trigger(req console.SchemaSnapshotRequest) error {
+	s.mu.Lock()
+	if st, ok := s.jobs[req.ServerID]; ok && st.State == "running" {
+		s.mu.Unlock()
+		return console.ErrSchemaSnapshotRunning
+	}
+	s.jobs[req.ServerID] = &console.SchemaSnapshotStatus{State: "running", Since: nowStamp()}
+	s.mu.Unlock()
+
+	slog.Info("schema snapshot: refreshing from the source", "server", req.ServerName, "id", req.ServerID)
+	go s.run(req)
+	return nil
+}
+
+// Status returns a copy of the latest known job state (idle if none ran here).
+func (s *schemaSnapshotSupervisor) Status(serverID string) console.SchemaSnapshotStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if st, ok := s.jobs[serverID]; ok {
+		return *st
+	}
+	return console.SchemaSnapshotStatus{State: "idle"}
+}
+
+func (s *schemaSnapshotSupervisor) run(req console.SchemaSnapshotRequest) {
+	st, err := s.execute(req)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prev := s.jobs[req.ServerID]
+	st.Since = ""
+	if prev != nil {
+		st.Since = prev.Since
+	}
+	st.FinishedAt = nowStamp()
+	if err != nil {
+		// Scrub both DSNs: this string is served over HTTP, and a driver error
+		// commonly embeds the whole connection string, password included.
+		st.State = "failed"
+		st.LastError = config.ScrubDSNError(err, req.SourceDSN, req.IndexDSN)
+		slog.Warn("schema snapshot failed", "server", req.ServerName, "id", req.ServerID, "error", st.LastError)
+	}
+	s.jobs[req.ServerID] = &st
+}
+
+// execute does the work: snapshot, then reload the stream. A reload failure is
+// NOT a job failure — the snapshot is durable and correct, capture is simply
+// still running on the old one — so it is reported in its own field with the
+// state left "succeeded". Folding it into LastError would hide that the
+// snapshot itself worked and invite the operator to run it again.
+func (s *schemaSnapshotSupervisor) execute(req console.SchemaSnapshotRequest) (console.SchemaSnapshotStatus, error) {
+	st := console.SchemaSnapshotStatus{State: "succeeded"}
+
+	stats, err := s.snapshotFn(req)
+	if err != nil {
+		return st, err
+	}
+	st.SnapshotID, st.Tables, st.ExcludedTables = stats.SnapshotID, stats.TableCount, stats.ExcludedTables
+	slog.Info("schema snapshot taken", "server", req.ServerName, "snapshot_id", stats.SnapshotID,
+		"tables", stats.TableCount, "excluded_tables", strings.Join(stats.ExcludedTables, ", "))
+
+	if s.reload == nil {
+		st.ReloadError = "this process does not supervise the stream for this server; restart its capture to pick the new snapshot up"
+		return st, nil
+	}
+	if err := s.reload(s.ctx, req.ServerID); err != nil {
+		st.ReloadError = config.ScrubDSNError(err, req.SourceDSN, req.IndexDSN)
+		slog.Warn("schema snapshot: stream did not reload; capture is still using the previous snapshot",
+			"server", req.ServerName, "id", req.ServerID, "error", st.ReloadError)
+		return st, nil
+	}
+	st.StreamReloaded = true
+	return st, nil
+}

--- a/consoleapp/schema_snapshot.go
+++ b/consoleapp/schema_snapshot.go
@@ -41,6 +41,13 @@ type schemaSnapshotSupervisor struct {
 	// reload contract can be exercised without a live MySQL.
 	snapshotFn func(req console.SchemaSnapshotRequest) (metadata.SnapshotStats, error)
 
+	// timeout bounds one job. Per-supervisor rather than a package var so a
+	// test that shrinks it touches only its own instance: a global is read by
+	// the job goroutine of every OTHER test in the package, and those outlive
+	// the test that spawned them, so writing one is a data race that -race
+	// catches and a plain `go test` does not.
+	timeout time.Duration
+
 	mu   sync.Mutex
 	jobs map[string]*console.SchemaSnapshotStatus
 	// gens counts triggered runs PER SERVER. A run whose generation is no
@@ -65,22 +72,24 @@ func reloadStreamSchema(sup *monitorSupervisor, reg *console.Registry) func(cont
 	}
 }
 
-// schemaSnapshotTimeout bounds one job. A var so tests can shrink it.
+// defaultSchemaSnapshotTimeout is what a supervisor gets unless a caller
+// narrows it.
 //
-// It exists because the snapshot itself cannot be cancelled: metadata's
+// A bound exists because the snapshot itself cannot be cancelled: metadata's
 // snapshot taker holds no context, and config.Connect's timeout covers only the
 // TCP handshake — a source whose information_schema read blocks behind a
 // metadata lock hangs the job forever. Without a deadline the job stays
 // "running" for the life of the process, every later Trigger answers 409, and
 // the only recovery is a daemon restart: an endpoint permanently unable to do
 // the thing it exists for.
-var schemaSnapshotTimeout = 10 * time.Minute
+const defaultSchemaSnapshotTimeout = 10 * time.Minute
 
 func newSchemaSnapshotSupervisor(ctx context.Context, reload func(context.Context, string) (bool, error)) *schemaSnapshotSupervisor {
 	return &schemaSnapshotSupervisor{
 		ctx:        ctx,
 		reload:     reload,
 		snapshotFn: takeSchemaSnapshot,
+		timeout:    defaultSchemaSnapshotTimeout,
 		jobs:       make(map[string]*console.SchemaSnapshotStatus),
 		gens:       make(map[string]uint64),
 	}
@@ -138,7 +147,7 @@ func (s *schemaSnapshotSupervisor) Status(serverID string) console.SchemaSnapsho
 	return console.SchemaSnapshotStatus{State: "idle"}
 }
 
-// run executes one job under schemaSnapshotTimeout. On timeout the job is
+// run executes one job under s.timeout. On timeout the job is
 // reported failed so the endpoint becomes usable again; the abandoned goroutine
 // cannot corrupt anything after that, because publish drops a result from a
 // superseded generation and execute declines to restart a stream it no longer
@@ -156,11 +165,11 @@ func (s *schemaSnapshotSupervisor) run(req console.SchemaSnapshotRequest, gen ui
 	select {
 	case o := <-done:
 		s.publish(req, gen, o.st, o.err)
-	case <-time.After(schemaSnapshotTimeout):
+	case <-time.After(s.timeout):
 		slog.Warn("schema snapshot timed out; the attempt may still be finishing in the background",
-			"server", req.ServerName, "id", req.ServerID, "timeout", schemaSnapshotTimeout)
+			"server", req.ServerName, "id", req.ServerID, "timeout", s.timeout)
 		s.publish(req, gen, console.SchemaSnapshotStatus{},
-			fmt.Errorf("the source did not answer within %s; it may be holding a metadata lock. The attempt may still finish in the background — capture was not restarted", schemaSnapshotTimeout))
+			fmt.Errorf("the source did not answer within %s; it may be holding a metadata lock. The attempt may still finish in the background — capture was not restarted", s.timeout))
 	case <-s.ctx.Done():
 		s.publish(req, gen, console.SchemaSnapshotStatus{}, errors.New("the daemon is shutting down; capture was not restarted"))
 	}

--- a/consoleapp/schema_snapshot.go
+++ b/consoleapp/schema_snapshot.go
@@ -2,10 +2,12 @@ package consoleapp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/dbtrail/dbtrail/internal/config"
 	"github.com/dbtrail/dbtrail/internal/console"
@@ -23,12 +25,15 @@ import (
 // "refresh" button without the reload would look like a fix and be a no-op,
 // which is a worse failure than the missing button this replaces.
 type schemaSnapshotSupervisor struct {
-	ctx context.Context // daemon lifecycle; bounds the snapshot query
+	ctx context.Context // daemon lifecycle; cancels an in-flight job on shutdown
 
 	// reload restarts the supervised stream for one entry so it loads the
-	// snapshot just written. nil is allowed (tests, and any wiring with no
-	// control plane) and reports StreamReloaded=false rather than pretending.
-	reload func(ctx context.Context, entryID string) error
+	// snapshot just written, reporting whether it ACTUALLY restarted one. A
+	// false with no error means this process supervises no stream for that
+	// entry — which must never render as a restart: the entry may be captured
+	// by another process, still decoding against the old snapshot. nil is
+	// allowed (tests, and any wiring with no control plane).
+	reload func(ctx context.Context, entryID string) (bool, error)
 
 	// snapshotFn takes the snapshot itself — a seam, like monitorSupervisor's
 	// streamFn: production connects to both DSNs and calls
@@ -38,28 +43,46 @@ type schemaSnapshotSupervisor struct {
 
 	mu   sync.Mutex
 	jobs map[string]*console.SchemaSnapshotStatus
+	// gens counts triggered runs PER SERVER. A run whose generation is no
+	// longer its server's current one has been superseded (its predecessor
+	// timed out and the operator retried) and must neither publish its outcome
+	// nor restart a stream. Per-server, not global: one counter would let a
+	// snapshot on server B silently abandon an in-flight one on server A.
+	gens map[string]uint64
 }
 
 // reloadStreamSchema binds the snapshot supervisor's reload hook to the monitor
 // supervisor. The lookup happens at reload time, not at wiring time: the entry
 // may have been edited (or deleted) between the daemon starting and the button
 // being pressed, and Start needs the CURRENT entry.
-func reloadStreamSchema(sup *monitorSupervisor, reg *console.Registry) func(context.Context, string) error {
-	return func(ctx context.Context, entryID string) error {
+func reloadStreamSchema(sup *monitorSupervisor, reg *console.Registry) func(context.Context, string) (bool, error) {
+	return func(ctx context.Context, entryID string) (bool, error) {
 		e, ok := reg.Get(entryID)
 		if !ok {
-			return fmt.Errorf("server %q is no longer in the registry", entryID)
+			return false, fmt.Errorf("server %q is no longer in the registry", entryID)
 		}
 		return sup.ReloadSchema(ctx, e)
 	}
 }
 
-func newSchemaSnapshotSupervisor(ctx context.Context, reload func(context.Context, string) error) *schemaSnapshotSupervisor {
+// schemaSnapshotTimeout bounds one job. A var so tests can shrink it.
+//
+// It exists because the snapshot itself cannot be cancelled: metadata's
+// snapshot taker holds no context, and config.Connect's timeout covers only the
+// TCP handshake — a source whose information_schema read blocks behind a
+// metadata lock hangs the job forever. Without a deadline the job stays
+// "running" for the life of the process, every later Trigger answers 409, and
+// the only recovery is a daemon restart: an endpoint permanently unable to do
+// the thing it exists for.
+var schemaSnapshotTimeout = 10 * time.Minute
+
+func newSchemaSnapshotSupervisor(ctx context.Context, reload func(context.Context, string) (bool, error)) *schemaSnapshotSupervisor {
 	return &schemaSnapshotSupervisor{
 		ctx:        ctx,
 		reload:     reload,
 		snapshotFn: takeSchemaSnapshot,
 		jobs:       make(map[string]*console.SchemaSnapshotStatus),
+		gens:       make(map[string]uint64),
 	}
 }
 
@@ -96,10 +119,12 @@ func (s *schemaSnapshotSupervisor) Trigger(req console.SchemaSnapshotRequest) er
 		return console.ErrSchemaSnapshotRunning
 	}
 	s.jobs[req.ServerID] = &console.SchemaSnapshotStatus{State: "running", Since: nowStamp()}
+	s.gens[req.ServerID]++
+	gen := s.gens[req.ServerID]
 	s.mu.Unlock()
 
 	slog.Info("schema snapshot: refreshing from the source", "server", req.ServerName, "id", req.ServerID)
-	go s.run(req)
+	go s.run(req, gen)
 	return nil
 }
 
@@ -113,10 +138,43 @@ func (s *schemaSnapshotSupervisor) Status(serverID string) console.SchemaSnapsho
 	return console.SchemaSnapshotStatus{State: "idle"}
 }
 
-func (s *schemaSnapshotSupervisor) run(req console.SchemaSnapshotRequest) {
-	st, err := s.execute(req)
+// run executes one job under schemaSnapshotTimeout. On timeout the job is
+// reported failed so the endpoint becomes usable again; the abandoned goroutine
+// cannot corrupt anything after that, because publish drops a result from a
+// superseded generation and execute declines to restart a stream it no longer
+// owns.
+func (s *schemaSnapshotSupervisor) run(req console.SchemaSnapshotRequest, gen uint64) {
+	type outcome struct {
+		st  console.SchemaSnapshotStatus
+		err error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		st, err := s.execute(req, gen)
+		done <- outcome{st, err}
+	}()
+	select {
+	case o := <-done:
+		s.publish(req, gen, o.st, o.err)
+	case <-time.After(schemaSnapshotTimeout):
+		slog.Warn("schema snapshot timed out; the attempt may still be finishing in the background",
+			"server", req.ServerName, "id", req.ServerID, "timeout", schemaSnapshotTimeout)
+		s.publish(req, gen, console.SchemaSnapshotStatus{},
+			fmt.Errorf("the source did not answer within %s; it may be holding a metadata lock. The attempt may still finish in the background — capture was not restarted", schemaSnapshotTimeout))
+	case <-s.ctx.Done():
+		s.publish(req, gen, console.SchemaSnapshotStatus{}, errors.New("the daemon is shutting down; capture was not restarted"))
+	}
+}
+
+// publish records a job's outcome, unless a newer run for this server has
+// already superseded it — a late finisher must not overwrite the newer job's
+// state (or resurrect a "succeeded" over it).
+func (s *schemaSnapshotSupervisor) publish(req console.SchemaSnapshotRequest, gen uint64, st console.SchemaSnapshotStatus, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.gens[req.ServerID] != gen {
+		return
+	}
 	prev := s.jobs[req.ServerID]
 	st.Since = ""
 	if prev != nil {
@@ -138,7 +196,7 @@ func (s *schemaSnapshotSupervisor) run(req console.SchemaSnapshotRequest) {
 // still running on the old one — so it is reported in its own field with the
 // state left "succeeded". Folding it into LastError would hide that the
 // snapshot itself worked and invite the operator to run it again.
-func (s *schemaSnapshotSupervisor) execute(req console.SchemaSnapshotRequest) (console.SchemaSnapshotStatus, error) {
+func (s *schemaSnapshotSupervisor) execute(req console.SchemaSnapshotRequest, gen uint64) (console.SchemaSnapshotStatus, error) {
 	st := console.SchemaSnapshotStatus{State: "succeeded"}
 
 	stats, err := s.snapshotFn(req)
@@ -150,15 +208,41 @@ func (s *schemaSnapshotSupervisor) execute(req console.SchemaSnapshotRequest) (c
 		"tables", stats.TableCount, "excluded_tables", strings.Join(stats.ExcludedTables, ", "))
 
 	if s.reload == nil {
-		st.ReloadError = "this process does not supervise the stream for this server; restart its capture to pick the new snapshot up"
+		st.ReloadError = notSupervisedNote
 		return st, nil
 	}
-	if err := s.reload(s.ctx, req.ServerID); err != nil {
+	if s.superseded(req.ServerID, gen) {
+		// This run timed out and the operator retried: a newer run owns the
+		// stream now. Restarting it here would fight that one.
+		st.ReloadError = "this attempt was superseded by a newer one; capture was not restarted by it"
+		return st, nil
+	}
+	reloaded, err := s.reload(s.ctx, req.ServerID)
+	if err != nil {
 		st.ReloadError = config.ScrubDSNError(err, req.SourceDSN, req.IndexDSN)
-		slog.Warn("schema snapshot: stream did not reload; capture is still using the previous snapshot",
+		slog.Warn("schema snapshot: the capture stream was not restarted onto the new snapshot",
 			"server", req.ServerName, "id", req.ServerID, "error", st.ReloadError)
+		return st, nil
+	}
+	if !reloaded {
+		// No stream here to restart. Never report this as a reload: whoever
+		// captures this source is still on the previous snapshot.
+		st.ReloadError = notSupervisedNote
 		return st, nil
 	}
 	st.StreamReloaded = true
 	return st, nil
+}
+
+// notSupervisedNote is what an operator is told when no stream was restarted
+// here. It states the consequence (capture is still on the old snapshot)
+// because that is the difference between a fix and a durable no-op.
+const notSupervisedNote = "this process does not supervise capture for this server, so nothing was restarted; " +
+	"restart whatever captures it to pick the new snapshot up"
+
+// superseded reports whether a newer run for the same server has started.
+func (s *schemaSnapshotSupervisor) superseded(serverID string, gen uint64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.gens[serverID] != gen
 }

--- a/consoleapp/schema_snapshot_test.go
+++ b/consoleapp/schema_snapshot_test.go
@@ -1,0 +1,155 @@
+package consoleapp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+)
+
+// ─── Refresh schema snapshot: the supervisor (#1296) ─────────────────────────
+//
+// The reload is the load-bearing half. A stream holds its resolver in memory
+// and swaps it only on a DDL event, so a snapshot written underneath a running
+// stream changes nothing: without the reload this feature is a button that
+// reports success and fixes the problem it was pressed for exactly never.
+
+func testSnapshotSupervisor(t *testing.T, snap func(console.SchemaSnapshotRequest) (metadata.SnapshotStats, error), reload func(context.Context, string) error) *schemaSnapshotSupervisor {
+	t.Helper()
+	s := newSchemaSnapshotSupervisor(context.Background(), reload)
+	s.snapshotFn = snap
+	return s
+}
+
+func okSnapshot(console.SchemaSnapshotRequest) (metadata.SnapshotStats, error) {
+	return metadata.SnapshotStats{SnapshotID: 7, TableCount: 12}, nil
+}
+
+func TestSchemaSnapshotSupervisor_reloadsTheStream(t *testing.T) {
+	var reloaded []string
+	s := testSnapshotSupervisor(t, okSnapshot, func(_ context.Context, id string) error {
+		reloaded = append(reloaded, id)
+		return nil
+	})
+	st, err := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(reloaded) != 1 || reloaded[0] != "srv-1" {
+		t.Fatalf("the stream was not reloaded onto the new snapshot: %v", reloaded)
+	}
+	if !st.StreamReloaded {
+		t.Error("stream_reloaded must be true once the stream restarted")
+	}
+	if st.State != "succeeded" || st.SnapshotID != 7 || st.Tables != 12 {
+		t.Errorf("snapshot result not reported: %+v", st)
+	}
+}
+
+// A failed reload is NOT a failed snapshot: the snapshot is durable, capture is
+// simply still on the old one. Reporting it as a failure would hide that the
+// snapshot worked; reporting it as a plain success would hide that nothing is
+// fixed yet.
+func TestSchemaSnapshotSupervisor_reloadFailureIsReportedNotSwallowed(t *testing.T) {
+	s := testSnapshotSupervisor(t, okSnapshot, func(context.Context, string) error {
+		return errors.New("stream did not stop within 15s")
+	})
+	st, err := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"})
+	if err != nil {
+		t.Fatalf("a reload failure must not fail the job: %v", err)
+	}
+	if st.StreamReloaded {
+		t.Error("stream_reloaded must stay false when the reload failed")
+	}
+	if !strings.Contains(st.ReloadError, "did not stop") {
+		t.Errorf("reload_error = %q, want the reload's own error", st.ReloadError)
+	}
+	if st.State != "succeeded" {
+		t.Errorf("state = %q; the snapshot itself succeeded", st.State)
+	}
+}
+
+// With no reload hook the process does not supervise this stream. Saying so is
+// the point: silence would read as "capture is on the new snapshot".
+func TestSchemaSnapshotSupervisor_withoutReloadSaysCaptureIsUnchanged(t *testing.T) {
+	s := testSnapshotSupervisor(t, okSnapshot, nil)
+	st, _ := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"})
+	if st.StreamReloaded {
+		t.Error("stream_reloaded must be false with no supervised stream")
+	}
+	if !strings.Contains(st.ReloadError, "restart its capture") {
+		t.Errorf("reload_error = %q, want an actionable note", st.ReloadError)
+	}
+}
+
+// A failed snapshot must never reload the stream: restarting capture would be a
+// side effect the operator did not ask for and gains nothing.
+func TestSchemaSnapshotSupervisor_snapshotFailureSkipsTheReload(t *testing.T) {
+	reloads := 0
+	s := testSnapshotSupervisor(t,
+		func(console.SchemaSnapshotRequest) (metadata.SnapshotStats, error) {
+			return metadata.SnapshotStats{}, errors.New("source unreachable")
+		},
+		func(context.Context, string) error { reloads++; return nil })
+	_, err := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"})
+	if err == nil {
+		t.Fatal("a failed snapshot must be reported as an error")
+	}
+	if reloads != 0 {
+		t.Error("a failed snapshot must not restart capture")
+	}
+}
+
+// Tables validation excluded stay uncaptured after this run; the operator has
+// to learn that from the result, not from the next degraded banner.
+func TestSchemaSnapshotSupervisor_reportsExcludedTables(t *testing.T) {
+	s := testSnapshotSupervisor(t, func(console.SchemaSnapshotRequest) (metadata.SnapshotStats, error) {
+		return metadata.SnapshotStats{SnapshotID: 8, TableCount: 3, ExcludedTables: []string{"shop.audit_raw"}}, nil
+	}, func(context.Context, string) error { return nil })
+	st, _ := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"})
+	if len(st.ExcludedTables) != 1 || st.ExcludedTables[0] != "shop.audit_raw" {
+		t.Errorf("excluded tables not reported: %+v", st)
+	}
+}
+
+// One run at a time per server: two concurrent runs would race to restart the
+// same stream.
+func TestSchemaSnapshotSupervisor_singleFlightPerServer(t *testing.T) {
+	release := make(chan struct{})
+	s := testSnapshotSupervisor(t, func(console.SchemaSnapshotRequest) (metadata.SnapshotStats, error) {
+		<-release
+		return metadata.SnapshotStats{}, nil
+	}, func(context.Context, string) error { return nil })
+	if err := s.Trigger(console.SchemaSnapshotRequest{ServerID: "srv-1"}); err != nil {
+		t.Fatalf("first trigger: %v", err)
+	}
+	if err := s.Trigger(console.SchemaSnapshotRequest{ServerID: "srv-1"}); !errors.Is(err, console.ErrSchemaSnapshotRunning) {
+		t.Errorf("second trigger err = %v, want ErrSchemaSnapshotRunning", err)
+	}
+	// A different server is unaffected.
+	if err := s.Trigger(console.SchemaSnapshotRequest{ServerID: "srv-2"}); err != nil {
+		t.Errorf("another server must not be blocked: %v", err)
+	}
+	close(release)
+}
+
+func TestSchemaSnapshotSupervisor_statusIsIdleBeforeAnyRun(t *testing.T) {
+	s := testSnapshotSupervisor(t, okSnapshot, nil)
+	if got := s.Status("never-run"); got.State != "idle" {
+		t.Errorf("state = %q, want idle", got.State)
+	}
+}
+
+// ReloadSchema on a server this process does not supervise is a no-op success:
+// there is no stream here to reload and the snapshot it was called for is
+// still valid. (The supervised path needs a live index and is covered by the
+// monitor integration tests.)
+func TestMonitorReloadSchema_unsupervisedEntryIsNoOp(t *testing.T) {
+	m := &monitorSupervisor{baseCtx: context.Background(), jobs: map[string]*monitorJob{}}
+	if err := m.ReloadSchema(context.Background(), console.ServerEntry{ID: "not-here"}); err != nil {
+		t.Errorf("unsupervised entry: %v, want nil", err)
+	}
+}

--- a/consoleapp/schema_snapshot_test.go
+++ b/consoleapp/schema_snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/metadata"
@@ -17,7 +18,7 @@ import (
 // stream changes nothing: without the reload this feature is a button that
 // reports success and fixes the problem it was pressed for exactly never.
 
-func testSnapshotSupervisor(t *testing.T, snap func(console.SchemaSnapshotRequest) (metadata.SnapshotStats, error), reload func(context.Context, string) error) *schemaSnapshotSupervisor {
+func testSnapshotSupervisor(t *testing.T, snap func(console.SchemaSnapshotRequest) (metadata.SnapshotStats, error), reload func(context.Context, string) (bool, error)) *schemaSnapshotSupervisor {
 	t.Helper()
 	s := newSchemaSnapshotSupervisor(context.Background(), reload)
 	s.snapshotFn = snap
@@ -30,11 +31,11 @@ func okSnapshot(console.SchemaSnapshotRequest) (metadata.SnapshotStats, error) {
 
 func TestSchemaSnapshotSupervisor_reloadsTheStream(t *testing.T) {
 	var reloaded []string
-	s := testSnapshotSupervisor(t, okSnapshot, func(_ context.Context, id string) error {
+	s := testSnapshotSupervisor(t, okSnapshot, func(_ context.Context, id string) (bool, error) {
 		reloaded = append(reloaded, id)
-		return nil
+		return true, nil
 	})
-	st, err := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"})
+	st, err := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"}, 0)
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
@@ -54,10 +55,10 @@ func TestSchemaSnapshotSupervisor_reloadsTheStream(t *testing.T) {
 // snapshot worked; reporting it as a plain success would hide that nothing is
 // fixed yet.
 func TestSchemaSnapshotSupervisor_reloadFailureIsReportedNotSwallowed(t *testing.T) {
-	s := testSnapshotSupervisor(t, okSnapshot, func(context.Context, string) error {
-		return errors.New("stream did not stop within 15s")
+	s := testSnapshotSupervisor(t, okSnapshot, func(context.Context, string) (bool, error) {
+		return false, errors.New("stream did not stop within 15s")
 	})
-	st, err := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"})
+	st, err := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"}, 0)
 	if err != nil {
 		t.Fatalf("a reload failure must not fail the job: %v", err)
 	}
@@ -76,12 +77,32 @@ func TestSchemaSnapshotSupervisor_reloadFailureIsReportedNotSwallowed(t *testing
 // the point: silence would read as "capture is on the new snapshot".
 func TestSchemaSnapshotSupervisor_withoutReloadSaysCaptureIsUnchanged(t *testing.T) {
 	s := testSnapshotSupervisor(t, okSnapshot, nil)
-	st, _ := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"})
+	st, _ := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"}, 0)
 	if st.StreamReloaded {
 		t.Error("stream_reloaded must be false with no supervised stream")
 	}
-	if !strings.Contains(st.ReloadError, "restart its capture") {
+	if !strings.Contains(st.ReloadError, "nothing was restarted") {
 		t.Errorf("reload_error = %q, want an actionable note", st.ReloadError)
+	}
+}
+
+// The entry may be captured by ANOTHER process: the reload hook reports "no
+// stream here" and that must never render as a restart, or the operator is told
+// capture is on the new snapshot while it is still decoding against the old one
+// — the silent no-op stream_reloaded exists to prevent.
+func TestSchemaSnapshotSupervisor_noStreamHereIsNotAReload(t *testing.T) {
+	s := testSnapshotSupervisor(t, okSnapshot, func(context.Context, string) (bool, error) {
+		return false, nil // supervised elsewhere (or not at all)
+	})
+	st, err := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"}, 0)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if st.StreamReloaded {
+		t.Error("stream_reloaded must stay false when no stream was restarted here")
+	}
+	if !strings.Contains(st.ReloadError, "nothing was restarted") {
+		t.Errorf("reload_error = %q, want the not-supervised note", st.ReloadError)
 	}
 }
 
@@ -93,8 +114,8 @@ func TestSchemaSnapshotSupervisor_snapshotFailureSkipsTheReload(t *testing.T) {
 		func(console.SchemaSnapshotRequest) (metadata.SnapshotStats, error) {
 			return metadata.SnapshotStats{}, errors.New("source unreachable")
 		},
-		func(context.Context, string) error { reloads++; return nil })
-	_, err := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"})
+		func(context.Context, string) (bool, error) { reloads++; return true, nil })
+	_, err := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"}, 0)
 	if err == nil {
 		t.Fatal("a failed snapshot must be reported as an error")
 	}
@@ -108,8 +129,8 @@ func TestSchemaSnapshotSupervisor_snapshotFailureSkipsTheReload(t *testing.T) {
 func TestSchemaSnapshotSupervisor_reportsExcludedTables(t *testing.T) {
 	s := testSnapshotSupervisor(t, func(console.SchemaSnapshotRequest) (metadata.SnapshotStats, error) {
 		return metadata.SnapshotStats{SnapshotID: 8, TableCount: 3, ExcludedTables: []string{"shop.audit_raw"}}, nil
-	}, func(context.Context, string) error { return nil })
-	st, _ := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"})
+	}, func(context.Context, string) (bool, error) { return true, nil })
+	st, _ := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"}, 0)
 	if len(st.ExcludedTables) != 1 || st.ExcludedTables[0] != "shop.audit_raw" {
 		t.Errorf("excluded tables not reported: %+v", st)
 	}
@@ -122,7 +143,7 @@ func TestSchemaSnapshotSupervisor_singleFlightPerServer(t *testing.T) {
 	s := testSnapshotSupervisor(t, func(console.SchemaSnapshotRequest) (metadata.SnapshotStats, error) {
 		<-release
 		return metadata.SnapshotStats{}, nil
-	}, func(context.Context, string) error { return nil })
+	}, func(context.Context, string) (bool, error) { return true, nil })
 	if err := s.Trigger(console.SchemaSnapshotRequest{ServerID: "srv-1"}); err != nil {
 		t.Fatalf("first trigger: %v", err)
 	}
@@ -145,11 +166,114 @@ func TestSchemaSnapshotSupervisor_statusIsIdleBeforeAnyRun(t *testing.T) {
 
 // ReloadSchema on a server this process does not supervise is a no-op success:
 // there is no stream here to reload and the snapshot it was called for is
-// still valid. (The supervised path needs a live index and is covered by the
-// monitor integration tests.)
+// still valid. (The supervised happy path needs a live index and is covered by
+// the monitor integration tests.)
 func TestMonitorReloadSchema_unsupervisedEntryIsNoOp(t *testing.T) {
 	m := &monitorSupervisor{baseCtx: context.Background(), jobs: map[string]*monitorJob{}}
-	if err := m.ReloadSchema(context.Background(), console.ServerEntry{ID: "not-here"}); err != nil {
+	reloaded, err := m.ReloadSchema(context.Background(), console.ServerEntry{ID: "not-here"})
+	if err != nil {
 		t.Errorf("unsupervised entry: %v, want nil", err)
+	}
+	if reloaded {
+		t.Error("reloaded must be false when there was no stream here to reload")
+	}
+}
+
+// A stream that does not drain within the timeout is NOT restarted, and the
+// operator is told so. The job entry must be put back: ActiveJobs feeds the
+// rotation provider, so an entry silently dropped from the map stops having its
+// per-source index archived and pruned — with no warning anywhere.
+func TestMonitorReloadSchema_undrainedStreamIsReportedAndKeepsTheJob(t *testing.T) {
+	prev := monitorReloadDrainTimeout
+	monitorReloadDrainTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { monitorReloadDrainTimeout = prev })
+
+	cancelled := false
+	job := &monitorJob{cancel: func() { cancelled = true }, done: make(chan struct{})} // never closed
+	m := &monitorSupervisor{baseCtx: context.Background(), jobs: map[string]*monitorJob{"srv-1": job}}
+
+	reloaded, err := m.ReloadSchema(context.Background(), console.ServerEntry{ID: "srv-1"})
+	if reloaded {
+		t.Error("a stream that never stopped was not reloaded")
+	}
+	if err == nil {
+		t.Fatal("an undrained stream must be reported, not silently accepted")
+	}
+	if !strings.Contains(err.Error(), "NOT restarted") {
+		t.Errorf("error = %q; it must say capture was not restarted", err)
+	}
+	if !cancelled {
+		t.Error("the old stream must have been cancelled")
+	}
+	if got := m.jobs["srv-1"]; got != job {
+		t.Error("the job must be put back — dropping it removes this source from rotation coverage with no warning")
+	}
+}
+
+// A snapshot that never returns must not wedge the endpoint. metadata's
+// snapshot taker holds no context and config.Connect's timeout covers only the
+// TCP handshake, so a source blocked behind a metadata lock hangs the job — and
+// a job stuck in "running" makes every later Trigger answer 409 for the life of
+// the process, with a daemon restart the only way out.
+func TestSchemaSnapshotSupervisor_timeoutFreesTheEndpoint(t *testing.T) {
+	prev := schemaSnapshotTimeout
+	schemaSnapshotTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { schemaSnapshotTimeout = prev })
+
+	hang := make(chan struct{})
+	t.Cleanup(func() { close(hang) })
+	reloads := make(chan string, 4)
+	s := testSnapshotSupervisor(t, func(console.SchemaSnapshotRequest) (metadata.SnapshotStats, error) {
+		<-hang
+		return metadata.SnapshotStats{}, nil
+	}, func(_ context.Context, id string) (bool, error) { reloads <- id; return true, nil })
+
+	req := console.SchemaSnapshotRequest{ServerID: "srv-1"}
+	if err := s.Trigger(req); err != nil {
+		t.Fatalf("trigger: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		st := s.Status("srv-1")
+		if st.State == "failed" {
+			if !strings.Contains(st.LastError, "did not answer") {
+				t.Errorf("last_error = %q, want the timeout's own account", st.LastError)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("job never left running: %+v", st)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// Retryable again — the 409 must not be permanent.
+	if err := s.Trigger(req); err != nil {
+		t.Errorf("a timed-out job must leave the endpoint usable, got %v", err)
+	}
+}
+
+// The abandoned goroutine of a timed-out run must not restart the stream behind
+// the retry's back, nor overwrite the newer job's status.
+func TestSchemaSnapshotSupervisor_supersededRunNeitherReloadsNorPublishes(t *testing.T) {
+	reloads := 0
+	s := testSnapshotSupervisor(t, func(console.SchemaSnapshotRequest) (metadata.SnapshotStats, error) {
+		return metadata.SnapshotStats{SnapshotID: 1}, nil
+	}, func(context.Context, string) (bool, error) { reloads++; return true, nil })
+
+	// Generation 1 finishes late; a retry (generation 2) already owns the server.
+	s.gens["srv-1"] = 2
+	st, err := s.execute(console.SchemaSnapshotRequest{ServerID: "srv-1"}, 1)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if reloads != 0 {
+		t.Error("a superseded run must not restart the stream the newer run owns")
+	}
+	if st.StreamReloaded {
+		t.Error("a superseded run must not claim a reload")
+	}
+	s.publish(console.SchemaSnapshotRequest{ServerID: "srv-1"}, 1, st, nil)
+	if got := s.Status("srv-1"); got.State != "idle" {
+		t.Errorf("a superseded run must not publish over the newer job: %+v", got)
 	}
 }

--- a/consoleapp/schema_snapshot_test.go
+++ b/consoleapp/schema_snapshot_test.go
@@ -216,10 +216,6 @@ func TestMonitorReloadSchema_undrainedStreamIsReportedAndKeepsTheJob(t *testing.
 // a job stuck in "running" makes every later Trigger answer 409 for the life of
 // the process, with a daemon restart the only way out.
 func TestSchemaSnapshotSupervisor_timeoutFreesTheEndpoint(t *testing.T) {
-	prev := schemaSnapshotTimeout
-	schemaSnapshotTimeout = 20 * time.Millisecond
-	t.Cleanup(func() { schemaSnapshotTimeout = prev })
-
 	hang := make(chan struct{})
 	t.Cleanup(func() { close(hang) })
 	reloads := make(chan string, 4)
@@ -227,6 +223,10 @@ func TestSchemaSnapshotSupervisor_timeoutFreesTheEndpoint(t *testing.T) {
 		<-hang
 		return metadata.SnapshotStats{}, nil
 	}, func(_ context.Context, id string) (bool, error) { reloads <- id; return true, nil })
+	// Shrink this supervisor's own bound. A package-level var would be read by
+	// the job goroutines of every other test here — which outlive the test that
+	// spawned them — so assigning to one is a data race, not a knob.
+	s.timeout = 20 * time.Millisecond
 
 	req := console.SchemaSnapshotRequest{ServerID: "srv-1"}
 	if err := s.Trigger(req); err != nil {

--- a/consoleapp/watch.go
+++ b/consoleapp/watch.go
@@ -425,6 +425,12 @@ func runUpConsoleOnly(cmd *cobra.Command) error {
 
 	supervisor := newMonitorSupervisor(ctx, upIndexDSN, registry, upRotationCfg.Retain)
 	cfg.MonitorCtrl = supervisor
+	// Refreshing a source's schema snapshot needs no opt-in of its own (#1296):
+	// unlike the baseline trigger it starts no dump and copies no row data — it
+	// re-reads information_schema and restarts that server's stream onto the
+	// result. It is wired wherever the control plane is, because the remedy for
+	// a degraded capture has to be reachable from the console that reports it.
+	cfg.SchemaSnapshotCtrl = newSchemaSnapshotSupervisor(ctx, reloadStreamSchema(supervisor, registry))
 	// One supervisor, TWO independently opt-in features: the manual dump-based
 	// baseline trigger (#613, needs mydumper and BINTRAIL_CONSOLE_BASELINE_TRIGGER=1)
 	// and the periodic refresh (#1171, needs neither — it exists precisely so a
@@ -616,6 +622,12 @@ func runUpStreamWithConsole(cmd *cobra.Command, args []string) error {
 	// the HTTP requests that start them.
 	supervisor := newMonitorSupervisor(ctx, upIndexDSN, registry, upRotationCfg.Retain)
 	cfg.MonitorCtrl = supervisor
+	// Refreshing a source's schema snapshot needs no opt-in of its own (#1296):
+	// unlike the baseline trigger it starts no dump and copies no row data — it
+	// re-reads information_schema and restarts that server's stream onto the
+	// result. It is wired wherever the control plane is, because the remedy for
+	// a degraded capture has to be reachable from the console that reports it.
+	cfg.SchemaSnapshotCtrl = newSchemaSnapshotSupervisor(ctx, reloadStreamSchema(supervisor, registry))
 	// One supervisor, TWO independently opt-in features: the manual dump-based
 	// baseline trigger (#613, needs mydumper and BINTRAIL_CONSOLE_BASELINE_TRIGGER=1)
 	// and the periodic refresh (#1171, needs neither — it exists precisely so a

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -487,8 +487,10 @@ the binlog — requires `binlog_format=ROW`). Routine skips of system schemas
 the snapshot deliberately excludes (e.g. RDS's `mysql.rds_heartbeat2`) are
 **not** counted.
 
-For `statement_format_dml` the daemon also stamps the most recent drop's
-**attribution** — binlog file:pos, statement keyword, and connection id, enough
+For `statement_format_dml` and the table-attributed reasons above the daemon
+also stamps the most recent drop's
+**attribution** — binlog file:pos, and for statement DML the statement keyword
+and connection id, enough
 to hunt the offending client without ever storing the statement text (it embeds
 row values). The DEGRADED block then adds a `Last drop:` line, e.g.
 `Last drop:       binlog.000042:99012 (UPDATE, connection id 55)`.

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -449,9 +449,27 @@ checkpoint, surviving restarts) and `status` renders the verdict:
   Continuity:      no gaps in the captured range (not a liveness check)
   Capture health:  ⚠ DEGRADED — 41,203 events skipped (column_count_mismatch), last 2026-07-17 12:24:12
   Skipped events were read from the stream but NOT indexed — a restore window
-  over them is incomplete. Most often the schema snapshot is stale or corrupt:
-  run `bintrail snapshot` against the source, then check the daemon log.
+  over them is incomplete.
+  shop.plugin_log changed on the source but is missing from the schema snapshot
+  capture decodes against, so those row events could not be indexed. […]
+  Fix: refresh the schema snapshot for this source — the record of each table's
+  columns that capture decodes against (not a baseline, which is a full copy of
+  the data). […]
+  None of this recovers what was already skipped: those changes are absent from
+  the index for good unless the source still has the binlogs covering that
+  window […]
+  Per-event detail is in the log of the process capturing this source […]
 ```
+
+The block after the verdict is the same text the [web console](console.md)
+shows, built once in `internal/status` and shipped in the JSON as
+`capture_health.explanation`, so the two surfaces cannot tell different
+stories. It names the affected tables, distinguishes the ordinary cause (a new
+table appeared and the stream's own auto-snapshot did not follow it) from the
+one a re-snapshot can never fix (a table validation excluded — see below), and
+says plainly that **a fresh snapshot fixes capture going forward only**: events
+already skipped stay missing unless the source still has the binlogs covering
+that window.
 
 | Text | Meaning |
 |---|---|
@@ -460,8 +478,11 @@ checkpoint, surviving restarts) and `status` renders the verdict:
 | *(line absent)* | Unknown — a legacy index, or one no skip-aware daemon has written; `OK` is never asserted from absent data |
 
 Skip reasons include `column_count_mismatch` (stale/corrupt snapshot),
-`table_not_in_snapshot`, `no_resolver`, `unhandled_row_event`, and
-`statement_format_dml` (a STATEMENT/MIXED-format DML whose row image is not in
+`table_not_in_snapshot` (a table the snapshot never saw — fixed by a fresh
+snapshot), `table_excluded_from_snapshot` (a table snapshot validation left out
+because it has no explicit primary key or is not InnoDB — a fresh snapshot
+excludes it again, so the fix is on the source's DDL), `no_resolver`,
+`unhandled_row_event`, and `statement_format_dml` (a STATEMENT/MIXED-format DML whose row image is not in
 the binlog — requires `binlog_format=ROW`). Routine skips of system schemas
 the snapshot deliberately excludes (e.g. RDS's `mysql.rds_heartbeat2`) are
 **not** counted.
@@ -481,8 +502,14 @@ Under `--format json` the verdict is `stream.capture_health`:
 "last_skip_at": "...", "skipped": {"<reason>": {"count": N, "last_at": "..."}}}`;
 the key is omitted when the verdict is unknown. Attributed reasons additionally
 carry `last_file`, `last_pos`, `last_statement_type`, `last_connection_id`
-(omitted when absent). The [web console](console.md)
-Overview shows an orange "Capture degraded" box in the same states.
+(omitted when absent). Table-attributed reasons also carry `tables` (capped, with
+`tables_truncated` when more were skipped than are listed) and `last_detail`;
+the verdict carries `explanation`, the rendered prose above. The
+[web console](console.md) Overview shows an orange "Capture incomplete" box in
+the same states, with a **Refresh schema snapshot** button for a monitored
+server: it re-reads the source's column layout and restarts that server's
+capture onto it (a schema snapshot is not a baseline — it records columns, not
+data), reporting whether the stream actually reloaded.
 
 ### Sections in detail
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2281,12 +2281,97 @@ function captureHealthBox(stream) {
   if (!stream || !stream.capture_health || stream.capture_health.status !== "degraded") return null;
   const h = stream.capture_health;
   const box = el("div", { class: "warn-box" });
-  box.append(el("b", { text: "⚠ Capture degraded — events are being skipped" }));
+  box.append(el("b", { text: "⚠ Capture incomplete — some changes were not indexed" }));
   const reasons = Object.keys(h.skipped || {}).sort().join(", ");
   box.append(el("div", { text: h.total_skipped + " event(s) were read from the stream but not indexed" +
     (reasons ? " (" + reasons + ")" : "") + (h.last_skip_at ? "; last " + h.last_skip_at : "") + "." }));
-  box.append(el("div", { text: "Changes in those events are missing from the index. Most often the schema snapshot is stale — take a fresh snapshot on the source, then check the capture log." }));
+  // Cause, remedy and scope come from the backend (status.ExplainCaptureSkips),
+  // the same strings `bintrail status` prints — the console must not re-author
+  // this advice in JavaScript, because the half that drifts is always the half
+  // saying what a remedy does NOT recover. The fallback covers a daemon too old
+  // to send the field, and deliberately promises nothing on its behalf.
+  const lines = (Array.isArray(h.explanation) && h.explanation.length) ? h.explanation
+    : ["Changes in those events are missing from the index. This daemon is too old to say why — run `bintrail status` against this index for the reason and the fix."];
+  lines.forEach((t) => box.append(el("div", { class: "warn-line", text: t })));
+  const action = schemaSnapshotButton();
+  if (action) box.append(action);
   return box;
+}
+
+// schemaSnapshotButton renders the Refresh-schema-snapshot action for the
+// selected server, or null when this console cannot perform it (#1296). It
+// exists because the old banner named a remedy with no button anywhere in the
+// UI, leaving the CLI — in a different container — as the only route.
+//
+// Gated on a real REGISTRY server: the reserved "default" entry is the daemon's
+// own command-line stream, which the control plane does not supervise and the
+// endpoint refuses with 409. The label never says just "snapshot": the button
+// next to it creates a BASELINE (a full copy of the data), and the two artifacts
+// were already being confused.
+function schemaSnapshotButton() {
+  const id = currentServer || defaultServerId;
+  if (!capsCache.schema_snapshot_trigger || !id || id === "default") return null;
+  const wrap = el("div", { class: "warn-actions" });
+  const btn = el("button", { class: "btn btn-sm", type: "button", text: "Refresh schema snapshot" });
+  btn.onclick = () => refreshSchemaSnapshot(id, btn);
+  wrap.append(btn);
+  return wrap;
+}
+
+// refreshSchemaSnapshot re-reads the source's column layout and restarts that
+// server's capture stream onto it, then reports what actually happened. The
+// three outcomes are reported separately on purpose: a failed snapshot, a
+// snapshot whose stream did NOT reload (capture is still on the old layout —
+// nothing is fixed yet), and tables validation excluded (those stay uncaptured
+// no matter how often this runs).
+async function refreshSchemaSnapshot(id, btn) {
+  if (btn) { btn.disabled = true; btn.textContent = "Refreshing…"; }
+  const restore = () => { if (btn) { btn.disabled = false; btn.textContent = "Refresh schema snapshot"; } };
+  try {
+    await api("/api/servers/" + encodeURIComponent(id) + "/schema-snapshot", { method: "POST", body: {} });
+  } catch (err) {
+    toast("Schema snapshot failed: " + ((err && err.message) || err));
+    restore();
+    return;
+  }
+  toast("Reading the source's table layout…");
+  const done = await pollSchemaSnapshot(id);
+  restore();
+  if (!done) { toast("Schema snapshot still running — check back shortly."); return; }
+  if (done.state !== "succeeded") {
+    toast("Schema snapshot failed: " + (done.last_error || "unknown error"));
+    return;
+  }
+  let msg = "Schema snapshot updated: " + (done.tables || 0) + " table(s).";
+  msg += done.stream_reloaded
+    ? " Capture restarted on it."
+    : " Capture is STILL using the previous snapshot" + (done.reload_error ? " (" + done.reload_error + ")" : "") + ".";
+  if ((done.excluded_tables || []).length) {
+    msg += " Still not captured (no primary key / not InnoDB): " + done.excluded_tables.join(", ") + ".";
+  }
+  msg += " Events already skipped stay missing.";
+  toast(msg);
+  renderStatus();
+}
+
+// pollSchemaSnapshot polls until the job leaves "running" (or a ~2-minute cap:
+// a snapshot is an information_schema read plus a stream restart, not a dump).
+// Returns the terminal status, or null if it never settled. Transient poll
+// errors are retried — the stream restart briefly disturbs nothing else, but a
+// blip must not be reported as a failed snapshot.
+async function pollSchemaSnapshot(id) {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  for (let i = 0; i < 60; i++) {
+    await sleep(2000);
+    let st;
+    try {
+      st = (await api("/api/servers/" + encodeURIComponent(id) + "/schema-snapshot")).schema_snapshot;
+    } catch (_) {
+      continue;
+    }
+    if (st && st.state !== "running") return st;
+  }
+  return null;
 }
 
 // PG_HEALTH_STALE_SEC: a source_health snapshot older than this reads as STALE. The

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2343,13 +2343,20 @@ async function refreshSchemaSnapshot(id, btn) {
     return;
   }
   let msg = "Schema snapshot updated: " + (done.tables || 0) + " table(s).";
+  // Never assert WHICH state capture ended in when the reload failed: the
+  // reload can fail with the old stream still running (registry gone) or with
+  // it stopped (it did not shut down in time). Print the daemon's own account
+  // instead of guessing — "still using the previous snapshot" would be a lie
+  // for the stopped case.
   msg += done.stream_reloaded
     ? " Capture restarted on it."
-    : " Capture is STILL using the previous snapshot" + (done.reload_error ? " (" + done.reload_error + ")" : "") + ".";
+    : " Capture did NOT restart onto it — " + (done.reload_error || "restart this server's capture to pick it up") + ".";
   if ((done.excluded_tables || []).length) {
     msg += " Still not captured (no primary key / not InnoDB): " + done.excluded_tables.join(", ") + ".";
   }
-  msg += " Events already skipped stay missing.";
+  // The banner is driven by a monotonic tally, so it stays up after a working
+  // fix. Say so here or the operator concludes the button did nothing.
+  msg += " Events already skipped stay missing, and this warning stays up — it counts skips that happened.";
   toast(msg);
   renderStatus();
 }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1253,6 +1253,11 @@ button { font-family: inherit; }
   border-radius: var(--radius-sm); padding: 12px 14px; margin: 8px 0;
   white-space: pre-wrap;
 }
+/* One paragraph per explanation line (#1296). Without the gap the cause, the
+   fix and the "this does not recover what was already skipped" caveat run
+   together as one block — and the caveat is the part that gets skimmed past. */
+.warn-box .warn-line { margin-top: 8px; }
+.warn-box .warn-actions { margin-top: 10px; }
 .warnings:empty { display: none; }
 .warn-item {
   display: flex; gap: 8px; align-items: flex-start;

--- a/internal/console/authz.go
+++ b/internal/console/authz.go
@@ -82,6 +82,11 @@ var apiRoutePerms = []routePerm{
 	// permission; it is an operator integrity action, tiered with baseline:create.
 	{"POST", "/api/servers/{}/baseline", ext.PermBaselineCreate},
 	{"POST", "/api/servers/{}/verify", ext.PermBaselineCreate},
+	// Refreshing the schema snapshot restarts that server's capture stream, so
+	// it is an operator action, not a read. Like verify it gets no dedicated
+	// permission — the core defines no new one for it; it is tiered with
+	// baseline:create, the operator-maintenance tier it belongs to.
+	{"POST", "/api/servers/{}/schema-snapshot", ext.PermBaselineCreate},
 
 	// Server registry + control-plane. List/get/status/verify-read and the
 	// write-free test probe are reads; create/update/delete/monitor are writes.
@@ -91,6 +96,7 @@ var apiRoutePerms = []routePerm{
 	{"POST", "/api/servers/{}/monitor/start", ext.PermServersWrite},
 	{"POST", "/api/servers/{}/monitor/stop", ext.PermServersWrite},
 	{"GET", "/api/servers/{}/baseline", ext.PermServersRead},
+	{"GET", "/api/servers/{}/schema-snapshot", ext.PermServersRead},
 	{"GET", "/api/servers/{}/verify", ext.PermServersRead},
 	{"GET", "/api/servers/{}/verify/explain", ext.PermServersRead},
 	{"GET", "/api/servers/{}/verify/history", ext.PermServersRead},

--- a/internal/console/authz.go
+++ b/internal/console/authz.go
@@ -82,11 +82,11 @@ var apiRoutePerms = []routePerm{
 	// permission; it is an operator integrity action, tiered with baseline:create.
 	{"POST", "/api/servers/{}/baseline", ext.PermBaselineCreate},
 	{"POST", "/api/servers/{}/verify", ext.PermBaselineCreate},
-	// Refreshing the schema snapshot restarts that server's capture stream, so
-	// it is an operator action, not a read. Like verify it gets no dedicated
-	// permission — the core defines no new one for it; it is tiered with
-	// baseline:create, the operator-maintenance tier it belongs to.
-	{"POST", "/api/servers/{}/schema-snapshot", ext.PermBaselineCreate},
+	// Refreshing the schema snapshot STOPS AND RESTARTS that server's capture
+	// stream, so it is tiered with the monitor verbs below (servers:write), not
+	// with baseline/verify. Those are maintenance actions that leave capture
+	// alone; this one can leave capture down if the restart fails, which is
+	// strictly the control-plane capability servers:write exists to gate.
 
 	// Server registry + control-plane. List/get/status/verify-read and the
 	// write-free test probe are reads; create/update/delete/monitor are writes.
@@ -95,6 +95,8 @@ var apiRoutePerms = []routePerm{
 	{"GET", "/api/servers/{}/monitor", ext.PermServersRead},
 	{"POST", "/api/servers/{}/monitor/start", ext.PermServersWrite},
 	{"POST", "/api/servers/{}/monitor/stop", ext.PermServersWrite},
+	// See the note above the maintenance block: this one restarts capture.
+	{"POST", "/api/servers/{}/schema-snapshot", ext.PermServersWrite},
 	{"GET", "/api/servers/{}/baseline", ext.PermServersRead},
 	{"GET", "/api/servers/{}/schema-snapshot", ext.PermServersRead},
 	{"GET", "/api/servers/{}/verify", ext.PermServersRead},

--- a/internal/console/authz_test.go
+++ b/internal/console/authz_test.go
@@ -46,6 +46,8 @@ var registeredAPIPatterns = []struct{ method, pattern string }{
 	{"GET", "/api/servers/{}/monitor"},
 	{"POST", "/api/servers/{}/baseline"},
 	{"GET", "/api/servers/{}/baseline"},
+	{"POST", "/api/servers/{}/schema-snapshot"},
+	{"GET", "/api/servers/{}/schema-snapshot"},
 	{"POST", "/api/servers/{}/verify"},
 	{"GET", "/api/servers/{}/verify"},
 	{"GET", "/api/servers/{}/verify/explain"},

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -83,6 +83,11 @@ type capabilitiesResponse struct {
 	// Process-global, like BaselineTrigger — the endpoint does the per-server/
 	// per-mode validation.
 	VerifyTrigger bool `json:"verify_trigger"`
+	// SchemaSnapshotTrigger: this process can refresh a monitored source's
+	// schema snapshot and restart its stream onto it (#1296). Process-global,
+	// like BaselineTrigger — the endpoint does the per-server validation
+	// (source configured, index provisioned, MySQL/MariaDB flavor).
+	SchemaSnapshotTrigger bool `json:"schema_snapshot_trigger"`
 	// Verify: baseline-anchored verify is usable for the SELECTED server — a
 	// baseline destination is configured, mirroring Reconstruct's gate (both
 	// read baseline state with no RBAC redaction, so an active profile also
@@ -181,6 +186,8 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		Monitor:         s.monitorCtrl != nil,
 		BaselineTrigger: s.baselineCtrl != nil,
 		VerifyTrigger:   s.verifyCtrl != nil,
+
+		SchemaSnapshotTrigger: s.schemaSnapCtrl != nil,
 		// recover-cascade is the free tier (like recover) and process-global, gated
 		// only by the RBAC profile (which would make synthesis leak redacted data).
 		RecoverCascade: !s.rbacActiveFor(r),

--- a/internal/console/schema_snapshot.go
+++ b/internal/console/schema_snapshot.go
@@ -1,0 +1,147 @@
+package console
+
+import (
+	"errors"
+	"net/http"
+)
+
+// ErrSchemaSnapshotRunning is returned by SchemaSnapshotController.Trigger when
+// one is already in flight for that server (one at a time per server). The
+// handler maps it to 409 Conflict.
+var ErrSchemaSnapshotRunning = errors.New("a schema snapshot is already running for this server")
+
+// SchemaSnapshotController re-reads a monitored source's column layout into the
+// index and puts the running capture stream onto it (#1296).
+//
+// A SCHEMA SNAPSHOT IS NOT A BASELINE, and this file is where the two are kept
+// apart. A schema snapshot is the record of each table's columns that capture
+// decodes row events against — cheap, metadata-only, read from
+// information_schema. A baseline (BaselineController) is a full COPY of the
+// data, produced by mydumper. The console offers both, and the capture-degraded
+// banner used to say "take a fresh snapshot" next to a button labelled
+// "Create baseline": an operator who follows that runs a dump they did not need
+// while capture stays broken. Keep the two vocabularies separate in every type
+// name, endpoint and label here.
+//
+// Wired in only by `bintrail-console watch`, which owns the supervised streams;
+// nil on the standalone read-only console, where the endpoints refuse with 403
+// (mirroring how MonitorController gates the monitor verbs).
+type SchemaSnapshotController interface {
+	// Trigger takes a fresh snapshot in the background and returns immediately.
+	// Returns ErrSchemaSnapshotRunning if one is already running for
+	// req.ServerID.
+	Trigger(req SchemaSnapshotRequest) error
+	// Status reports the latest known state for a server (idle if none has run
+	// in this process).
+	Status(serverID string) SchemaSnapshotStatus
+}
+
+// SchemaSnapshotRequest is the in-process job description the endpoint hands
+// the controller. Both DSNs are secrets: they stay inside the process and are
+// never written to disk or serialized into any HTTP response.
+type SchemaSnapshotRequest struct {
+	ServerID   string
+	ServerName string
+	SourceDSN  string
+	// IndexDSN is the entry's per-source index database — where the new
+	// snapshot rows are written and where the restarted stream will read them
+	// from. The two must be the same database or the stream would reload the
+	// snapshot it already had.
+	IndexDSN string
+	Schemas  []string
+}
+
+// SchemaSnapshotStatus is the pollable state of a server's most recent
+// snapshot job.
+type SchemaSnapshotStatus struct {
+	State      string `json:"state"` // idle | running | succeeded | failed
+	Since      string `json:"since,omitempty"`
+	FinishedAt string `json:"finished_at,omitempty"`
+	LastError  string `json:"last_error,omitempty"`
+	SnapshotID int    `json:"snapshot_id,omitempty"`
+	Tables     int    `json:"tables,omitempty"`
+	// ExcludedTables names tables snapshot validation left out (no explicit
+	// primary key / non-InnoDB). Reported because those tables are exactly the
+	// ones that will KEEP being skipped after this run — an operator who
+	// pressed the button to fix capture must not read "succeeded" as "every
+	// table is captured now".
+	ExcludedTables []string `json:"excluded_tables,omitempty"`
+	// StreamReloaded reports whether the capture stream was actually restarted
+	// onto the new snapshot. A running stream holds its resolver in memory and
+	// only swaps it on a DDL event, so a snapshot written underneath it changes
+	// NOTHING until the stream reloads. Without this field a silent no-op would
+	// be indistinguishable from a fix — the precise failure this feature exists
+	// to prevent.
+	StreamReloaded bool `json:"stream_reloaded"`
+	// ReloadError explains a failed reload. The snapshot itself is still
+	// durable, so this is not a job failure — it is "the new snapshot is
+	// recorded but capture is still running on the old one; restart it".
+	ReloadError string `json:"reload_error,omitempty"`
+}
+
+// handleSchemaSnapshotTrigger serves POST /api/servers/{id}/schema-snapshot:
+// re-read the source's column layout and put the running stream onto it.
+// Gating, in order: the control plane must be wired in, the entry must be a
+// real registry server with a source configured and an index database it is
+// already monitored on, and the flavor must be one that uses these snapshots.
+func (s *Server) handleSchemaSnapshotTrigger(w http.ResponseWriter, r *http.Request) {
+	if s.schemaSnapCtrl == nil {
+		writeJSONError(w, http.StatusForbidden,
+			"refreshing the schema snapshot needs the control plane; it is available from the `bintrail-console watch` process")
+		return
+	}
+	e, ok := s.requireMonitorEntry(w, r.PathValue("id"))
+	if !ok {
+		return
+	}
+	if e.SourceDSN == "" {
+		writeJSONError(w, http.StatusBadRequest, "this server has no source configured; set the source connection first")
+		return
+	}
+	if e.IsPostgres() {
+		// The snapshot taker reads information_schema with MySQL's InnoDB/PK
+		// validation; PostgreSQL capture resolves its own column layout from
+		// the publication. Refuse plainly instead of running a MySQL snapshot
+		// against a PostgreSQL source.
+		writeJSONError(w, http.StatusBadRequest,
+			"this server is PostgreSQL; its capture does not use MySQL schema snapshots")
+		return
+	}
+	if e.DSN == "" {
+		writeJSONError(w, http.StatusBadRequest,
+			"this server has no index database yet; start monitoring it first, then refresh the schema snapshot")
+		return
+	}
+
+	req := SchemaSnapshotRequest{
+		ServerID:   e.ID,
+		ServerName: e.Name,
+		SourceDSN:  e.SourceDSN,
+		IndexDSN:   e.DSN,
+		Schemas:    splitSchemas(e.Schemas),
+	}
+	if err := s.schemaSnapCtrl.Trigger(req); err != nil {
+		if errors.Is(err, ErrSchemaSnapshotRunning) {
+			writeJSONError(w, http.StatusConflict, err.Error())
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusAccepted, map[string]any{"schema_snapshot": s.schemaSnapCtrl.Status(e.ID)})
+}
+
+// handleSchemaSnapshotStatus reports the latest snapshot job state for the
+// selected server, for the frontend to poll while a run is in flight.
+func (s *Server) handleSchemaSnapshotStatus(w http.ResponseWriter, r *http.Request) {
+	if s.schemaSnapCtrl == nil {
+		writeJSONError(w, http.StatusForbidden,
+			"refreshing the schema snapshot needs the control plane; it is available from the `bintrail-console watch` process")
+		return
+	}
+	e, ok := s.requireMonitorEntry(w, r.PathValue("id"))
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"schema_snapshot": s.schemaSnapCtrl.Status(e.ID)})
+}

--- a/internal/console/schema_snapshot_test.go
+++ b/internal/console/schema_snapshot_test.go
@@ -1,0 +1,236 @@
+package console
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// ─── Refresh schema snapshot (#1296) ──────────────────────────────────────────
+//
+// The capture-degraded banner named a remedy the UI could not perform; this is
+// that remedy. The tests below pin the two things that make it worth having:
+// the endpoint reaches a controller (not a hopeful 202), and it refuses the
+// cases where taking a snapshot would be wrong or a no-op.
+
+type stubSchemaSnapCtrl struct {
+	triggered []SchemaSnapshotRequest
+	err       error
+	status    SchemaSnapshotStatus
+}
+
+func (c *stubSchemaSnapCtrl) Trigger(req SchemaSnapshotRequest) error {
+	c.triggered = append(c.triggered, req)
+	return c.err
+}
+
+func (c *stubSchemaSnapCtrl) Status(string) SchemaSnapshotStatus { return c.status }
+
+func newSchemaSnapshotServer(t *testing.T) (*Server, *stubSchemaSnapCtrl) {
+	t.Helper()
+	reg, err := LoadRegistry(t.TempDir() + "/console-servers.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctrl := &stubSchemaSnapCtrl{status: SchemaSnapshotStatus{State: "idle"}}
+	srv, err := New(Config{
+		Listen: "127.0.0.1:8090", Token: "t", Registry: reg,
+		MonitorCtrl: &stubMonitorCtrl{}, SchemaSnapshotCtrl: ctrl,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv, ctrl
+}
+
+func addSnapshotEntry(t *testing.T, srv *Server, e ServerEntry) string {
+	t.Helper()
+	added, err := srv.cm.reg.Add(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return added.ID
+}
+
+func mysqlSnapshotEntry() ServerEntry {
+	return ServerEntry{
+		Name:      "wp",
+		DSN:       "idx:idxpw@tcp(127.0.0.1:3306)/bintrail_wp",
+		SourceDSN: "u:p@tcp(127.0.0.1:3306)/",
+		Schemas:   "shop, blog",
+	}
+}
+
+func TestSchemaSnapshotTrigger_reachesTheController(t *testing.T) {
+	srv, ctrl := newSchemaSnapshotServer(t)
+	id := addSnapshotEntry(t, srv, mysqlSnapshotEntry())
+	rec, body := doServersReq(t, srv, "POST", "/api/servers/"+id+"/schema-snapshot", "")
+	if rec.Code != 202 {
+		t.Fatalf("trigger: code=%d body=%s", rec.Code, body)
+	}
+	if len(ctrl.triggered) != 1 {
+		t.Fatalf("controller was not asked to take a snapshot: %v", ctrl.triggered)
+	}
+	req := ctrl.triggered[0]
+	if req.ServerID != id || req.SourceDSN != "u:p@tcp(127.0.0.1:3306)/" {
+		t.Errorf("request does not carry the entry's source: %+v", req)
+	}
+	// The snapshot must land in the entry's OWN index database — writing it to
+	// another index would leave the stream reloading the snapshot it already had.
+	if req.IndexDSN != "idx:idxpw@tcp(127.0.0.1:3306)/bintrail_wp" {
+		t.Errorf("request does not carry the entry's index DSN: %+v", req)
+	}
+	if len(req.Schemas) != 2 || req.Schemas[0] != "shop" || req.Schemas[1] != "blog" {
+		t.Errorf("schema filter not carried: %v", req.Schemas)
+	}
+	// The DSNs are secrets and must never come back over HTTP.
+	if strings.Contains(string(body), "idxpw") || strings.Contains(string(body), "u:p@") {
+		t.Errorf("response leaked a DSN: %s", body)
+	}
+}
+
+func TestSchemaSnapshotTrigger_readOnlyConsoleRefuses(t *testing.T) {
+	reg, _ := LoadRegistry(t.TempDir() + "/console-servers.yaml")
+	srv, err := New(Config{Listen: "127.0.0.1:8090", Token: "t", Registry: reg, MonitorCtrl: &stubMonitorCtrl{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := addSnapshotEntry(t, srv, mysqlSnapshotEntry())
+	for _, method := range []string{"POST", "GET"} {
+		rec, _ := doServersReq(t, srv, method, "/api/servers/"+id+"/schema-snapshot", "")
+		if rec.Code != 403 {
+			t.Errorf("%s with no controller: code=%d, want 403", method, rec.Code)
+		}
+	}
+}
+
+func TestSchemaSnapshotTrigger_requiresSource(t *testing.T) {
+	srv, ctrl := newSchemaSnapshotServer(t)
+	e := mysqlSnapshotEntry()
+	e.SourceDSN = ""
+	id := addSnapshotEntry(t, srv, e)
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+id+"/schema-snapshot", "")
+	if rec.Code != 400 {
+		t.Fatalf("no source: code=%d, want 400", rec.Code)
+	}
+	if len(ctrl.triggered) != 0 {
+		t.Error("controller must not run without a source to read the layout from")
+	}
+}
+
+// Without an index database there is nowhere to write the snapshot and no
+// stream to reload — a 202 here would be a button that does nothing.
+func TestSchemaSnapshotTrigger_requiresIndex(t *testing.T) {
+	srv, ctrl := newSchemaSnapshotServer(t)
+	e := mysqlSnapshotEntry()
+	e.DSN = ""
+	id := addSnapshotEntry(t, srv, e)
+	rec, body := doServersReq(t, srv, "POST", "/api/servers/"+id+"/schema-snapshot", "")
+	if rec.Code != 400 {
+		t.Fatalf("no index: code=%d, want 400", rec.Code)
+	}
+	if !strings.Contains(string(body), "start monitoring") {
+		t.Errorf("the refusal must say what to do first: %s", body)
+	}
+	if len(ctrl.triggered) != 0 {
+		t.Error("controller must not run without an index database")
+	}
+}
+
+// PostgreSQL capture resolves its own column layout; running the MySQL snapshot
+// taker against it would query information_schema with MySQL's InnoDB/PK rules.
+func TestSchemaSnapshotTrigger_refusesPostgres(t *testing.T) {
+	srv, ctrl := newSchemaSnapshotServer(t)
+	e := mysqlSnapshotEntry()
+	e.SourceDSN = "postgres://u:p@127.0.0.1:5432/app"
+	e.Flavor = FlavorPostgres
+	id := addSnapshotEntry(t, srv, e)
+	rec, body := doServersReq(t, srv, "POST", "/api/servers/"+id+"/schema-snapshot", "")
+	if rec.Code != 400 {
+		t.Fatalf("postgres: code=%d body=%s, want 400", rec.Code, body)
+	}
+	if len(ctrl.triggered) != 0 {
+		t.Error("a PostgreSQL source must never reach the MySQL snapshot taker")
+	}
+}
+
+// The command-line entry is streamed by the daemon itself, outside the control
+// plane — the monitor verbs already refuse it and so must this.
+func TestSchemaSnapshotTrigger_refusesBootEntry(t *testing.T) {
+	srv, ctrl := newSchemaSnapshotServer(t)
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+bootServerID+"/schema-snapshot", "")
+	if rec.Code != 409 {
+		t.Fatalf("boot entry: code=%d, want 409", rec.Code)
+	}
+	if len(ctrl.triggered) != 0 {
+		t.Error("the boot entry has no supervised stream to reload")
+	}
+}
+
+func TestSchemaSnapshotTrigger_alreadyRunningIsConflict(t *testing.T) {
+	srv, ctrl := newSchemaSnapshotServer(t)
+	ctrl.err = ErrSchemaSnapshotRunning
+	id := addSnapshotEntry(t, srv, mysqlSnapshotEntry())
+	rec, _ := doServersReq(t, srv, "POST", "/api/servers/"+id+"/schema-snapshot", "")
+	if rec.Code != 409 {
+		t.Fatalf("already running: code=%d, want 409", rec.Code)
+	}
+}
+
+// The status endpoint is what the UI polls; it must report the reload outcome,
+// because a snapshot whose stream did not reload has fixed nothing yet.
+func TestSchemaSnapshotStatus_reportsTheReloadOutcome(t *testing.T) {
+	srv, ctrl := newSchemaSnapshotServer(t)
+	ctrl.status = SchemaSnapshotStatus{
+		State: "succeeded", Tables: 12, SnapshotID: 7,
+		StreamReloaded: false, ReloadError: "stream did not stop within 15s",
+		ExcludedTables: []string{"shop.audit_raw"},
+	}
+	id := addSnapshotEntry(t, srv, mysqlSnapshotEntry())
+	rec, body := doServersReq(t, srv, "GET", "/api/servers/"+id+"/schema-snapshot", "")
+	if rec.Code != 200 {
+		t.Fatalf("status: code=%d body=%s", rec.Code, body)
+	}
+	var got struct {
+		SchemaSnapshot SchemaSnapshotStatus `json:"schema_snapshot"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.SchemaSnapshot.StreamReloaded {
+		t.Error("stream_reloaded must not be reported true when the stream did not reload")
+	}
+	if got.SchemaSnapshot.ReloadError == "" {
+		t.Error("a failed reload must be reported, or a no-op looks like a fix")
+	}
+	if len(got.SchemaSnapshot.ExcludedTables) != 1 {
+		t.Error("tables validation excluded must be reported — they stay uncaptured after this run")
+	}
+}
+
+// The UI gate: only a console with the control plane advertises the action.
+func TestCapabilitySchemaSnapshotTriggerGate(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		reg, _ := LoadRegistry("")
+		cfg := Config{Listen: "127.0.0.1:8090", Token: "t", Registry: reg}
+		if enabled {
+			cfg.SchemaSnapshotCtrl = &stubSchemaSnapCtrl{}
+		}
+		srv, err := New(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		srv.cm.boot = &bundle{}
+		rec, body := doServersReq(t, srv, "GET", "/api/capabilities", "")
+		if rec.Code != 200 {
+			t.Fatalf("capabilities: code=%d body=%s", rec.Code, body)
+		}
+		var caps capabilitiesResponse
+		if err := json.Unmarshal(body, &caps); err != nil {
+			t.Fatal(err)
+		}
+		if caps.SchemaSnapshotTrigger != enabled {
+			t.Errorf("schema_snapshot_trigger capability = %v, want %v", caps.SchemaSnapshotTrigger, enabled)
+		}
+	}
+}

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -533,7 +533,10 @@ func (s *Server) buildHandler() http.Handler {
 	// restart that server's stream onto it — the remedy the capture-degraded
 	// banner names, which had no button anywhere before. 403 unless this
 	// process runs the control plane.
-	api.HandleFunc("POST /api/servers/{id}/schema-snapshot", s.recordAction("schema_snapshot", s.handleSchemaSnapshotTrigger))
+	// Hyphen, not underscore: telemetry's sanitizeCommand rejects anything
+	// outside [a-z0-9-] and files it under "other", which would lose this
+	// action's signal entirely.
+	api.HandleFunc("POST /api/servers/{id}/schema-snapshot", s.recordAction("schema-snapshot", s.handleSchemaSnapshotTrigger))
 	api.HandleFunc("GET /api/servers/{id}/schema-snapshot", s.handleSchemaSnapshotStatus)
 	api.HandleFunc("POST /api/servers/{id}/verify", s.recordAction("verify", s.handleVerifyTrigger))
 	api.HandleFunc("GET /api/servers/{id}/verify", s.handleVerifyStatus)

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -97,6 +97,13 @@ type Config struct {
 	// BINTRAIL_CONSOLE_BASELINE_TRIGGER=1. nil when no refresh loop runs, and the
 	// baseline listing then simply carries no refresh section.
 	BaselineRefresh BaselineRefreshReporter
+	// SchemaSnapshotCtrl re-reads a monitored source's column layout and
+	// restarts that server's stream onto the result (#1296). Wired in by
+	// `bintrail-console watch` alongside MonitorCtrl and needing no separate
+	// opt-in — unlike BaselineCtrl it starts no dump and copies no row data.
+	// nil elsewhere, where the endpoints refuse with 403 and
+	// /api/capabilities reports schema_snapshot_trigger:false.
+	SchemaSnapshotCtrl SchemaSnapshotController
 	// VerifyCtrl runs bintrail verify's engine in-process for a monitored
 	// server (#677). Wired in ONLY by `bintrail-console watch` when the
 	// operator opts in (BINTRAIL_CONSOLE_VERIFY_TRIGGER=1); nil otherwise,
@@ -196,6 +203,9 @@ type Server struct {
 	// baselineRefresh: non-nil only when the watch daemon opted into the
 	// periodic refresh (see Config.BaselineRefresh).
 	baselineRefresh BaselineRefreshReporter
+	// schemaSnapCtrl: non-nil only when this process runs the control plane
+	// (see Config.SchemaSnapshotCtrl).
+	schemaSnapCtrl SchemaSnapshotController
 	// verifyCtrl: non-nil only when the watch daemon opted into in-process
 	// verify runs (see Config.VerifyCtrl).
 	verifyCtrl VerifyController
@@ -381,6 +391,7 @@ func New(cfg Config) (*Server, error) {
 		monitorCtrl:      cfg.MonitorCtrl,
 		baselineCtrl:     cfg.BaselineCtrl,
 		baselineRefresh:  cfg.BaselineRefresh,
+		schemaSnapCtrl:   cfg.SchemaSnapshotCtrl,
 		verifyCtrl:       cfg.VerifyCtrl,
 		verifyHistory:    cfg.VerifyHistory,
 		telemetry:        cfg.Telemetry,
@@ -518,6 +529,12 @@ func (s *Server) buildHandler() http.Handler {
 	// (BINTRAIL_CONSOLE_BASELINE_TRIGGER=1). GET polls the running/last state.
 	api.HandleFunc("POST /api/servers/{id}/baseline", s.recordAction("baseline", s.handleBaselineTrigger))
 	api.HandleFunc("GET /api/servers/{id}/baseline", s.handleBaselineStatus)
+	// Schema-snapshot refresh (#1296): re-read the source's column layout and
+	// restart that server's stream onto it — the remedy the capture-degraded
+	// banner names, which had no button anywhere before. 403 unless this
+	// process runs the control plane.
+	api.HandleFunc("POST /api/servers/{id}/schema-snapshot", s.recordAction("schema_snapshot", s.handleSchemaSnapshotTrigger))
+	api.HandleFunc("GET /api/servers/{id}/schema-snapshot", s.handleSchemaSnapshotStatus)
 	api.HandleFunc("POST /api/servers/{id}/verify", s.recordAction("verify", s.handleVerifyTrigger))
 	api.HandleFunc("GET /api/servers/{id}/verify", s.handleVerifyStatus)
 	api.HandleFunc("GET /api/servers/{id}/verify/explain", s.handleVerifyExplain)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -526,7 +526,7 @@ func handleRows(
 		// (persisted on the stream; run-scoped + end-of-run summary in file
 		// mode, which has no capture ledger by design — an empty stream_state
 		// is file mode's "no capture ran" marker).
-		_, excludedByValidation := resolver.ExclusionReason(schema, table)
+		exclusionReason, excludedByValidation := resolver.ExclusionReason(schema, table)
 		if gapTracker != nil && !excludedByValidation && !isSnapshotExcludedSchema(schema) && !eventPredatesSnapshot(binlogEv, resolver) {
 			if gapTracker.record(fmt.Sprintf("%s.%s not in snapshot %d at %s:%d", schema, table, schemaVersion, filename, binlogEv.Header.LogPos)) {
 				logger.Error("schema gap: skipping rows for a table absent from the snapshot at-or-after snapshot time — the snapshot is stale; this file will be marked failed (run `bintrail snapshot`, then re-index)",
@@ -536,8 +536,26 @@ func handleRows(
 		// Stream path (#1034): count the discard so `status` can show it —
 		// except for snapshot-excluded system schemas (e.g. mysql.rds_heartbeat2),
 		// a routine permanent skip that must never mark capture degraded.
+		//
+		// The two causes go under DIFFERENT reasons (#1296): a table missing
+		// because the snapshot never saw it is fixed by a fresh snapshot, while
+		// a VALIDATION-EXCLUDED table is re-excluded by every future snapshot,
+		// so one shared reason would make `status` hand half of these operators
+		// a remediation that can never converge. The table name rides along so
+		// the verdict can say WHICH table stopped being captured instead of
+		// leaving that answer only in this log line.
 		if !isSnapshotExcludedSchema(schema) {
-			skips.RecordSkip(SkipTableNotInSnapshot)
+			reason := SkipTableNotInSnapshot
+			if excludedByValidation {
+				reason = SkipTableExcludedFromSnapshot
+			}
+			skips.RecordSkipAttributed(reason, SkipAttribution{
+				File:   filename,
+				Pos:    uint64(binlogEv.Header.LogPos),
+				Schema: schema,
+				Table:  table,
+				Detail: exclusionReason,
+			})
 		}
 		return nil
 	}
@@ -564,7 +582,15 @@ func handleRows(
 					"file", filename, "pos", binlogEv.Header.LogPos, "schema", schema, "table", table)
 			}
 		}
-		skips.RecordSkip(SkipColumnCountMismatch)
+		// Same reasoning as the not-in-snapshot site above (#1296): name the
+		// table in the ledger so the status verdict can say which table stopped
+		// being captured. This reason's fix IS a fresh snapshot.
+		skips.RecordSkipAttributed(SkipColumnCountMismatch, SkipAttribution{
+			File:   filename,
+			Pos:    uint64(binlogEv.Header.LogPos),
+			Schema: schema,
+			Table:  table,
+		})
 		return nil
 	}
 

--- a/internal/parser/skip_table_wiring_test.go
+++ b/internal/parser/skip_table_wiring_test.go
@@ -1,0 +1,79 @@
+package parser
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-mysql-org/go-mysql/replication"
+)
+
+// ─── The skip ledger as PRODUCTION fills it (#1296) ──────────────────────────
+//
+// skips_tables_test.go drives SkipCounters directly; these drive handleRows,
+// the only caller that decides WHICH reason a dropped table lands under. That
+// decision is the whole point of the split — a test of the counters alone would
+// stay green if handleRows recorded every absent table under one reason again.
+
+func skipLedgerFromHandleRows(t *testing.T, schema, table string) map[string]SkipStat {
+	t.Helper()
+	snapT := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	ev := gapRowsEvent(schema, table, 2, uint32(snapT.Add(time.Hour).Unix()))
+	rowsEv := ev.Event.(*replication.RowsEvent)
+	skips := NewSkipCounters(newTestLogger(&bytes.Buffer{}))
+	out := make(chan Event, 4)
+	err := handleRows(context.Background(), newTestLogger(&bytes.Buffer{}), excludedScratchResolver(snapT),
+		&Filters{}, ev, rowsEv, "binlog.000007", "", 0, 0, "", 9, emitTo(out), nil, skips)
+	close(out)
+	if err != nil {
+		t.Fatalf("handleRows: %v", err)
+	}
+	return decodeLedger(t, skips)
+}
+
+// A table the snapshot simply never saw: fixable by a fresh snapshot.
+func TestHandleRows_absentTableRecordsMissingReasonWithName(t *testing.T) {
+	m := skipLedgerFromHandleRows(t, "shop", "plugin_log")
+	st, ok := m[SkipTableNotInSnapshot]
+	if !ok {
+		t.Fatalf("absent table not counted under %s: %v", SkipTableNotInSnapshot, m)
+	}
+	if len(st.Tables) != 1 || st.Tables[0] != "shop.plugin_log" {
+		t.Errorf("ledger does not name the skipped table: %v", st.Tables)
+	}
+	if st.LastFile != "binlog.000007" {
+		t.Errorf("last_file = %q, want the binlog the drop happened in", st.LastFile)
+	}
+	if _, wrong := m[SkipTableExcludedFromSnapshot]; wrong {
+		t.Error("an absent table must not be reported as validation-excluded — its fix IS a fresh snapshot")
+	}
+}
+
+// A table validation excluded on purpose: a fresh snapshot excludes it again,
+// so it must never be counted under the reason whose remedy is re-snapshotting.
+func TestHandleRows_excludedTableRecordsItsOwnReason(t *testing.T) {
+	m := skipLedgerFromHandleRows(t, "shop", "scratch")
+	st, ok := m[SkipTableExcludedFromSnapshot]
+	if !ok {
+		t.Fatalf("excluded table not counted under %s: %v", SkipTableExcludedFromSnapshot, m)
+	}
+	if len(st.Tables) != 1 || st.Tables[0] != "shop.scratch" {
+		t.Errorf("ledger does not name the excluded table: %v", st.Tables)
+	}
+	if st.LastDetail != "no primary key" {
+		t.Errorf("last_detail = %q, want the validator's exclusion reason", st.LastDetail)
+	}
+	if _, wrong := m[SkipTableNotInSnapshot]; wrong {
+		t.Error("a validation-excluded table under table_not_in_snapshot sends the operator to a remedy that can never converge (#1199)")
+	}
+}
+
+// A snapshot-excluded system schema stays a routine permanent skip: counting it
+// would mark capture degraded forever on any RDS source.
+func TestHandleRows_systemSchemaStillNotCounted(t *testing.T) {
+	m := skipLedgerFromHandleRows(t, "mysql", "rds_heartbeat2")
+	if len(m) != 0 {
+		t.Errorf("system-schema skip must not enter the ledger: %v", m)
+	}
+}

--- a/internal/parser/skips.go
+++ b/internal/parser/skips.go
@@ -16,6 +16,7 @@ package parser
 import (
 	"encoding/json"
 	"log/slog"
+	"slices"
 	"sync"
 	"time"
 )
@@ -32,6 +33,13 @@ const (
 	// counted — e.g. mysql.rds_heartbeat2 is a routine, permanent skip that
 	// must never mark capture degraded).
 	SkipTableNotInSnapshot = "table_not_in_snapshot"
+	// SkipTableExcludedFromSnapshot — the row's table is absent from the
+	// snapshot because the snapshot VALIDATOR excluded it (#1051: no explicit
+	// primary key, or a non-InnoDB engine). Split from SkipTableNotInSnapshot
+	// (#1296) because the two have opposite remedies and merging them hands the
+	// operator a remediation that cannot converge: re-snapshotting excludes
+	// this table again, forever. The fix is on the source's DDL, not here.
+	SkipTableExcludedFromSnapshot = "table_excluded_from_snapshot"
 	// SkipNoResolver — no schema snapshot was available at all.
 	SkipNoResolver = "no_resolver"
 	// SkipUnhandledRowEvent — a RowsEvent type bintrail does not decode
@@ -74,7 +82,29 @@ type SkipStat struct {
 	LastPos           uint64 `json:"last_pos,omitempty"`
 	LastStatementType string `json:"last_statement_type,omitempty"`
 	LastConnectionID  uint32 `json:"last_connection_id,omitempty"`
+
+	// Tables lists the distinct "schema.table" names this reason dropped rows
+	// for, capped at MaxLedgerTables (#1296). Without it an operator is told
+	// changes are missing but not WHICH table's — the first question they ask,
+	// and one only the daemon log could answer before. Absent on a ledger
+	// written by an older daemon: consumers must then name no table at all
+	// rather than present an empty list as "none".
+	Tables []string `json:"tables,omitempty"`
+	// TablesTruncated records that more distinct tables were skipped than
+	// Tables holds. The list is capped because this document is persisted in a
+	// single stream_state column and grows monotonically — an unfiltered source
+	// with thousands of unsnapshotted tables would grow it without bound. With
+	// no flag, a capped list would read as the complete set.
+	TablesTruncated bool `json:"tables_truncated,omitempty"`
+	// LastDetail is the newest per-skip explanation the detection site could
+	// state (today: the snapshot validator's exclusion reason). Display-only
+	// free text, never parsed.
+	LastDetail string `json:"last_detail,omitempty"`
 }
+
+// MaxLedgerTables caps SkipStat.Tables — enough names to act on in one sitting
+// without letting a persisted, monotonic document grow unbounded.
+const MaxLedgerTables = 8
 
 // SkipAttribution locates one skipped event: binlog file/pos, the statement
 // keyword (derived from the statement text, which is then discarded), and the
@@ -85,6 +115,15 @@ type SkipAttribution struct {
 	Pos           uint64
 	StatementType string
 	ConnectionID  uint32
+	// Schema and Table name the table whose rows were dropped. Kept as two
+	// plain strings, not a slice: RecordSkipAttributed compares this struct
+	// against its zero value with ==, which a slice field would break at
+	// compile time.
+	Schema string
+	Table  string
+	// Detail is a short human explanation of THIS skip (today: the snapshot
+	// validator's exclusion reason). Optional.
+	Detail string
 }
 
 // SkipCounters aggregates capture-time skips by reason. Safe for concurrent
@@ -163,20 +202,48 @@ func (c *SkipCounters) RecordSkipAttributed(reason string, attr SkipAttribution)
 	if attr != (SkipAttribution{}) {
 		st.LastFile, st.LastPos = attr.File, attr.Pos
 		st.LastStatementType, st.LastConnectionID = attr.StatementType, attr.ConnectionID
+		if attr.Detail != "" {
+			st.LastDetail = attr.Detail
+		}
+		if attr.Table != "" {
+			addLedgerTable(&st, attr.Schema, attr.Table)
+		}
 	}
 	c.byReason[reason] = st
 	c.consecutive++
 	if c.consecutive >= SkipEscalationThreshold && !c.escalated {
 		c.escalated = true
 		remediation := "the schema snapshot is likely stale or corrupt — run `bintrail snapshot` against the source, then restart the stream"
-		if reason == SkipStatementFormatDML {
+		switch reason {
+		case SkipStatementFormatDML:
 			remediation = "set binlog_format=ROW server-wide on the source (a STATEMENT/MIXED format or a session-level override is producing row-less events)"
+		case SkipTableExcludedFromSnapshot:
+			// Never point this reason at `bintrail snapshot`: the validator
+			// excludes the same table on every re-run (#1051/#1199), so that
+			// remediation loops forever while the operator believes they fixed it.
+			remediation = "these tables are excluded from every snapshot by validation — give each an explicit PRIMARY KEY on an InnoDB engine at the source; re-snapshotting alone will not capture them"
 		}
 		c.logger.Error("sustained event skipping — capture is effectively stopped: every recent event was read from the stream and discarded, while the checkpoint keeps advancing past them; the skipped changes are NOT in the index",
 			"consecutive_skips", c.consecutive,
 			"reason", reason,
 			"remediation", remediation)
 	}
+}
+
+// addLedgerTable adds "schema.table" to st.Tables if it is new and the cap
+// allows, flagging TablesTruncated otherwise. Insertion order is preserved (the
+// first tables to break are the ones that broke first); dedup is linear because
+// the slice never exceeds MaxLedgerTables entries.
+func addLedgerTable(st *SkipStat, schema, table string) {
+	name := schema + "." + table
+	if slices.Contains(st.Tables, name) {
+		return
+	}
+	if len(st.Tables) >= MaxLedgerTables {
+		st.TablesTruncated = true
+		return
+	}
+	st.Tables = append(st.Tables, name)
 }
 
 // RecordCaptured notes that an event cleared every guard and was emitted for

--- a/internal/parser/skips_tables_test.go
+++ b/internal/parser/skips_tables_test.go
@@ -1,0 +1,115 @@
+package parser
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// ─── Per-table skip attribution (#1296) ───────────────────────────────────────
+//
+// The capture-degraded verdict could say events were dropped but not WHICH
+// table's — the first question an operator asks, and one only the daemon log
+// could answer. These pin the ledger half of that fix, including the two
+// properties a persisted, monotonic document needs: a bound, and a way to tell
+// a capped list from a complete one.
+
+func TestRecordSkipAttributed_recordsTheTable(t *testing.T) {
+	c := NewSkipCounters(nil)
+	c.RecordSkipAttributed(SkipTableNotInSnapshot, SkipAttribution{
+		File: "binlog.000042", Pos: 512, Schema: "shop", Table: "plugin_log",
+	})
+	c.RecordSkipAttributed(SkipTableNotInSnapshot, SkipAttribution{
+		File: "binlog.000042", Pos: 700, Schema: "shop", Table: "plugin_meta",
+	})
+	// The same table again must not appear twice.
+	c.RecordSkipAttributed(SkipTableNotInSnapshot, SkipAttribution{
+		File: "binlog.000042", Pos: 900, Schema: "shop", Table: "plugin_log",
+	})
+
+	st := decodeLedger(t, c)[SkipTableNotInSnapshot]
+	if st.Count != 3 {
+		t.Errorf("count = %d, want 3", st.Count)
+	}
+	want := []string{"shop.plugin_log", "shop.plugin_meta"}
+	if len(st.Tables) != len(want) {
+		t.Fatalf("tables = %v, want %v", st.Tables, want)
+	}
+	for i, w := range want {
+		if st.Tables[i] != w {
+			t.Errorf("tables[%d] = %q, want %q", i, st.Tables[i], w)
+		}
+	}
+	if st.TablesTruncated {
+		t.Error("two tables under the cap must not be flagged truncated")
+	}
+}
+
+func TestRecordSkipAttributed_capsAndFlagsTheTableList(t *testing.T) {
+	c := NewSkipCounters(nil)
+	for i := range MaxLedgerTables + 5 {
+		c.RecordSkipAttributed(SkipTableNotInSnapshot, SkipAttribution{
+			Schema: "shop", Table: string(rune('a'+i)) + "_tbl",
+		})
+	}
+	st := decodeLedger(t, c)[SkipTableNotInSnapshot]
+	if len(st.Tables) != MaxLedgerTables {
+		t.Errorf("tables kept %d entries, want the cap %d — this document is persisted and monotonic", len(st.Tables), MaxLedgerTables)
+	}
+	if !st.TablesTruncated {
+		t.Error("a capped list must be flagged, or it reads as the complete set")
+	}
+}
+
+// The exclusion reason is what tells an operator their table needs a primary
+// key rather than another snapshot.
+func TestRecordSkipAttributed_keepsTheDetail(t *testing.T) {
+	c := NewSkipCounters(nil)
+	c.RecordSkipAttributed(SkipTableExcludedFromSnapshot, SkipAttribution{
+		Schema: "shop", Table: "audit_raw", Detail: "no explicit primary key",
+	})
+	st := decodeLedger(t, c)[SkipTableExcludedFromSnapshot]
+	if st.LastDetail != "no explicit primary key" {
+		t.Errorf("last_detail = %q, want the exclusion reason", st.LastDetail)
+	}
+}
+
+// The two absent-table causes must stay under separate reasons: merged, half
+// the operators get a remedy that can never converge.
+func TestRecordSkip_excludedAndMissingAreDistinctReasons(t *testing.T) {
+	c := NewSkipCounters(nil)
+	c.RecordSkipAttributed(SkipTableNotInSnapshot, SkipAttribution{Schema: "a", Table: "b"})
+	c.RecordSkipAttributed(SkipTableExcludedFromSnapshot, SkipAttribution{Schema: "c", Table: "d"})
+	m := decodeLedger(t, c)
+	if m[SkipTableNotInSnapshot].Count != 1 || m[SkipTableExcludedFromSnapshot].Count != 1 {
+		t.Errorf("the two causes must be counted apart: %v", m)
+	}
+	if SkipTableNotInSnapshot == SkipTableExcludedFromSnapshot {
+		t.Fatal("the reason keys must differ")
+	}
+}
+
+// A ledger written before this change has no tables key; seeding it must not
+// invent one.
+func TestSeed_legacyLedgerHasNoTables(t *testing.T) {
+	c := NewSkipCounters(nil)
+	if err := c.Seed(`{"table_not_in_snapshot":{"count":3,"last_at":"2026-08-04T19:49:33Z"}}`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	st := decodeLedger(t, c)[SkipTableNotInSnapshot]
+	if len(st.Tables) != 0 {
+		t.Errorf("a legacy ledger must carry no table names, got %v", st.Tables)
+	}
+}
+
+func decodeLedger(t *testing.T, c *SkipCounters) map[string]SkipStat {
+	t.Helper()
+	raw, err := c.Snapshot()
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	m := map[string]SkipStat{}
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatalf("unmarshal %s: %v", raw, err)
+	}
+	return m
+}

--- a/internal/status/capture_explain_test.go
+++ b/internal/status/capture_explain_test.go
@@ -1,0 +1,236 @@
+package status
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ─── The DEGRADED verdict's explanation (#1296) ───────────────────────────────
+//
+// An operator on a live install read the old single sentence and reported three
+// things, all fair: it implied they had misconfigured something, its remedy had
+// no button anywhere, and "check the capture log" named neither a place nor a
+// string to look for. Each test below pins one of those repairs, plus the
+// honesty caveat the old text omitted entirely.
+
+func explainJoined(skips map[string]CaptureSkipStat) string {
+	return strings.Join(ExplainCaptureSkips(skips), "\n")
+}
+
+func TestExplainCaptureSkips_namesTheSkippedTables(t *testing.T) {
+	out := explainJoined(map[string]CaptureSkipStat{
+		CaptureSkipReasonTableNotInSnapshot: {
+			Count:  3,
+			LastAt: time.Date(2026, 8, 4, 19, 49, 33, 0, time.UTC),
+			Tables: []string{"shop.plugin_log", "shop.plugin_meta"},
+		},
+	})
+	for _, want := range []string{"shop.plugin_log", "shop.plugin_meta"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("explanation does not name the skipped table %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestExplainCaptureSkips_truncatedTableListSaysSo(t *testing.T) {
+	out := explainJoined(map[string]CaptureSkipStat{
+		CaptureSkipReasonTableNotInSnapshot: {
+			Count: 99, Tables: []string{"a.b"}, TablesTruncated: true,
+		},
+	})
+	if !strings.Contains(out, "and others") {
+		t.Errorf("a capped table list must not read as the complete set:\n%s", out)
+	}
+}
+
+// A ledger written before per-table attribution has NO table names. The
+// explanation must then name none — inventing one, or rendering the empty list
+// as "no tables", would be worse than saying nothing.
+func TestExplainCaptureSkips_legacyLedgerNamesNoTable(t *testing.T) {
+	out := explainJoined(map[string]CaptureSkipStat{
+		CaptureSkipReasonTableNotInSnapshot: {Count: 3},
+	})
+	if !strings.Contains(out, "cannot name them") {
+		t.Errorf("a ledger without table attribution must say so:\n%s", out)
+	}
+	if strings.Contains(out, "no tables") {
+		t.Errorf("an empty table list must never render as 'no tables':\n%s", out)
+	}
+}
+
+// The complaint that started this: the text read as operator error. A table
+// appearing on the source is ordinary, and the explanation must say the stream's
+// OWN auto-snapshot path is what did not run — not that the operator forgot
+// something.
+func TestExplainCaptureSkips_doesNotBlameTheOperator(t *testing.T) {
+	out := explainJoined(map[string]CaptureSkipStat{
+		CaptureSkipReasonTableNotInSnapshot: {Count: 3, Tables: []string{"shop.plugin_log"}},
+	})
+	if !strings.Contains(out, "ordinary") {
+		t.Errorf("the ordinary cause must be named as ordinary:\n%s", out)
+	}
+	if !strings.Contains(out, "snapshot when it sees the CREATE/ALTER") {
+		t.Errorf("the explanation must say the stream's own auto-snapshot path did not run:\n%s", out)
+	}
+}
+
+// A fresh snapshot fixes capture GOING FORWARD only. Without this line an
+// operator re-snapshots, sees green, and believes the hole closed.
+func TestExplainCaptureSkips_statesWhatIsNotRecovered(t *testing.T) {
+	out := explainJoined(map[string]CaptureSkipStat{
+		CaptureSkipReasonTableNotInSnapshot: {Count: 3, Tables: []string{"shop.plugin_log"}},
+	})
+	if !strings.Contains(out, "recovers what was already skipped") {
+		t.Errorf("the explanation must say the remedy is forward-only:\n%s", out)
+	}
+	if !strings.Contains(out, "binlogs covering that window") {
+		t.Errorf("the only path back to the skipped events must be stated honestly:\n%s", out)
+	}
+}
+
+// "Check the capture log" named neither a location nor a string. Both must be
+// present.
+func TestExplainCaptureSkips_namesTheLogAndTheLine(t *testing.T) {
+	out := explainJoined(map[string]CaptureSkipStat{
+		CaptureSkipReasonTableNotInSnapshot: {Count: 3},
+	})
+	if !strings.Contains(out, "docker compose logs bintrail") {
+		t.Errorf("the log must be named concretely:\n%s", out)
+	}
+	if !strings.Contains(out, "table not in snapshot — skipping") {
+		t.Errorf("the exact log line to look for must be named:\n%s", out)
+	}
+}
+
+// The two causes of an absent table have OPPOSITE remedies. Sending a
+// validation-excluded table to `bintrail snapshot` is the non-converging
+// remediation #1199 fixed elsewhere: every future snapshot excludes it again.
+func TestExplainCaptureSkips_excludedTableIsNotSentToResnapshot(t *testing.T) {
+	out := explainJoined(map[string]CaptureSkipStat{
+		CaptureSkipReasonTableExcludedFromSnapshot: {
+			Count: 12, Tables: []string{"shop.audit_raw"}, LastDetail: "no explicit primary key",
+		},
+	})
+	if !strings.Contains(out, "PRIMARY KEY") {
+		t.Errorf("the excluded-table branch must ask for a primary key:\n%s", out)
+	}
+	if !strings.Contains(out, "Re-snapshotting is NOT the fix here") {
+		t.Errorf("the excluded-table branch must refuse the re-snapshot remedy:\n%s", out)
+	}
+	if !strings.Contains(out, "no explicit primary key") {
+		t.Errorf("the recorded exclusion reason must be surfaced:\n%s", out)
+	}
+	if strings.Contains(out, "Refresh schema snapshot") {
+		t.Errorf("the excluded-table branch must not offer the console's re-snapshot action:\n%s", out)
+	}
+}
+
+// The ordinary branch must NOT borrow the excluded branch's text, and vice
+// versa — one shared remedy is exactly what made the message useless.
+func TestExplainCaptureSkips_branchesDoNotShareRemedies(t *testing.T) {
+	ordinary := explainJoined(map[string]CaptureSkipStat{
+		CaptureSkipReasonTableNotInSnapshot: {Count: 1, Tables: []string{"a.b"}},
+	})
+	if !strings.Contains(ordinary, "Refresh schema snapshot") {
+		t.Errorf("the ordinary branch must point at the console action:\n%s", ordinary)
+	}
+	if strings.Contains(ordinary, "Re-snapshotting is NOT the fix here") {
+		t.Errorf("the ordinary branch must not carry the excluded branch's refusal:\n%s", ordinary)
+	}
+}
+
+// The remedy names a SCHEMA SNAPSHOT; the console's neighbouring button creates
+// a BASELINE. The old wording invited confusing the two.
+func TestExplainCaptureSkips_distinguishesSnapshotFromBaseline(t *testing.T) {
+	out := explainJoined(map[string]CaptureSkipStat{
+		CaptureSkipReasonTableNotInSnapshot: {Count: 1, Tables: []string{"a.b"}},
+	})
+	if !strings.Contains(out, "not a baseline") {
+		t.Errorf("the remedy must say a schema snapshot is not a baseline:\n%s", out)
+	}
+}
+
+func TestExplainCaptureSkips_emptyLedgerExplainsNothing(t *testing.T) {
+	if got := ExplainCaptureSkips(map[string]CaptureSkipStat{}); got != nil {
+		t.Errorf("nothing skipped must explain nothing, got %v", got)
+	}
+	if got := ExplainCaptureSkips(map[string]CaptureSkipStat{"x": {Count: 0}}); got != nil {
+		t.Errorf("a zero-count reason must explain nothing, got %v", got)
+	}
+}
+
+// The text report and the console must render the SAME strings: the wire field
+// is what makes that true, so its absence is a regression, not a cosmetic one.
+func TestWriteStatus_degradedBlockCarriesTheExplanation(t *testing.T) {
+	var buf bytes.Buffer
+	ledger := `{"table_not_in_snapshot":{"count":3,"last_at":"2026-08-04T19:49:33Z","tables":["shop.plugin_log"]}}`
+	WriteStatus(&buf, nil, nil, nil, nil, nil, captureStream(ledger))
+	// Collapse the fixed-width wrapping before matching: the report wraps these
+	// paragraphs to the column width, so a phrase assertion against the raw text
+	// would break on an unrelated prose edit that shifts a line boundary.
+	out := strings.Join(strings.Fields(buf.String()), " ")
+	for _, want := range []string{
+		"shop.plugin_log",
+		"recovers what was already skipped",
+		"docker compose logs bintrail",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text status is missing %q:\n%s", want, out)
+		}
+	}
+	// The old text sent everyone to the CLI with no other option; the console
+	// action is now the first remedy named.
+	if !strings.Contains(out, "bintrail snapshot --source-dsn") {
+		t.Errorf("text status must still give the CLI form of the remedy:\n%s", out)
+	}
+}
+
+func TestWriteStatusJSON_carriesExplanationAndTables(t *testing.T) {
+	ledger := `{"table_not_in_snapshot":{"count":3,"last_at":"2026-08-04T19:49:33Z","tables":["shop.plugin_log"],"tables_truncated":true}}`
+	out := decodeStatusJSON(t, captureStream(ledger))
+	ch := out["stream"].(map[string]any)["capture_health"].(map[string]any)
+	expl, ok := ch["explanation"].([]any)
+	if !ok || len(expl) == 0 {
+		t.Fatalf("capture_health carries no explanation: %v", ch)
+	}
+	joined, _ := json.Marshal(expl)
+	if !strings.Contains(string(joined), "shop.plugin_log") {
+		t.Errorf("the wire explanation does not name the table: %s", joined)
+	}
+	stat := ch["skipped"].(map[string]any)["table_not_in_snapshot"].(map[string]any)
+	tables, _ := stat["tables"].([]any)
+	if len(tables) != 1 || tables[0] != "shop.plugin_log" {
+		t.Errorf("per-reason tables not carried on the wire: %v", stat)
+	}
+	if stat["tables_truncated"] != true {
+		t.Errorf("tables_truncated not carried on the wire: %v", stat)
+	}
+}
+
+// An "ok" verdict must carry no explanation — a green banner with remediation
+// prose in it would be its own bug report.
+func TestWriteStatusJSON_okVerdictHasNoExplanation(t *testing.T) {
+	out := decodeStatusJSON(t, captureStream("{}"))
+	ch := out["stream"].(map[string]any)["capture_health"].(map[string]any)
+	if _, present := ch["explanation"]; present {
+		t.Errorf("ok verdict must omit the explanation: %v", ch)
+	}
+}
+
+func TestWrapAt_keepsLongWordsIntact(t *testing.T) {
+	// A table name or a command broken across lines is uncopyable, which is
+	// worse than an over-long line.
+	got := wrapAt("run `bintrail-console-with-a-very-long-name --flag` now", 20)
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, "`bintrail-console-with-a-very-long-name") {
+		t.Errorf("a long word must not be split: %q", got)
+	}
+	for _, line := range got {
+		if strings.Contains(line, "  ") {
+			t.Errorf("wrapping introduced double spaces: %q", line)
+		}
+	}
+}

--- a/internal/status/capture_health.go
+++ b/internal/status/capture_health.go
@@ -1,0 +1,236 @@
+// Package status — this file builds the operator-facing account of a DEGRADED
+// capture verdict (#1296). It is shared on purpose: `bintrail status` prints
+// these lines and the console renders the same strings from
+// /api/status (stream.capture_health.explanation), so the two surfaces cannot
+// drift into telling one operator a different story than the other.
+//
+// What the old single sentence got wrong, and what every line here defends:
+//
+//   - It read as operator error. A table appearing on the source (an
+//     application or a plugin creating one) is ordinary operation, not
+//     misconfiguration, and the text must not imply otherwise.
+//   - It named a remedy with no location. "Take a fresh snapshot" said nothing
+//     about WHICH table, WHERE the button is, or that a schema snapshot is a
+//     different artifact from a baseline.
+//   - It implied the remedy closed the hole. It does not: a fresh snapshot
+//     fixes capture from that point on, and the already-skipped events stay
+//     missing unless the source's binlogs still cover the window.
+//   - It sent everyone to `bintrail snapshot`, including the operators for whom
+//     that can never converge (a validation-excluded table is excluded again by
+//     every future snapshot — #1051/#1199).
+package status
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// Capture-skip reason keys, mirroring the parser's persisted vocabulary. Kept
+// as independent decls for the same reason CaptureSkipStat is: this display
+// package deliberately does not import the binlog parser.
+const (
+	CaptureSkipReasonTableNotInSnapshot        = "table_not_in_snapshot"
+	CaptureSkipReasonTableExcludedFromSnapshot = "table_excluded_from_snapshot"
+	CaptureSkipReasonColumnCountMismatch       = "column_count_mismatch"
+	CaptureSkipReasonNoResolver                = "no_resolver"
+)
+
+// ExplainCaptureSkips renders the DEGRADED verdict's explanation: one
+// cause/remedy pair per active reason (most events first), then the two lines
+// that apply to every reason — what a remedy does NOT recover, and where the
+// per-event detail lives. Returns nil when nothing was skipped, so a caller can
+// use a nil result as "there is nothing to explain".
+//
+// Pure and fixture-drivable: no clock, no IO. The caller supplies the decoded
+// ledger; every claim here is derived from it.
+func ExplainCaptureSkips(skips map[string]CaptureSkipStat) []string {
+	active := activeReasons(skips)
+	if len(active) == 0 {
+		return nil
+	}
+	var lines []string
+	for _, reason := range active {
+		lines = append(lines, causeLine(reason, skips[reason]))
+		lines = append(lines, remedyLine(reason))
+	}
+	// The scope caveat is unconditional and deliberately blunt: without it an
+	// operator applies the remedy, sees capture go green, and assumes the hole
+	// closed. It never did — the remedy is forward-only.
+	lines = append(lines, "None of this recovers what was already skipped: those changes are absent "+
+		"from the index for good unless the source still has the binlogs covering that window, in "+
+		"which case `bintrail index --binlog-dir <dir> --files <file>` can re-read them.")
+	lines = append(lines, logLine(active[0]))
+	return lines
+}
+
+// activeReasons lists the reasons with a non-zero count, most events first
+// (ties alphabetical) — the same ordering captureSkipReasons uses, so the
+// summary line and this explanation agree on which reason dominates.
+func activeReasons(skips map[string]CaptureSkipStat) []string {
+	var reasons []string
+	for r, st := range skips {
+		if st.Count > 0 {
+			reasons = append(reasons, r)
+		}
+	}
+	sort.Slice(reasons, func(i, j int) bool {
+		if skips[reasons[i]].Count != skips[reasons[j]].Count {
+			return skips[reasons[i]].Count > skips[reasons[j]].Count
+		}
+		return reasons[i] < reasons[j]
+	})
+	return reasons
+}
+
+// causeLine states what happened for one reason, naming the tables when the
+// ledger recorded them.
+func causeLine(reason string, st CaptureSkipStat) string {
+	subject := namedTables(st)
+	switch reason {
+	case CaptureSkipReasonTableNotInSnapshot:
+		return subject + " changed on the source but " + isAre(st) + " missing from the schema snapshot " +
+			"capture decodes against, so those row events could not be indexed. A table appearing on the " +
+			"source is ordinary — an application or plugin creating one is not a misconfiguration. What is " +
+			"unusual is that capture did not follow it: the stream takes its own snapshot when it sees the " +
+			"CREATE/ALTER, so this points at that path not running — the DDL happened while capture was " +
+			"stopped, or the automatic snapshot failed, or the table falls outside this stream's " +
+			"schema/table filter."
+	case CaptureSkipReasonTableExcludedFromSnapshot:
+		detail := ""
+		if st.LastDetail != "" {
+			detail = " (" + st.LastDetail + ")"
+		}
+		return subject + " " + isAre(st) + " left out of the schema snapshot ON PURPOSE by snapshot " +
+			"validation" + detail + ". bintrail addresses rows by primary key on an InnoDB table; without " +
+			"one it cannot index or reverse a change, so those row events are dropped."
+	case CaptureSkipReasonColumnCountMismatch:
+		return subject + " " + hasHave(st) + " a different number of columns in the binlog than in the " +
+			"schema snapshot, so values would map to the wrong column names. Capture drops the rows rather " +
+			"than index them under wrong names — the snapshot is behind a schema change on the source."
+	case CaptureSkipReasonNoResolver:
+		return "Capture ran with no schema snapshot loaded at all, so no row event could be decoded."
+	case CaptureSkipReasonStatementFormatDML:
+		return "The source wrote these changes as STATEMENT/MIXED-format events, which carry no row images. " +
+			"There is nothing in the binlog to index — this is a source configuration, not a bintrail fault."
+	case CaptureSkipReasonUnreadablePreviousLedger:
+		return "The capture ledger persisted by a previous run could not be parsed, so an earlier tally of " +
+			"skipped events may have been lost. This entry preserves the fact; it is not itself a skipped event."
+	default:
+		return subject + " had row events read from the stream and dropped under \"" + reason + "\"."
+	}
+}
+
+// remedyLine gives the action for one reason. The schema-snapshot remedies say
+// what a schema snapshot IS: the console's other button creates a BASELINE (a
+// full copy of the data), and an operator who confuses the two runs a dump they
+// did not need while capture stays broken.
+func remedyLine(reason string) string {
+	switch reason {
+	case CaptureSkipReasonTableNotInSnapshot, CaptureSkipReasonColumnCountMismatch, CaptureSkipReasonNoResolver:
+		return "Fix: refresh the schema snapshot for this source — the record of each table's columns that " +
+			"capture decodes against (not a baseline, which is a full copy of the data). In the console: " +
+			"Overview → \"Refresh schema snapshot\". On the command line: `bintrail snapshot --source-dsn " +
+			"<source> --index-dsn <index>`, then restart the stream so it picks the new snapshot up."
+	case CaptureSkipReasonTableExcludedFromSnapshot:
+		return "Fix: give each table listed above an explicit PRIMARY KEY on an InnoDB engine at the source. " +
+			"Re-snapshotting is NOT the fix here — validation excludes these tables again every time, so a " +
+			"fresh snapshot would leave capture exactly as it is now."
+	case CaptureSkipReasonStatementFormatDML:
+		return "Fix: set binlog_format=ROW server-wide on the source (a session-level override can also " +
+			"produce row-less events)."
+	case CaptureSkipReasonUnreadablePreviousLedger:
+		return "Fix: with the capture daemon stopped, clear stream_state.capture_skips to acknowledge the " +
+			"lost tally; leaving it makes every later status report stay non-clean."
+	default:
+		return "Fix: see the capture daemon's log for this reason's detail."
+	}
+}
+
+// logLine names the log to read and the exact line to look for. "check the
+// capture log" named neither a location nor a string to grep, which is what
+// made it useless; anything replacing it must name both.
+func logLine(reason string) string {
+	needle := map[string]string{
+		CaptureSkipReasonTableNotInSnapshot:        "table not in snapshot — skipping",
+		CaptureSkipReasonTableExcludedFromSnapshot: "table not in snapshot — skipping",
+		CaptureSkipReasonColumnCountMismatch:       "column count mismatch — skipping",
+		CaptureSkipReasonNoResolver:                "no resolver available — skipping",
+	}[reason]
+	s := "Per-event detail is in the log of the process capturing this source — `bintrail stream` or " +
+		"`bintrail-console watch` (with the bundled compose file: `docker compose logs bintrail`)"
+	if needle != "" {
+		s += ", on the lines reading \"" + needle + "\""
+	}
+	return s + "."
+}
+
+// namedTables renders the ledger's table names as the subject of a sentence, or
+// a neutral subject when the ledger has none. A ledger written before per-table
+// attribution has an EMPTY list, which must never render as "no tables" — the
+// tables exist, this index just cannot name them.
+func namedTables(st CaptureSkipStat) string {
+	if len(st.Tables) == 0 {
+		return "Rows of one or more tables (this index's ledger predates per-table attribution, so it cannot name them)"
+	}
+	names := strings.Join(st.Tables, ", ")
+	if st.TablesTruncated {
+		names += " and others"
+	}
+	return names
+}
+
+// isAre / hasHave keep the sentences grammatical for one table vs several, and
+// for the unnamed-tables subject (always plural).
+func isAre(st CaptureSkipStat) string {
+	if len(st.Tables) == 1 {
+		return "is"
+	}
+	return "are"
+}
+
+func hasHave(st CaptureSkipStat) string {
+	if len(st.Tables) == 1 {
+		return "has"
+	}
+	return "have"
+}
+
+// wrapAt breaks text into lines of at most width runes at word boundaries, for
+// the fixed-width text status output. A word longer than width is emitted on
+// its own line rather than split — breaking a table name or a command in half
+// would make it uncopyable, which is worse than an over-long line.
+func wrapAt(text string, width int) []string {
+	var (
+		out  []string
+		line strings.Builder
+	)
+	for _, word := range strings.Fields(text) {
+		switch {
+		case line.Len() == 0:
+			line.WriteString(word)
+		case line.Len()+1+len(word) <= width:
+			line.WriteString(" ")
+			line.WriteString(word)
+		default:
+			out = append(out, line.String())
+			line.Reset()
+			line.WriteString(word)
+		}
+	}
+	if line.Len() > 0 {
+		out = append(out, line.String())
+	}
+	return out
+}
+
+// writeCaptureSkipExplanation prints the explanation into the text status
+// output, indented and wrapped to the width the rest of the report uses.
+func writeCaptureSkipExplanation(w io.Writer, skips map[string]CaptureSkipStat) {
+	for _, para := range ExplainCaptureSkips(skips) {
+		for _, line := range wrapAt(para, 76) {
+			fmt.Fprintf(w, "  %s\n", line)
+		}
+	}
+}

--- a/internal/status/capture_health.go
+++ b/internal/status/capture_health.go
@@ -61,6 +61,15 @@ func ExplainCaptureSkips(skips map[string]CaptureSkipStat) []string {
 	lines = append(lines, "None of this recovers what was already skipped: those changes are absent "+
 		"from the index for good unless the source still has the binlogs covering that window, in "+
 		"which case `bintrail index --binlog-dir <dir> --files <file>` can re-read them.")
+	// Say that the verdict itself persists. The tallies are monotonic and
+	// re-seeded across restarts precisely so a skip episode cannot be laundered
+	// away by a restart — which means a WORKING fix does not turn this banner
+	// green, and an operator who does not know that concludes the fix failed and
+	// applies it again.
+	lines = append(lines, "This warning does not clear on its own: the tally counts skips that happened, "+
+		"not skips still happening, so it stays after a successful fix. Confirm the fix by watching the "+
+		"count stop rising; to reset the tally, stop capture for this source and clear "+
+		"stream_state.capture_skips in its index.")
 	lines = append(lines, logLine(active[0]))
 	return lines
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -130,6 +130,14 @@ type CaptureSkipStat struct {
 	LastPos           uint64 `json:"last_pos,omitempty"`
 	LastStatementType string `json:"last_statement_type,omitempty"`
 	LastConnectionID  uint32 `json:"last_connection_id,omitempty"`
+	// Tables / TablesTruncated / LastDetail mirror parser.SkipStat (#1296):
+	// which tables stopped being captured, whether the capped list is complete,
+	// and the newest per-skip explanation. Empty on a ledger written before
+	// per-table attribution — the explanation must then name no table at all
+	// rather than present the empty list as "none".
+	Tables          []string `json:"tables,omitempty"`
+	TablesTruncated bool     `json:"tables_truncated,omitempty"`
+	LastDetail      string   `json:"last_detail,omitempty"`
 }
 
 // CaptureSkipReasonStatementFormatDML mirrors parser.SkipStatementFormatDML —
@@ -718,8 +726,11 @@ func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, arch
 					fmt.Fprintf(w, "  Last drop:       %s\n", attr)
 				}
 				fmt.Fprintln(w, "  Skipped events were read from the stream but NOT indexed — a restore window")
-				fmt.Fprintln(w, "  over them is incomplete. Most often the schema snapshot is stale or corrupt:")
-				fmt.Fprintln(w, "  run `bintrail snapshot` against the source, then check the daemon log.")
+				fmt.Fprintln(w, "  over them is incomplete.")
+				// Cause, remedy and scope come from the shared explanation
+				// builder (#1296) so this report and the console cannot tell
+				// two different stories about the same ledger.
+				writeCaptureSkipExplanation(w, skips)
 			} else {
 				fmt.Fprintln(w, "  Capture health:  OK — no events skipped")
 			}
@@ -1112,12 +1123,24 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		LastPos           uint64 `json:"last_pos,omitempty"`
 		LastStatementType string `json:"last_statement_type,omitempty"`
 		LastConnectionID  uint32 `json:"last_connection_id,omitempty"`
+		// Which tables stopped being captured (#1296), and whether the capped
+		// list is the complete set.
+		Tables          []string `json:"tables,omitempty"`
+		TablesTruncated bool     `json:"tables_truncated,omitempty"`
+		LastDetail      string   `json:"last_detail,omitempty"`
 	}
 	type jsonCaptureHealth struct {
 		Status       string                  `json:"status"`
 		TotalSkipped int64                   `json:"total_skipped"`
 		LastSkipAt   string                  `json:"last_skip_at,omitempty"`
 		Skipped      map[string]jsonSkipStat `json:"skipped,omitempty"`
+		// Explanation is the rendered cause/remedy/scope prose (#1296), built by
+		// the same ExplainCaptureSkips the text report uses. It ships over the
+		// wire rather than being re-authored in the console's JavaScript,
+		// because two hand-written copies of this advice drifted once already —
+		// and the half that drifts is the half telling an operator what a
+		// remedy does NOT recover.
+		Explanation []string `json:"explanation,omitempty"`
 	}
 	type jsonStream struct {
 		BintrailID     *string        `json:"bintrail_id"`
@@ -1276,9 +1299,13 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 							LastPos:           st.LastPos,
 							LastStatementType: st.LastStatementType,
 							LastConnectionID:  st.LastConnectionID,
+							Tables:            st.Tables,
+							TablesTruncated:   st.TablesTruncated,
+							LastDetail:        st.LastDetail,
 						}
 					}
 				}
+				ch.Explanation = ExplainCaptureSkips(skips)
 			}
 			jstr.CaptureHealth = ch
 		}

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -418,6 +418,81 @@ try {
   cont.missingNeither ? ok("continuity: missing continuity (legacy backend) shows no green") : bad("continuity: missing continuity (legacy backend) shows no green", "rendered green without continuity");
   cont.nilNeither ? ok("continuity: nil stream shows neither box") : bad("continuity: nil stream shows neither box", "rendered a box for nil stream");
 
+  // Scenario 8b — capture-degraded banner (#1296). captureHealthBox is pure
+  // like continuityBox. What it must NOT do again: render advice written in
+  // this file. The cause/remedy/scope prose is built by the backend
+  // (status.ExplainCaptureSkips) and shipped in capture_health.explanation, so
+  // `bintrail status` and the console cannot drift — and the half that drifted
+  // would be the one saying what a remedy does NOT recover. The fixture drives
+  // both the current backend (explanation present) and an older one (absent).
+  const cap = await page.evaluate(() => {
+    const withExpl = captureHealthBox({
+      capture_health: {
+        status: "degraded", total_skipped: 3, last_skip_at: "2026-08-04 19:49:33",
+        skipped: { table_not_in_snapshot: { count: 3, tables: ["shop.plugin_log"] } },
+        explanation: [
+          "shop.plugin_log changed on the source but is missing from the schema snapshot.",
+          "None of this recovers what was already skipped.",
+        ],
+      },
+    });
+    const legacy = captureHealthBox({
+      capture_health: { status: "degraded", total_skipped: 3, skipped: { table_not_in_snapshot: { count: 3 } } },
+    });
+    const okBox = captureHealthBox({ capture_health: { status: "ok" } });
+    const nilBox = captureHealthBox(null);
+    // Render it to confirm the per-paragraph spacing rule resolves — without it
+    // the caveat merges into the wall of text above it.
+    let lineGap = "";
+    if (withExpl) {
+      document.body.appendChild(withExpl);
+      const line = withExpl.querySelector(".warn-line");
+      lineGap = line ? getComputedStyle(line).marginTop : "";
+      withExpl.remove();
+    }
+    return {
+      showsBackendProse: !!withExpl && /shop\.plugin_log/.test(withExpl.textContent)
+        && /recovers what was already skipped/.test(withExpl.textContent),
+      noOperatorBlame: !!withExpl && !/take a fresh snapshot on the source/.test(withExpl.textContent)
+        && !/check the capture log/.test(withExpl.textContent),
+      legacyFallback: !!legacy && /too old to say why/.test(legacy.textContent)
+        && !/recovers what was already skipped/.test(legacy.textContent),
+      okNone: okBox === null,
+      nilNone: nilBox === null,
+      lineGap,
+    };
+  });
+  cap.showsBackendProse ? ok("capture health: banner renders the backend's explanation (table named)") : bad("capture health: banner renders the backend's explanation (table named)", JSON.stringify(cap));
+  cap.noOperatorBlame ? ok("capture health: the old blame-the-operator wording is gone") : bad("capture health: the old blame-the-operator wording is gone", "old copy still rendered");
+  cap.legacyFallback ? ok("capture health: an old backend gets a fallback that promises nothing") : bad("capture health: an old backend gets a fallback that promises nothing", "fallback missing or invents advice");
+  (cap.okNone && cap.nilNone) ? ok("capture health: ok/nil render no banner") : bad("capture health: ok/nil render no banner", `ok=${cap.okNone} nil=${cap.nilNone}`);
+  (cap.lineGap && cap.lineGap !== "0px") ? ok("capture health: explanation paragraphs are spaced apart (CSS applied)") : bad("capture health: explanation paragraphs are spaced apart (CSS applied)", `marginTop=${cap.lineGap}`);
+
+  // Scenario 8c — the remedy is reachable from the UI (#1296). The whole point
+  // of the issue: the banner named an action with no button anywhere. It must
+  // appear for a monitored REGISTRY server, and never for the reserved boot
+  // entry (which the endpoint refuses — a button that 409s is worse than none).
+  const capBtn = await page.evaluate(async () => {
+    const servers = (await api("/api/servers")).servers || [];
+    const registryServer = servers.find((s) => s.kind !== "ephemeral");
+    const before = currentServer;
+    const probe = (id) => {
+      currentServer = id;
+      const box = captureHealthBox({ capture_health: { status: "degraded", total_skipped: 1, skipped: {} } });
+      const btn = box ? Array.from(box.querySelectorAll("button")).find((b) => /Refresh schema snapshot/.test(b.textContent)) : null;
+      return !!btn;
+    };
+    const onRegistry = registryServer ? probe(registryServer.id) : null;
+    const onBoot = probe("default");
+    currentServer = before;
+    return { capOn: !!capsCache.schema_snapshot_trigger, onRegistry, onBoot };
+  });
+  capBtn.capOn ? ok("capture health: schema_snapshot_trigger capability reaches the frontend") : bad("capture health: schema_snapshot_trigger capability reaches the frontend", "capsCache.schema_snapshot_trigger falsy");
+  (capBtn.onRegistry === null || capBtn.onRegistry)
+    ? ok("capture health: Refresh-schema-snapshot button renders for a registry server")
+    : bad("capture health: Refresh-schema-snapshot button renders for a registry server", "no button in the banner");
+  !capBtn.onBoot ? ok("capture health: no Refresh button for the command-line entry") : bad("capture health: no Refresh button for the command-line entry", "offered an action the endpoint refuses");
+
   // Scenario 9 — Storage page AWS-credentials card (#681). credentialsCard is
   // pure (like pgHealthCard/continuityBox): it must lead with a plain-language
   // summary of which credential source is active, never leave the raw signals

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -482,15 +482,27 @@ try {
       const btn = box ? Array.from(box.querySelectorAll("button")).find((b) => /Refresh schema snapshot/.test(b.textContent)) : null;
       return !!btn;
     };
-    const onRegistry = registryServer ? probe(registryServer.id) : null;
-    const onBoot = probe("default");
-    currentServer = before;
-    return { capOn: !!capsCache.schema_snapshot_trigger, onRegistry, onBoot };
+    try {
+      return {
+        capOn: !!capsCache.schema_snapshot_trigger,
+        // Reported, not assumed: with no registry server the button check would
+        // otherwise pass by testing nothing.
+        foundRegistryServer: !!registryServer,
+        onRegistry: registryServer ? probe(registryServer.id) : false,
+        onBoot: probe("default"),
+      };
+    } finally {
+      // Restore even on a throw: page.evaluate throwing crashes this harness,
+      // but a half-restored selection would silently point every later scenario
+      // at the wrong server.
+      currentServer = before;
+    }
   });
   capBtn.capOn ? ok("capture health: schema_snapshot_trigger capability reaches the frontend") : bad("capture health: schema_snapshot_trigger capability reaches the frontend", "capsCache.schema_snapshot_trigger falsy");
-  (capBtn.onRegistry === null || capBtn.onRegistry)
+  (capBtn.foundRegistryServer && capBtn.onRegistry)
     ? ok("capture health: Refresh-schema-snapshot button renders for a registry server")
-    : bad("capture health: Refresh-schema-snapshot button renders for a registry server", "no button in the banner");
+    : bad("capture health: Refresh-schema-snapshot button renders for a registry server",
+      capBtn.foundRegistryServer ? "no button in the banner" : "no registry server in the fixture — the check tested nothing");
   !capBtn.onBoot ? ok("capture health: no Refresh button for the command-line entry") : bad("capture health: no Refresh button for the command-line entry", "offered an action the endpoint refuses");
 
   // Scenario 9 — Storage page AWS-credentials card (#681). credentialsCard is


### PR DESCRIPTION
Closes #1296.

The report was that the "Capture degraded" banner was unreadable, that its remedy could not be followed from the UI, and that following it appeared not to work. All three were true, and the third is the interesting one.

**The banner does not clear when you fix the problem.** `capture_skips` is a monotonic tally, re-seeded across restarts on purpose so a skip episode cannot be laundered away by bouncing the daemon. So a *working* fix leaves the warning exactly where it was, and an operator who does not know that concludes the fix failed and applies it again. The banner now says so, and says how to confirm a fix (watch the count stop rising) and how to reset the tally deliberately.

**The remedy is reachable now.** "Take a fresh snapshot on the source" had no button. `POST /api/servers/{id}/schema-snapshot` takes the snapshot and restarts that server's capture stream so the new snapshot is actually loaded — a refresh that skipped the reload would look like a fix and be a no-op, which is worse than the missing button it replaces.

Three things the review pass corrected, each a way the action could have lied:

- **The reload hook returned only an error**, so "this process supervises no stream for that entry" and "the stream restarted" were the same answer. They are not — the entry may be captured by *another* process, still decoding against the old snapshot. It returns `(restarted bool, err error)` now, and the UI prints the daemon's account rather than asserting a state it cannot see. The reload can fail with the old stream still running (registry entry gone) or with it stopped (it did not drain in time), so the old copy, "capture is still using the previous snapshot", was a lie for the second case.
- **The job had no deadline.** The snapshot cannot be cancelled — `metadata`'s snapshot taker holds no context and `config.Connect`'s timeout covers only the TCP handshake — so a source blocked behind a metadata lock would hang the job for the life of the process and leave every later trigger answering 409. Jobs are bounded, and a superseded run publishes nothing; generations are counted **per server**, since one global counter would let a snapshot on server B abandon an in-flight one on server A.
- **The permission tier was wrong.** This verb stops and restarts capture, which is what `servers:write` gates. `baseline:create` and `verify` are maintenance actions that leave capture alone; tiering a capture-stopping verb with them hands it to a role never meant to be able to take capture down.

Verification: `go build ./...`, `go vet ./...` and `go vet -tags integration ./...` clean; `consoleapp`, `internal/console` and `internal/status` green; `node --check` on the frontend; new `console_e2e.mjs` assertions. Rebased onto `main` after #1305/#1306/#1307. (Two `internal/status` integration test files show up under `gofmt -l` — they are unformatted on `main` as well and untouched here.)
