### PR TITLE
pgshim: enforce allowed_schemas on the PostgreSQL wire front-end

### DIFF
--- a/cmd/bintrail-pg/flashback.go
+++ b/cmd/bintrail-pg/flashback.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -105,6 +106,17 @@ func runFlashback(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Per-tenant schema isolation (#824/#1261), built from the same helper the
+	// MySQL shim uses. The startup warning mirrors it too: an operator who set
+	// allowed_schemas on some tenants can reasonably read the file as isolated,
+	// and silence there is how an unrestricted tenant goes unnoticed.
+	allowedSchemas := shim.UserAllowedSchemas(tenantCfgs)
+	if unrestricted := shim.TenantsWithoutAllowedSchemas(tenantCfgs); len(tenantCfgs) > 1 && len(unrestricted) > 0 {
+		slog.Warn(
+			"flashback: cross-schema isolation is NOT enforced for some tenants; any of them can query every schema in the index. Add allowed_schemas to each tenant in shim.yaml to isolate them",
+			"tenants", strings.Join(unrestricted, ", "))
+	}
+
 	db, err := config.Connect(fbIndexDSN)
 	if err != nil {
 		return fmt.Errorf("connect to index: %w", err)
@@ -168,9 +180,10 @@ func runFlashback(cmd *cobra.Command, args []string) error {
 			BaselineS3:   fbBaselineS3,
 			QueryTimeout: fbQueryTimeout,
 		},
-		Auth:     auth,
-		Logger:   slog.Default(),
-		MaxConns: fbMaxConns,
+		Auth:           auth,
+		AllowedSchemas: allowedSchemas,
+		Logger:         slog.Default(),
+		MaxConns:       fbMaxConns,
 	}
 	return pgshim.Serve(ctx, listener, cfg)
 }

--- a/docs/time-travel-sql.md
+++ b/docs/time-travel-sql.md
@@ -216,6 +216,13 @@ any-schema behaviour, so existing configs are unaffected. When `shim.yaml`
 has more than one tenant and any of them lacks `allowed_schemas`, the shim
 logs a startup warning that cross-schema isolation is not enforced.
 
+**Both wire front-ends enforce it.** `bintrail-pg flashback` reads the same
+`shim.yaml` and applies the same allowlist to the same resolved target schema,
+including a fully qualified query that never selected a database; there the
+refusal is `SQLSTATE 42501` (`insufficient_privilege`) rather than MySQL 1044,
+and it is a query error — the connection stays usable. It emits the same
+multi-tenant startup warning.
+
 ---
 
 ## Step 2 — Install ProxySQL

--- a/internal/cli/shim.go
+++ b/internal/cli/shim.go
@@ -691,19 +691,17 @@ func buildUserSchemas(tenantCfgs []shim.TenantConfig) map[string]string {
 	return out
 }
 
-// buildUserAllowedSchemas maps mysql_user → allowed_schemas for the
+// buildUserAllowedSchemas delegates to shim.UserAllowedSchemas, which the
+// PostgreSQL front-end also builds from (#1261) — one derivation, so the two
+// front-ends cannot disagree about who is restricted.
+//
+// Original doc: maps mysql_user → allowed_schemas for the
 // tenants that opted into schema isolation (#824). Tenants without the
 // field are simply absent — handleConn's map lookup then yields nil,
 // which Handler.BindAllowedSchemas treats as unrestricted (the exact
 // pre-#824 behaviour).
 func buildUserAllowedSchemas(tenantCfgs []shim.TenantConfig) map[string][]string {
-	out := make(map[string][]string)
-	for _, t := range tenantCfgs {
-		if len(t.AllowedSchemas) > 0 {
-			out[t.MySQLUser] = t.AllowedSchemas
-		}
-	}
-	return out
+	return shim.UserAllowedSchemas(tenantCfgs)
 }
 
 // tenantsWithoutAllowedSchemas lists the mysql_users that have no
@@ -713,13 +711,7 @@ func buildUserAllowedSchemas(tenantCfgs []shim.TenantConfig) map[string][]string
 // tenant's indexed history. Pure function so the classification is
 // unit-testable without a listener.
 func tenantsWithoutAllowedSchemas(tenantCfgs []shim.TenantConfig) []string {
-	var out []string
-	for _, t := range tenantCfgs {
-		if len(t.AllowedSchemas) == 0 {
-			out = append(out, t.MySQLUser)
-		}
-	}
-	return out
+	return shim.TenantsWithoutAllowedSchemas(tenantCfgs)
 }
 
 // handleConn wraps one accepted TCP connection in go-mysql/server's

--- a/internal/pgshim/pgshim.go
+++ b/internal/pgshim/pgshim.go
@@ -81,6 +81,12 @@ type Config struct {
 	ShimConfig shim.Config
 	// Auth validates the per-tenant cleartext password (loaded from shim.yaml).
 	Auth shim.TenantAuth
+	// AllowedSchemas maps tenant username → allowed_schemas (#824/#1261),
+	// built with shim.UserAllowedSchemas from the same shim.yaml the MySQL
+	// front-end loads. A username ABSENT from the map is unrestricted, which
+	// is what an empty/omitted allowed_schemas means; nil disables the gate
+	// for every tenant.
+	AllowedSchemas map[string][]string
 	// Logger; nil → slog.Default().
 	Logger *slog.Logger
 	// MaxConns caps concurrent connections; 0 = unlimited.
@@ -210,8 +216,21 @@ func handleConn(ctx context.Context, c net.Conn, cfg Config, logger *slog.Logger
 	// the audit identity for every time-travel query on this connection is
 	// that tenant. Post-auth: user is only trustworthy here.
 	h.BindActor(user)
+	// Bind the tenant's allowed_schemas allowlist (#1261) BEFORE any schema is
+	// seeded, mirroring the MySQL front-end (internal/cli/shim.go handleConn).
+	// The enforcement point itself is session.resolve, on the parser-resolved
+	// target schema — the only place that sees every way a client can name one.
+	h.BindAllowedSchemas(cfg.AllowedSchemas[user])
 	// currentDB = the connect database param (the bintrail schema). Empty is
 	// allowed: queries must then schema-qualify the table (<schema>.<table>).
+	//
+	// A connect database outside the tenant's allowlist is deliberately NOT a
+	// startup refusal: denial belongs on the query, as a proper wire error the
+	// client can read, rather than a connection that dies during handshake. So
+	// the param still seeds session.currentDB and the per-query gate answers
+	// 42501 on the first real query. UseDB's error is discarded because h.db is
+	// unused on this front-end — session.currentDB is what Parse sees — and it
+	// now returns one whenever the allowlist excludes the connect database.
 	_ = h.UseDB(database)
 
 	sess := &session{be: be, h: h, currentDB: database, logger: logger}

--- a/internal/pgshim/schema_authz_test.go
+++ b/internal/pgshim/schema_authz_test.go
@@ -1,0 +1,218 @@
+package pgshim
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbtrail/dbtrail/internal/shim"
+)
+
+// These drive the REAL session entry point over a real pgx client and socket:
+// the allowed_schemas gate must fire on this front-end (#1261), on whichever
+// schema the parser resolves — the connect database or an explicit
+// `<schema>.<table>` qualification that never went through a selection.
+//
+// All DB-free. The gate refuses before any index read, and the positive
+// controls land on the full-table refusal (0A000), which also precedes any
+// index read — so cfg.IndexDB stays nil and a wrong verdict shows up as a
+// different SQLSTATE rather than a nil-pointer panic.
+
+// serveAddrCfg stands up Serve with an arbitrary Config; serveAddr is the
+// auth-only shorthand over it.
+func serveAddrCfg(t *testing.T, cfg Config) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = discardLogger()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); _ = Serve(ctx, ln, cfg) }()
+	t.Cleanup(func() {
+		cancel()
+		_ = ln.Close()
+		<-done
+	})
+	return ln.Addr().String()
+}
+
+// dialDB connects with an explicit connect-database param — the pg equivalent
+// of the MySQL front-end's USE, and the value Parse resolves an unqualified
+// virtual-schema query against.
+func dialDB(t *testing.T, addr, user, pass, database string) *pgx.Conn {
+	t.Helper()
+	cfg, err := pgx.ParseConfig(fmt.Sprintf("postgres://%s:%s@%s/%s", user, pass, addr, database))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	cfg.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer dialCancel()
+	conn, err := pgx.ConnectConfig(dialCtx, cfg)
+	if err != nil {
+		t.Fatalf("pgx connect (database=%s): %v", database, err)
+	}
+	t.Cleanup(func() {
+		cc, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = conn.Close(cc)
+	})
+	return conn
+}
+
+// deadDB is a CLOSED index handle: no server is contacted, but a query that
+// gets past the gate fails with "database is closed" instead of dereferencing
+// nil. That is what keeps the mutation signal readable — delete the
+// enforcement call and the denial tests fail on the SQLSTATE they assert
+// (XX000, not 42501) rather than panicking somewhere down the resolve path.
+func deadDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("mysql", "u:p@tcp(127.0.0.1:1)/idx")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return db
+}
+
+// gatedConn serves a single tenant restricted to allowed and connects to
+// database.
+func gatedConn(t *testing.T, database string, allowed ...string) *pgx.Conn {
+	t.Helper()
+	addr := serveAddrCfg(t, Config{
+		IndexDB:        deadDB(t),
+		Auth:           testAuth(t),
+		AllowedSchemas: map[string][]string{testUser: allowed},
+	})
+	return dialDB(t, addr, testUser, testPass, database)
+}
+
+func TestPGWire_AllowedSchemasDeniesConnectDatabase(t *testing.T) {
+	conn := gatedConn(t, "public", "shop")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Unqualified virtual-schema form: Parse resolves the schema from the
+	// connect database, which is outside the allowlist.
+	_, err := conn.Exec(ctx, "SELECT * FROM _flashback.orders AS OF 'now' WHERE id = 1")
+	pgErr := requirePgError(t, err)
+	if pgErr.Code != "42501" {
+		t.Fatalf("code = %s, want 42501 (insufficient_privilege); msg=%s", pgErr.Code, pgErr.Message)
+	}
+	if !contains(pgErr.Message, "public") || !contains(pgErr.Message, testUser) {
+		t.Fatalf("denial message names neither the schema nor the tenant: %s", pgErr.Message)
+	}
+	// A denied query is a QUERY error, not a connection drop (#1261): the
+	// session must still be usable.
+	if _, err := conn.Exec(ctx, "SET x=1"); err != nil {
+		t.Fatalf("connection did not survive the denial: %v", err)
+	}
+}
+
+func TestPGWire_AllowedSchemasDeniesQualifiedBypass(t *testing.T) {
+	// Connected to an ALLOWED database, so nothing about the session's
+	// selection is suspicious — the foreign schema arrives only in the
+	// statement. This is the case a connect-time-only check would miss.
+	conn := gatedConn(t, "shop", "shop")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Bare AS OF on a real table is END-anchored (#385), so the WHERE precedes it.
+	_, err := conn.Exec(ctx, "SELECT * FROM other.orders WHERE id = 1 AS OF 'now'")
+	pgErr := requirePgError(t, err)
+	if pgErr.Code != "42501" {
+		t.Fatalf("code = %s, want 42501; msg=%s", pgErr.Code, pgErr.Message)
+	}
+	if !contains(pgErr.Message, "other") {
+		t.Fatalf("denial names the wrong schema: %s", pgErr.Message)
+	}
+}
+
+func TestPGWire_AllowedSchemasAdmitsListedSchema(t *testing.T) {
+	conn := gatedConn(t, "shop", "shop", "warehouse")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Both the connect database and an explicitly qualified sibling are on the
+	// allowlist. Neither may be refused BY THE GATE: each falls through to the
+	// full-table refusal, which is what a permitted query hits next here.
+	for _, q := range []string{
+		"SELECT * FROM _flashback.orders AS OF 'now'",
+		"SELECT * FROM warehouse.orders AS OF 'now'",
+	} {
+		_, err := conn.Exec(ctx, q)
+		pgErr := requirePgError(t, err)
+		if pgErr.Code == "42501" {
+			t.Fatalf("allowed schema refused by the gate: %q → %s", q, pgErr.Message)
+		}
+		if pgErr.Code != "0A000" || !contains(pgErr.Message, "full-table") {
+			// 0A000 is also the not-time-travel refusal, so the message is what
+			// proves the statement PARSED and reached the full-table gate —
+			// otherwise a misparse would read as "the schema gate allowed it".
+			t.Fatalf("%q: code = %s, want the 0A000 full-table refusal; msg=%s", q, pgErr.Code, pgErr.Message)
+		}
+	}
+}
+
+func TestPGWire_NoAllowlistIsUnrestricted(t *testing.T) {
+	// Absent from the map = no allowed_schemas in shim.yaml = the pre-#824
+	// behaviour. A tenant who never opted in must not start being refused.
+	addr := serveAddrCfg(t, Config{Auth: testAuth(t), AllowedSchemas: map[string][]string{}})
+	conn := dialDB(t, addr, testUser, testPass, "anything")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := conn.Exec(ctx, "SELECT * FROM whatever.orders AS OF 'now'")
+	pgErr := requirePgError(t, err)
+	if pgErr.Code != "0A000" || !contains(pgErr.Message, "full-table") {
+		t.Fatalf("unrestricted tenant: code = %s, want the 0A000 full-table refusal; msg=%s", pgErr.Code, pgErr.Message)
+	}
+}
+
+// TestPGWireGateAgreesWithMySQLGate pins that the two front-ends decide
+// identically. They render different errors on purpose (mysqld's 1044 wording
+// vs SQLSTATE 42501), so the shared piece is the VERDICT — and a verdict that
+// drifts is precisely what #1261 was.
+func TestPGWireGateAgreesWithMySQLGate(t *testing.T) {
+	cases := []struct {
+		allowed []string
+		schema  string
+		wantOK  bool
+	}{
+		{nil, "anything", true},
+		{[]string{}, "anything", true},
+		{[]string{"shop"}, "shop", true},
+		{[]string{"shop"}, "SHOP", true}, // schema names fold case
+		{[]string{"shop"}, "public", false},
+		{[]string{"shop", "warehouse"}, "warehouse", true},
+		{[]string{"shop"}, "", false},
+	}
+	for _, c := range cases {
+		h := shim.NewHandler(nil, discardLogger())
+		h.BindAllowedSchemas(c.allowed)
+
+		_, deny := h.SchemaAuthzCheck(c.schema)
+		useErr := h.UseDB(c.schema)
+
+		if deny == c.wantOK {
+			t.Errorf("SchemaAuthzCheck(%q) under %v: deny=%v, want allowed=%v", c.schema, c.allowed, deny, c.wantOK)
+		}
+		if (useErr == nil) != c.wantOK {
+			t.Errorf("UseDB(%q) under %v: err=%v, want allowed=%v", c.schema, c.allowed, useErr, c.wantOK)
+		}
+		if deny == (useErr == nil) {
+			t.Errorf("front-ends disagree on %q under %v: pg deny=%v, mysql err=%v", c.schema, c.allowed, deny, useErr)
+		}
+	}
+}

--- a/internal/pgshim/session.go
+++ b/internal/pgshim/session.go
@@ -81,6 +81,19 @@ func (s *session) resolve(qstr string) (cols []string, rows [][][]byte, tag stri
 			strings.TrimSpace(qstr))}
 	}
 
+	// Per-tenant schema authorization (#824/#1261), on the RESOLVED target
+	// schema — the same rule and the same call the MySQL front-end applies in
+	// HandleQuery. Parse fills q.Schema from the connect database for the
+	// virtual-schema shapes AND from an explicit `<schema>.<table>` on the bare
+	// AS OF form, so this one site covers every way a client can name a schema,
+	// with or without a prior selection.
+	//
+	// It runs BEFORE the PK check, matching the MySQL order: an unauthorized
+	// schema must not first be told whether its WHERE column is a PK.
+	if msg, deny := s.h.SchemaAuthzCheck(q.Schema); deny {
+		return nil, nil, "", &pgErr{"42501", msg}
+	}
+
 	// PK-column validation is shared with the MySQL front-end (#296/#821): a
 	// WHERE whose column is not the table's single-column PK is refused so a
 	// non-PK filter cannot silently return the wrong row.

--- a/internal/shim/schema_authz.go
+++ b/internal/shim/schema_authz.go
@@ -7,34 +7,16 @@ import (
 	"github.com/go-mysql-org/go-mysql/mysql"
 )
 
-// Per-tenant schema authorization (issue #824).
-//
-// shim.yaml models multiple tenants — each with its own credentials and
-// source_dsn — but the virtual-schema query surface answers against ONE
-// shared index, so before this gate any authenticated tenant could read
-// any other tenant's entire indexed history (including deleted rows) by
-// issuing `USE <other-schema>` or by fully qualifying the target table.
-//
-// The gate is OPT-IN: a tenant without allowed_schemas in shim.yaml keeps
-// the historical unrestricted behaviour, so existing single-tenant
-// deployments are untouched. The standalone `bintrail shim` warns at
-// startup when a multi-tenant config leaves any tenant unrestricted.
-
 // BindAllowedSchemas binds the authenticated tenant's allowed_schemas
-// allowlist to this connection's handler. Call it once per connection,
-// after the handshake and before serving commands — same lifecycle (and
-// same no-lock-needed reasoning) as BindActor. nil or empty means
-// unrestricted.
+// allowlist to this connection's handler. Empty/nil = unrestricted (the
+// pre-#824 behaviour). Call it BEFORE seeding the handler's schema, so a
+// seed outside the allowlist is refused rather than silently trusted.
 func (h *Handler) BindAllowedSchemas(schemas []string) {
 	h.allowedSchemas = schemas
 }
 
 // schemaAllowed reports whether the connection may touch schema. An
-// unbound (nil/empty) allowlist allows everything — the opt-in contract.
-// Comparison is case-insensitive (strings.EqualFold), matching how MySQL
-// folds database identifiers under its default lower_case_table_names
-// packaging on the platforms bintrail ships for; an allowlist must not
-// become bypassable by re-casing the schema name.
+// empty allowlist means unrestricted.
 func (h *Handler) schemaAllowed(schema string) bool {
 	if len(h.allowedSchemas) == 0 {
 		return true
@@ -47,23 +29,82 @@ func (h *Handler) schemaAllowed(schema string) bool {
 	return false
 }
 
-// schemaDenied logs the denied cross-schema attempt and returns the
-// wire error for it: ER_DBACCESS_DENIED_ERROR (1044), the code a real
-// mysqld uses when a user has no grants on a database — a proper MySQL
-// error the client library surfaces, never a connection drop. The slog
-// warning is the denial's operator-visible trail; the shim has no
-// denied-side audit action in the ext seam taxonomy (only successful
-// timetravel.query emissions), and this deliberately does not invent
-// one.
-func (h *Handler) schemaDenied(schema string) error {
+// logSchemaDenial emits the single denial log line and returns a
+// protocol-neutral message. Both wire front-ends funnel through it so a
+// denied access is logged exactly once, with the same fields, wherever it was
+// refused.
+func (h *Handler) logSchemaDenial(schema string) string {
 	actor := h.actor
 	if actor == "" {
 		actor = unboundActor
 	}
-	if h.logger != nil { // struct-literal handlers in tests may omit it
+	if h.logger != nil {
 		h.logger.Warn("shim: cross-schema access denied by allowed_schemas",
 			"tenant", actor, "schema", schema)
 	}
+	return fmt.Sprintf("access denied for user %q to schema %q", actor, schema)
+}
+
+// SchemaAuthzCheck is the cross-protocol half of the allowed_schemas gate
+// (#824, extended to the PostgreSQL front-end in #1261): it makes the
+// DECISION, emits the denial log, and hands back a protocol-neutral message
+// for the caller to render as its own wire error. Same shape and the same
+// reason as PKColumnCheck — one rule enforced from two front-ends, each
+// speaking its own protocol.
+//
+// The MySQL front-end does NOT use the returned message: its wording mimics
+// mysqld's own ER_DBACCESS_DENIED_ERROR text, which clients and ProxySQL key
+// on. Only the decision and the log are shared.
+func (h *Handler) SchemaAuthzCheck(schema string) (msg string, deny bool) {
+	if h.schemaAllowed(schema) {
+		return "", false
+	}
+	return h.logSchemaDenial(schema), true
+}
+
+// schemaDenied builds the MySQL front-end's refusal: the same 1044 a real
+// mysqld returns for a schema the user has no grants on.
+func (h *Handler) schemaDenied(schema string) error {
+	h.logSchemaDenial(schema)
+	actor := h.actor
+	if actor == "" {
+		actor = unboundActor
+	}
 	return mysql.NewError(mysql.ER_DBACCESS_DENIED_ERROR, fmt.Sprintf(
 		"Access denied for user '%s' to database '%s'", actor, schema))
+}
+
+// UserAllowedSchemas maps tenant username → allowed_schemas for every tenant
+// that declares one. Tenants without an allowlist are ABSENT from the map, so
+// a lookup yields nil, which BindAllowedSchemas treats as unrestricted (the
+// exact pre-#824 behaviour).
+//
+// Both serving front-ends build their per-connection binding from this one
+// function: an allowlist derived twice is an allowlist that can disagree with
+// itself, which is how one protocol ends up enforcing what the other does not
+// (#1261 was exactly that, on a larger scale).
+func UserAllowedSchemas(cfgs []TenantConfig) map[string][]string {
+	out := make(map[string][]string, len(cfgs))
+	for _, t := range cfgs {
+		if len(t.AllowedSchemas) > 0 {
+			out[t.MySQLUser] = t.AllowedSchemas
+		}
+	}
+	return out
+}
+
+// TenantsWithoutAllowedSchemas lists the tenant usernames that declare no
+// allowlist. A serving front-end warns once at startup when more than one
+// tenant is configured and any of them is unrestricted: with a single tenant
+// there is nobody to be isolated from, but in a multi-tenant shim an operator
+// who configured allowed_schemas for some tenants can reasonably believe the
+// whole file is isolated.
+func TenantsWithoutAllowedSchemas(cfgs []TenantConfig) []string {
+	var out []string
+	for _, t := range cfgs {
+		if len(t.AllowedSchemas) == 0 {
+			out = append(out, t.MySQLUser)
+		}
+	}
+	return out
 }


### PR DESCRIPTION
Closes #1261. Follow-up to #824 (PR #1255), which noted this gap at delivery.

## The hole

`allowed_schemas` is enforced in the MySQL front-end's two chokepoints — `Handler.UseDB` and `Handler.HandleQuery`. The PostgreSQL front-end reaches neither: `internal/pgshim/session.go` parses with `shim.Parse` and dispatches to the resolver directly. So a tenant connecting over `bintrail-pg flashback` was unrestricted regardless of configuration, and the failure was silent in the worst direction — an operator who configured isolation had every reason to believe it applied.

Mitigated by the field being opt-in and brand new, and the PostgreSQL front-end being beta, which is why it was split out of #1255 rather than blocking it.

## The fix

One decision, two renderings:

- `shim.Handler.SchemaAuthzCheck(schema) (msg, deny)` — the verdict plus the single denial log, returning a protocol-neutral message. Same shape as the existing `PKColumnCheck`, for the same reason: one rule, two front-ends. MySQL keeps its own wording (it mimics mysqld's 1044 text, which clients and ProxySQL key on), so only the decision and the log are shared.
- `shim.UserAllowedSchemas` / `shim.TenantsWithoutAllowedSchemas` — the allowlist is now derived once. `internal/cli` delegates to both. An allowlist derived twice is an allowlist that can disagree with itself, which is this bug's own failure mode one level up.
- `pgshim.Config.AllowedSchemas` is bound per connection, and `session.resolve` gates on the parser-resolved `q.Schema` **before** the PK check — matching the MySQL order, so an unauthorized schema is not first told whether its WHERE column is a primary key.
- `bintrail-pg flashback` builds the map from the same `shim.yaml` and emits the same multi-tenant startup warning the MySQL shim does.

Denial is `SQLSTATE 42501` (`insufficient_privilege`) and a **query** error — the connection survives, as the issue asked. A connect database outside the allowlist is deliberately not a startup refusal either: it seeds the session and the first real query answers 42501, which is readable, rather than a handshake that dies without explanation.

## Tests

Through the real session entry point, over a real pgx client and socket, DB-free:

- connect database outside the list → 42501, message naming tenant and schema, connection still usable afterwards;
- **fully-qualified query with no prior schema selection** → 42501 (the case a connect-time-only check misses);
- allowed schemas — both the connect database and an explicitly qualified sibling — fall through to the full-table refusal, asserted on the message so a misparse cannot masquerade as "the gate allowed it";
- a tenant with no allowlist stays unrestricted (the pre-#824 behaviour must not regress);
- `SchemaAuthzCheck` and `UseDB` never disagree, over a case table including case-folding and the empty schema.

Mutation-checked as #1255's tests were: deleting the enforcement call in `resolve` fails the two denial tests on the SQLSTATE they assert. The test server holds a *closed* index handle on purpose — no server is contacted, but a query that slips past the gate fails with "database is closed" instead of dereferencing nil, which is what keeps that mutation signal readable rather than a panic stack.

`docs/time-travel-sql.md` now states that both wire front-ends enforce the allowlist, and how the refusal differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
