### PR TITLE
console: date the capture-skip tally against the schema snapshot

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2277,14 +2277,34 @@ function continuityBox(stream, pg) {
 // checkpoint, green continuity) while indexing nothing. "ok", "unknown"
 // (missing field) and no stream all render nothing; the continuity box remains
 // the affirmative/loss surface. Pure and fixture-drivable like continuityBox.
+// Two things this renders that the tally alone cannot say (#1312):
+//
+//   - HISTORIC vs ACTIVE. The tally is monotonic, so a successful re-snapshot
+//     leaves it byte-identical and the button this box offers had no visible
+//     effect at all — an operator clicked it, reloaded, and saw the same orange
+//     alarm. `skips_predate_snapshot` (computed by the backend against the
+//     schema snapshot's own timestamp) separates "still dropping rows" from "a
+//     record of something that stopped". Historic goes quiet; it does NOT go
+//     away, because those events are permanently missing and a dismissed box
+//     would trade an annoyance for lost evidence.
+//   - The long form is one click away instead of five paragraphs down. ~250
+//     words of cause/remedy/scope in an alarm box is text nobody reads.
+//
+// An old daemon sends neither field: no anchor, so the box stays loud and open
+// — the pre-#1312 rendering, which is the safe direction.
 function captureHealthBox(stream) {
   if (!stream || !stream.capture_health || stream.capture_health.status !== "degraded") return null;
   const h = stream.capture_health;
-  const box = el("div", { class: "warn-box" });
-  box.append(el("b", { text: "⚠ Capture incomplete — some changes were not indexed" }));
+  const historic = h.skips_predate_snapshot === true;
+  const box = el("div", { class: historic ? "ok-box" : "warn-box" });
+  box.append(el("b", { text: historic
+    ? "Capture gap on record — nothing skipped since the current snapshot"
+    : "⚠ Capture incomplete — some changes were not indexed" }));
   const reasons = Object.keys(h.skipped || {}).sort().join(", ");
   box.append(el("div", { text: h.total_skipped + " event(s) were read from the stream but not indexed" +
-    (reasons ? " (" + reasons + ")" : "") + (h.last_skip_at ? "; last " + h.last_skip_at : "") + "." }));
+    (reasons ? " (" + reasons + ")" : "") + (h.last_skip_at ? "; last " + h.last_skip_at : "") +
+    ". Those changes are missing from the index for good." +
+    (historic && h.snapshot_at ? " The schema snapshot in force since " + h.snapshot_at + " has recorded none." : "") }));
   // Cause, remedy and scope come from the backend (status.ExplainCaptureSkips),
   // the same strings `bintrail status` prints — the console must not re-author
   // this advice in JavaScript, because the half that drifts is always the half
@@ -2292,9 +2312,14 @@ function captureHealthBox(stream) {
   // to send the field, and deliberately promises nothing on its behalf.
   const lines = (Array.isArray(h.explanation) && h.explanation.length) ? h.explanation
     : ["Changes in those events are missing from the index. This daemon is too old to say why — run `bintrail status` against this index for the reason and the fix."];
-  lines.forEach((t) => box.append(el("div", { class: "warn-line", text: t })));
+  const details = el("details", { class: "warn-details" }, el("summary", { text: "Why this happened, and what fixes it" }));
+  lines.forEach((t) => details.append(el("div", { class: "warn-line", text: t })));
   const action = schemaSnapshotButton();
-  if (action) box.append(action);
+  // The action sits inside the disclosure once the skips are historic: it has
+  // already been pressed, and leaving it under the headline invites pressing it
+  // again forever against a tally that will never move.
+  if (action) (historic ? details : box).append(action);
+  box.append(details);
   return box;
 }
 

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1256,8 +1256,18 @@ button { font-family: inherit; }
 /* One paragraph per explanation line (#1296). Without the gap the cause, the
    fix and the "this does not recover what was already skipped" caveat run
    together as one block — and the caveat is the part that gets skimmed past. */
-.warn-box .warn-line { margin-top: 8px; }
-.warn-box .warn-actions { margin-top: 10px; }
+.warn-box .warn-line, .ok-box .warn-line { margin-top: 8px; }
+.warn-box .warn-actions, .ok-box .warn-actions { margin-top: 10px; }
+/* The long-form cause/remedy/scope, collapsed (#1312). It used to render flat
+   and unconditionally — ~250 words inside an alarm box, which is the reliable
+   way to have none of it read. The summary is the affordance; the caveat about
+   what a remedy does NOT recover stays one click away, never deleted. */
+.warn-details { margin-top: 10px; }
+.warn-details > summary {
+  cursor: pointer; font-family: var(--f-mono); font-size: 12.5px;
+  text-decoration: underline; text-underline-offset: 2px; opacity: 0.85;
+}
+.warn-details[open] > summary { margin-bottom: 4px; }
 .warnings:empty { display: none; }
 .warn-item {
   display: flex; gap: 8px; align-items: flex-start;

--- a/internal/status/capture_explain_test.go
+++ b/internal/status/capture_explain_test.go
@@ -16,8 +16,12 @@ import (
 // string to look for. Each test below pins one of those repairs, plus the
 // honesty caveat the old text omitted entirely.
 
+// explainJoined renders with NO snapshot anchor (the zero time), which is the
+// state of an index that holds no schema snapshot. The anchored states have
+// their own tests below; these pin the per-reason cause/remedy prose, which the
+// anchor does not touch.
 func explainJoined(skips map[string]CaptureSkipStat) string {
-	return strings.Join(ExplainCaptureSkips(skips), "\n")
+	return strings.Join(ExplainCaptureSkips(skips, time.Time{}), "\n")
 }
 
 func TestExplainCaptureSkips_namesTheSkippedTables(t *testing.T) {
@@ -154,10 +158,10 @@ func TestExplainCaptureSkips_distinguishesSnapshotFromBaseline(t *testing.T) {
 }
 
 func TestExplainCaptureSkips_emptyLedgerExplainsNothing(t *testing.T) {
-	if got := ExplainCaptureSkips(map[string]CaptureSkipStat{}); got != nil {
+	if got := ExplainCaptureSkips(map[string]CaptureSkipStat{}, time.Time{}); got != nil {
 		t.Errorf("nothing skipped must explain nothing, got %v", got)
 	}
-	if got := ExplainCaptureSkips(map[string]CaptureSkipStat{"x": {Count: 0}}); got != nil {
+	if got := ExplainCaptureSkips(map[string]CaptureSkipStat{"x": {Count: 0}}, time.Time{}); got != nil {
 		t.Errorf("a zero-count reason must explain nothing, got %v", got)
 	}
 }
@@ -232,5 +236,138 @@ func TestWrapAt_keepsLongWordsIntact(t *testing.T) {
 		if strings.Contains(line, "  ") {
 			t.Errorf("wrapping introduced double spaces: %q", line)
 		}
+	}
+}
+
+// ─── The snapshot anchor (#1312) ─────────────────────────────────────────────
+//
+// The tally is monotonic, so it reads identically before and after a successful
+// re-snapshot: an operator pressed the console's own "Refresh schema snapshot"
+// button, reloaded, and got the same alarm. These pin the comparison that makes
+// the tally answerable — and, just as hard, pin that it never claims "fixed".
+
+func skipAt(ts string) CaptureSkipStat {
+	t, err := time.Parse("2006-01-02 15:04:05", ts)
+	if err != nil {
+		panic(err)
+	}
+	return CaptureSkipStat{Count: 3, LastAt: t, Tables: []string{"shop.plugin_log"}}
+}
+
+func mustTime(t *testing.T, ts string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse("2006-01-02 15:04:05", ts)
+	if err != nil {
+		t.Fatalf("bad fixture time %q: %v", ts, err)
+	}
+	return parsed
+}
+
+func TestSkipsPredateSnapshot(t *testing.T) {
+	cases := []struct {
+		name     string
+		skips    map[string]CaptureSkipStat
+		snapshot string
+		want     bool
+	}{
+		{"skip before the snapshot is historic",
+			map[string]CaptureSkipStat{CaptureSkipReasonTableNotInSnapshot: skipAt("2026-08-04 19:49:33")},
+			"2026-08-11 12:00:00", true},
+		{"skip after the snapshot is still active",
+			map[string]CaptureSkipStat{CaptureSkipReasonTableNotInSnapshot: skipAt("2026-08-11 13:00:00")},
+			"2026-08-11 12:00:00", false},
+		// Equal timestamps are NOT historic: a skip stamped at the same second
+		// the snapshot was taken could have come after it, and this verdict
+		// decides whether an operator sees an alarm.
+		{"a skip at the snapshot's own second is not historic",
+			map[string]CaptureSkipStat{CaptureSkipReasonTableNotInSnapshot: skipAt("2026-08-11 12:00:00")},
+			"2026-08-11 12:00:00", false},
+		// One reason quiet does not make the ledger quiet.
+		{"one active reason after the snapshot keeps the whole ledger active",
+			map[string]CaptureSkipStat{
+				CaptureSkipReasonTableNotInSnapshot:  skipAt("2026-08-04 19:49:33"),
+				CaptureSkipReasonColumnCountMismatch: skipAt("2026-08-11 13:00:00"),
+			},
+			"2026-08-11 12:00:00", false},
+		// A zero-count reason is not active and must not veto the verdict.
+		{"a zero-count reason is ignored",
+			map[string]CaptureSkipStat{
+				CaptureSkipReasonTableNotInSnapshot:  skipAt("2026-08-04 19:49:33"),
+				CaptureSkipReasonColumnCountMismatch: {Count: 0},
+			},
+			"2026-08-11 12:00:00", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := SkipsPredateSnapshot(c.skips, mustTime(t, c.snapshot)); got != c.want {
+				t.Errorf("SkipsPredateSnapshot = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// No anchor and an undated skip both mean "cannot tell", and cannot-tell must
+// never render as the quiet state — that is the direction that hides a live
+// capture failure.
+func TestSkipsPredateSnapshot_missingAnchorIsNeverHistoric(t *testing.T) {
+	skips := map[string]CaptureSkipStat{CaptureSkipReasonTableNotInSnapshot: skipAt("2026-08-04 19:49:33")}
+	if SkipsPredateSnapshot(skips, time.Time{}) {
+		t.Error("no snapshot time must not read as historic")
+	}
+	undated := map[string]CaptureSkipStat{CaptureSkipReasonTableNotInSnapshot: {Count: 3}}
+	if SkipsPredateSnapshot(undated, mustTime(t, "2026-08-11 12:00:00")) {
+		t.Error("a skip with no last_at must not read as historic")
+	}
+	if SkipsPredateSnapshot(map[string]CaptureSkipStat{}, mustTime(t, "2026-08-11 12:00:00")) {
+		t.Error("an empty ledger is not a historic ledger")
+	}
+}
+
+func TestExplainCaptureSkips_historicSaysNothingSinceTheSnapshot(t *testing.T) {
+	out := strings.Join(ExplainCaptureSkips(
+		map[string]CaptureSkipStat{CaptureSkipReasonTableNotInSnapshot: skipAt("2026-08-04 19:49:33")},
+		mustTime(t, "2026-08-11 12:00:00")), "\n")
+	if !strings.Contains(out, "Nothing has been skipped since the current schema snapshot") {
+		t.Errorf("the historic state must say the tally stopped moving:\n%s", out)
+	}
+	if !strings.Contains(out, "2026-08-11 12:00:00") {
+		t.Errorf("the historic state must date the snapshot it compared against:\n%s", out)
+	}
+	// The whole reason this verdict is safe to show quietly.
+	if !strings.Contains(out, "not proof the fix took hold") {
+		t.Errorf("the historic state must not read as 'resolved':\n%s", out)
+	}
+	if !strings.Contains(out, "no writes skips nothing") {
+		t.Errorf("an idle source makes 'nothing skipped since' vacuous; the text must say so:\n%s", out)
+	}
+	if !strings.Contains(out, "recovers what was already skipped") {
+		t.Errorf("going quiet must not drop the permanent-loss statement:\n%s", out)
+	}
+}
+
+func TestExplainCaptureSkips_activeSaysTheDropsAreCurrent(t *testing.T) {
+	out := strings.Join(ExplainCaptureSkips(
+		map[string]CaptureSkipStat{CaptureSkipReasonTableNotInSnapshot: skipAt("2026-08-11 13:00:00")},
+		mustTime(t, "2026-08-11 12:00:00")), "\n")
+	if !strings.Contains(out, "skipped AFTER the current schema snapshot") {
+		t.Errorf("the active state must say the drops post-date the snapshot:\n%s", out)
+	}
+	if strings.Contains(out, "Nothing has been skipped since") {
+		t.Errorf("the active state must not carry the historic wording:\n%s", out)
+	}
+}
+
+// With no snapshot in the index there is nothing to compare against, so the
+// pre-#1312 paragraph — including the manual ledger-clearing escape hatch — is
+// still the honest thing to print.
+func TestExplainCaptureSkips_noAnchorKeepsTheManualAcknowledgement(t *testing.T) {
+	out := strings.Join(ExplainCaptureSkips(
+		map[string]CaptureSkipStat{CaptureSkipReasonTableNotInSnapshot: skipAt("2026-08-04 19:49:33")},
+		time.Time{}), "\n")
+	if !strings.Contains(out, "does not clear on its own") {
+		t.Errorf("without an anchor the caveat must stay:\n%s", out)
+	}
+	if strings.Contains(out, "current schema snapshot") {
+		t.Errorf("without an anchor nothing may be claimed about a snapshot:\n%s", out)
 	}
 }

--- a/internal/status/capture_health.go
+++ b/internal/status/capture_health.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"time"
 )
 
 // Capture-skip reason keys, mirroring the parser's persisted vocabulary. Kept
@@ -45,7 +46,7 @@ const (
 //
 // Pure and fixture-drivable: no clock, no IO. The caller supplies the decoded
 // ledger; every claim here is derived from it.
-func ExplainCaptureSkips(skips map[string]CaptureSkipStat) []string {
+func ExplainCaptureSkips(skips map[string]CaptureSkipStat, snapshotAt time.Time) []string {
 	active := activeReasons(skips)
 	if len(active) == 0 {
 		return nil
@@ -66,12 +67,70 @@ func ExplainCaptureSkips(skips map[string]CaptureSkipStat) []string {
 	// away by a restart — which means a WORKING fix does not turn this banner
 	// green, and an operator who does not know that concludes the fix failed and
 	// applies it again.
-	lines = append(lines, "This warning does not clear on its own: the tally counts skips that happened, "+
-		"not skips still happening, so it stays after a successful fix. Confirm the fix by watching the "+
-		"count stop rising; to reset the tally, stop capture for this source and clear "+
-		"stream_state.capture_skips in its index.")
+	lines = append(lines, acknowledgementLine(skips, snapshotAt))
 	lines = append(lines, logLine(active[0]))
 	return lines
+}
+
+// SkipsPredateSnapshot reports whether every recorded skip happened BEFORE the
+// schema snapshot capture decodes against today.
+//
+// It exists because the tally is monotonic — it counts skips that HAPPENED, not
+// skips still happening — so it reads identically before and after a successful
+// re-snapshot, which left the console's own "Refresh schema snapshot" button
+// with no observable effect at all (#1312). The snapshot's own timestamp is the
+// acknowledgement: no new column, and nothing erased.
+//
+// False when the anchor is missing (no snapshot time, or a ledger entry with no
+// last_at): absence of evidence is not a clean window, and this verdict decides
+// whether an operator is shown an alarm.
+//
+// There is deliberately no `if snapshotAt.IsZero()` guard: it would be dead
+// code. No recorded skip can predate the zero time, so a zero anchor already
+// falls out of the comparison below as false — and a guard that cannot be made
+// to fail is a guard nobody can trust. The zero case IS load-bearing in
+// acknowledgementLine, where it selects a different paragraph, and it is tested
+// there.
+func SkipsPredateSnapshot(skips map[string]CaptureSkipStat, snapshotAt time.Time) bool {
+	active := activeReasons(skips)
+	if len(active) == 0 {
+		return false
+	}
+	for _, r := range active {
+		if st := skips[r]; st.LastAt.IsZero() || !st.LastAt.Before(snapshotAt) {
+			return false
+		}
+	}
+	return true
+}
+
+// acknowledgementLine answers the one question the tally cannot: is this still
+// happening, or am I looking at a record of something already fixed?
+//
+// Neither branch says "resolved", and that restraint is the point. stream_state
+// does not record WHICH snapshot capture is running on, so a newer snapshot
+// proves one exists — not that the stream reloaded onto it (refreshSchemaSnapshot
+// already treats "snapshot taken, stream did NOT reload" as its own outcome).
+// And on a source with no writes, "nothing skipped since" is true for the
+// trivial reason. What both branches report is the comparison itself, which is
+// a fact; the caller's own preceding line has already said the skipped events
+// are missing for good.
+func acknowledgementLine(skips map[string]CaptureSkipStat, snapshotAt time.Time) string {
+	if snapshotAt.IsZero() {
+		return "This warning does not clear on its own: the tally counts skips that happened, not skips " +
+			"still happening, so it stays after a successful fix. Confirm the fix by watching the count " +
+			"stop rising; to reset the tally, stop capture for this source and clear " +
+			"stream_state.capture_skips in its index."
+	}
+	if SkipsPredateSnapshot(skips, snapshotAt) {
+		return "Nothing has been skipped since the current schema snapshot was taken (" +
+			snapshotAt.Format(TSFmt) + "). That is not proof the fix took hold — capture does not record " +
+			"which snapshot it is running on, and a source with no writes skips nothing either way — but " +
+			"no drop has been recorded against the layout capture decodes against today."
+	}
+	return "Events were skipped AFTER the current schema snapshot was taken (" + snapshotAt.Format(TSFmt) +
+		"), so this is not a stale tally left over from an already-fixed problem: rows are being dropped " +
+		"against the layout capture decodes against today."
 }
 
 // activeReasons lists the reasons with a non-zero count, most events first
@@ -236,8 +295,8 @@ func wrapAt(text string, width int) []string {
 
 // writeCaptureSkipExplanation prints the explanation into the text status
 // output, indented and wrapped to the width the rest of the report uses.
-func writeCaptureSkipExplanation(w io.Writer, skips map[string]CaptureSkipStat) {
-	for _, para := range ExplainCaptureSkips(skips) {
+func writeCaptureSkipExplanation(w io.Writer, skips map[string]CaptureSkipStat, snapshotAt time.Time) {
+	for _, para := range ExplainCaptureSkips(skips, snapshotAt) {
 		for _, line := range wrapAt(para, 76) {
 			fmt.Fprintf(w, "  %s\n", line)
 		}

--- a/internal/status/capture_health_test.go
+++ b/internal/status/capture_health_test.go
@@ -240,3 +240,55 @@ func TestCommaGroup(t *testing.T) {
 		}
 	}
 }
+
+// ─── The snapshot anchor on the wire (#1312) ─────────────────────────────────
+//
+// The console renders quietly or loudly off these two fields alone, so their
+// presence and their absence both have to be pinned: a missing anchor must not
+// arrive as `skips_predate_snapshot: false` dressed up as a judgement — it is
+// simply no claim, and the renderer keeps the alarm.
+
+func TestWriteStatusJSON_captureHealthCarriesTheSnapshotAnchor(t *testing.T) {
+	s := captureStream(`{"table_not_in_snapshot":{"count":3,"last_at":"2026-08-04T19:49:33Z"}}`)
+	s.SchemaSnapshotAt = sql.NullTime{Time: time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC), Valid: true}
+	ch := decodeStatusJSON(t, s)["stream"].(map[string]any)["capture_health"].(map[string]any)
+
+	if ch["snapshot_at"] != "2026-08-11 12:00:00" {
+		t.Errorf("snapshot_at = %v, want the newest schema snapshot's time", ch["snapshot_at"])
+	}
+	if ch["skips_predate_snapshot"] != true {
+		t.Errorf("skips_predate_snapshot = %v, want true (the skip is a week older)", ch["skips_predate_snapshot"])
+	}
+	// The verdict stays degraded: --fail-on-gap keys on it, and these events are
+	// still permanently missing from the index.
+	if ch["status"] != "degraded" {
+		t.Errorf("status = %v, want degraded even when the skips are historic", ch["status"])
+	}
+}
+
+func TestWriteStatusJSON_captureHealthOmitsTheAnchorWhenThereIsNoSnapshot(t *testing.T) {
+	s := captureStream(`{"table_not_in_snapshot":{"count":3,"last_at":"2026-08-04T19:49:33Z"}}`)
+	ch := decodeStatusJSON(t, s)["stream"].(map[string]any)["capture_health"].(map[string]any)
+
+	if _, present := ch["snapshot_at"]; present {
+		t.Errorf("snapshot_at must be absent with no snapshot in the index, got %v", ch["snapshot_at"])
+	}
+	if _, present := ch["skips_predate_snapshot"]; present {
+		t.Error("skips_predate_snapshot must be absent rather than a false that reads as a judgement")
+	}
+}
+
+func TestWriteStatusJSON_captureHealthAnchorSaysActiveWhenSkipsAreNewer(t *testing.T) {
+	s := captureStream(`{"table_not_in_snapshot":{"count":3,"last_at":"2026-08-11T13:00:00Z"}}`)
+	s.SchemaSnapshotAt = sql.NullTime{Time: time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC), Valid: true}
+	ch := decodeStatusJSON(t, s)["stream"].(map[string]any)["capture_health"].(map[string]any)
+
+	if ch["snapshot_at"] != "2026-08-11 12:00:00" {
+		t.Errorf("snapshot_at = %v", ch["snapshot_at"])
+	}
+	// omitempty: false is absent on the wire, which the renderer reads as
+	// "not historic" — the loud path.
+	if _, present := ch["skips_predate_snapshot"]; present {
+		t.Errorf("a skip newer than the snapshot must not ship a true flag, got %v", ch["skips_predate_snapshot"])
+	}
+}

--- a/internal/status/schema_snapshot_anchor_integration_test.go
+++ b/internal/status/schema_snapshot_anchor_integration_test.go
@@ -1,0 +1,101 @@
+//go:build integration
+
+package status_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/status"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// The snapshot anchor (#1312) is what lets the console tell a capture failure
+// that is STILL HAPPENING from a record of one already fixed — the monotonic
+// tally cannot, which is why pressing "Refresh schema snapshot" changed nothing
+// on screen. The verdict is unit-tested against fixtures; what those cannot
+// cover is that LoadStreamState actually READS the column. Delete the
+// loadSchemaSnapshotTime call and every fixture test still passes, because they
+// set the field by hand. This one goes to a real database.
+
+func TestLoadStreamState_ReadsTheNewestSchemaSnapshotTime(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	db, _ := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		"INSERT INTO stream_state (id, mode, server_id, last_checkpoint) VALUES (1, 'gtid', 7, UTC_TIMESTAMP())"); err != nil {
+		t.Fatalf("seed stream_state: %v", err)
+	}
+
+	// With no snapshot at all the anchor stays invalid — "cannot tell", never a
+	// zero time that would date every skip as "after the snapshot".
+	st, err := status.LoadStreamState(ctx, db)
+	if err != nil {
+		t.Fatalf("LoadStreamState: %v", err)
+	}
+	if st.SchemaSnapshotAt.Valid {
+		t.Errorf("an index with no schema snapshot must leave the anchor invalid, got %v", st.SchemaSnapshotAt.Time)
+	}
+
+	// Two snapshots: the anchor is the NEWEST, and deliberately not the highest
+	// snapshot_id — the id is an auto-increment, the comparison is about time.
+	older := time.Date(2026, 8, 4, 10, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	for i, ts := range []time.Time{newer, older} {
+		if _, err := db.ExecContext(ctx, `INSERT INTO schema_snapshots
+			(snapshot_id, snapshot_time, schema_name, table_name, column_name, ordinal_position, column_key, data_type, is_nullable)
+			VALUES (?, ?, 'shop', 'orders', 'id', 1, 'PRI', 'int', 'NO')`, i+1, ts); err != nil {
+			t.Fatalf("seed schema_snapshots: %v", err)
+		}
+	}
+
+	st, err = status.LoadStreamState(ctx, db)
+	if err != nil {
+		t.Fatalf("LoadStreamState: %v", err)
+	}
+	if !st.SchemaSnapshotAt.Valid {
+		t.Fatal("the anchor must be loaded once a snapshot exists — without it the console cannot go quiet")
+	}
+	if !st.SchemaSnapshotAt.Time.Equal(newer) {
+		t.Errorf("anchor = %v, want the newest snapshot %v (the later row carries the LOWER snapshot_id on purpose)",
+			st.SchemaSnapshotAt.Time, newer)
+	}
+}
+
+// An index old enough to have no schema_snapshots table at all must still load:
+// the anchor only sharpens the capture verdict, so failing to read it may never
+// cost the caller the stream state — including a gap-loss record — it already
+// had. Same tolerance contract as the source_health and capture_skips loaders.
+func TestLoadStreamState_MissingSnapshotTableIsTolerated(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	db, _ := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		"INSERT INTO stream_state (id, mode, server_id, last_checkpoint) VALUES (1, 'gtid', 7, UTC_TIMESTAMP())"); err != nil {
+		t.Fatalf("seed stream_state: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "DROP TABLE schema_snapshots"); err != nil {
+		t.Fatalf("drop schema_snapshots: %v", err)
+	}
+
+	st, err := status.LoadStreamState(ctx, db)
+	if err != nil {
+		t.Fatalf("LoadStreamState must tolerate a missing schema_snapshots table, got: %v", err)
+	}
+	if st == nil || st.ServerID != 7 {
+		t.Fatalf("the stream state itself must survive the missing table: %+v", st)
+	}
+	if st.SchemaSnapshotAt.Valid {
+		t.Error("no table means no anchor, not a zero-time anchor")
+	}
+}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -114,6 +114,17 @@ type StreamStateInfo struct {
 	// Capture health verdict is then unknown and the line is omitted rather
 	// than asserting OK from absent data (the GapColumnsPresent philosophy).
 	CaptureSkips sql.NullString
+	// SchemaSnapshotAt is when the newest schema snapshot in this index was
+	// taken — the layout capture decodes against today. It is the anchor that
+	// makes a monotonic skip tally answerable (#1312): a skip older than this
+	// cannot have been caused by the snapshot now in force. Invalid when the
+	// index holds no snapshot at all, which keeps the verdict at "cannot tell"
+	// rather than inventing a clean window.
+	//
+	// stream_state is single-row per index database, so the newest snapshot in
+	// the same database belongs to the same source — the comparison cannot
+	// cross sources.
+	SchemaSnapshotAt sql.NullTime
 }
 
 // CaptureSkipStat is one reason's tally decoded from CaptureSkips. The JSON
@@ -418,7 +429,31 @@ func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) 
 	if err := loadCaptureSkips(ctx, db, s); err != nil {
 		slog.Warn("could not load capture_skips; keeping stream state without it", "error", err)
 	}
+	// The snapshot anchor (#1312) is best-effort for the same reason: it only
+	// SHARPENS the capture verdict, so failing to read it must never cost the
+	// caller the stream state it already has.
+	if err := loadSchemaSnapshotTime(ctx, db, s); err != nil {
+		slog.Warn("could not load the newest schema snapshot time; capture skips will not be dated against it", "error", err)
+	}
 	return s, nil
+}
+
+// loadSchemaSnapshotTime augments an already-loaded StreamStateInfo with the
+// newest schema_snapshots.snapshot_time (#1312). MAX over the whole table, not
+// the newest snapshot_id: the id is an auto-increment and the time is what the
+// comparison is about.
+//
+// An index with no snapshot yields a NULL row, not zero rows, so the scan
+// target is nullable and an empty result leaves the field invalid — the
+// verdict then stays "cannot tell". A missing TABLE (an index predating
+// snapshots entirely) is tolerated for the same reason the sibling loaders
+// tolerate a missing column.
+func loadSchemaSnapshotTime(ctx context.Context, db *sql.DB, s *StreamStateInfo) error {
+	err := db.QueryRowContext(ctx, `SELECT MAX(snapshot_time) FROM schema_snapshots`).Scan(&s.SchemaSnapshotAt)
+	if isMissingTableErr(err) || errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	return err
 }
 
 func loadStreamStateCore(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) {
@@ -503,6 +538,16 @@ func loadStreamStateBase(ctx context.Context, db *sql.DB) (*StreamStateInfo, err
 func isUnknownColumnErr(err error) bool {
 	var me *mysql.MySQLError
 	return errors.As(err, &me) && me.Number == 1054
+}
+
+// isMissingTableErr is 1054's sibling for a whole table that is not there
+// (1146) — the shape an index predating a table shows, as opposed to a
+// connection that died. Kept narrow to 1146 on purpose: swallowing any error
+// would report "no snapshot exists" for an unreachable database, and the
+// caller reads that absence as "cannot tell", not as an alarm.
+func isMissingTableErr(err error) bool {
+	var me *mysql.MySQLError
+	return errors.As(err, &me) && me.Number == 1146
 }
 
 // StatusData holds all data sections loaded by CollectStatus.
@@ -730,7 +775,7 @@ func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, arch
 				// Cause, remedy and scope come from the shared explanation
 				// builder (#1296) so this report and the console cannot tell
 				// two different stories about the same ledger.
-				writeCaptureSkipExplanation(w, skips)
+				writeCaptureSkipExplanation(w, skips, stream.SchemaSnapshotAt.Time)
 			} else {
 				fmt.Fprintln(w, "  Capture health:  OK — no events skipped")
 			}
@@ -1141,6 +1186,17 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		// and the half that drifts is the half telling an operator what a
 		// remedy does NOT recover.
 		Explanation []string `json:"explanation,omitempty"`
+		// SnapshotAt / SkipsPredateSnapshot are the anchor that makes a
+		// monotonic tally answerable (#1312): when every skip predates the
+		// schema snapshot capture decodes against today, the console renders
+		// the box quietly instead of as a live alarm. Omitted together when
+		// the index holds no snapshot — no anchor, no claim.
+		//
+		// Status stays "degraded" in both cases on purpose. --fail-on-gap keys
+		// on it, and turning a permanent-loss record into an "ok" would be a
+		// change to exit semantics, not a rendering change.
+		SnapshotAt           string `json:"snapshot_at,omitempty"`
+		SkipsPredateSnapshot bool   `json:"skips_predate_snapshot,omitempty"`
 	}
 	type jsonStream struct {
 		BintrailID     *string        `json:"bintrail_id"`
@@ -1305,7 +1361,11 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 						}
 					}
 				}
-				ch.Explanation = ExplainCaptureSkips(skips)
+				if stream.SchemaSnapshotAt.Valid {
+					ch.SnapshotAt = stream.SchemaSnapshotAt.Time.Format(TSFmt)
+					ch.SkipsPredateSnapshot = SkipsPredateSnapshot(skips, stream.SchemaSnapshotAt.Time)
+				}
+				ch.Explanation = ExplainCaptureSkips(skips, stream.SchemaSnapshotAt.Time)
 			}
 			jstr.CaptureHealth = ch
 		}

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -426,6 +426,14 @@ try {
   // would be the one saying what a remedy does NOT recover. The fixture drives
   // both the current backend (explanation present) and an older one (absent).
   const cap = await page.evaluate(() => {
+    // schemaSnapshotButton() is gated on the capability and on a REAL registry
+    // server (the reserved "default" is the daemon's own CLI stream, which the
+    // control plane refuses). Force both, restored below: without them the
+    // button is null and the placement assertions would pass by rendering
+    // nothing, which is the shape this whole scenario exists to catch.
+    const keepCaps = capsCache.schema_snapshot_trigger, keepServer = currentServer;
+    capsCache.schema_snapshot_trigger = true;
+    currentServer = "e2e-registry-server";
     const withExpl = captureHealthBox({
       capture_health: {
         status: "degraded", total_skipped: 3, last_skip_at: "2026-08-04 19:49:33",
@@ -441,15 +449,45 @@ try {
     });
     const okBox = captureHealthBox({ capture_health: { status: "ok" } });
     const nilBox = captureHealthBox(null);
+    // Historic vs active (#1312): the SAME tally, distinguished only by the
+    // backend's skips_predate_snapshot. Historic must go quiet without going
+    // away — the events are still permanently missing.
+    const historic = captureHealthBox({
+      capture_health: {
+        status: "degraded", total_skipped: 3, last_skip_at: "2026-08-04 19:49:33",
+        snapshot_at: "2026-08-11 12:00:00", skips_predate_snapshot: true,
+        skipped: { table_not_in_snapshot: { count: 3 } },
+        explanation: ["Nothing has been skipped since the current schema snapshot was taken (2026-08-11 12:00:00)."],
+      },
+    });
     // Render it to confirm the per-paragraph spacing rule resolves — without it
-    // the caveat merges into the wall of text above it.
-    let lineGap = "";
+    // the caveat merges into the wall of text above it. The lines now live in a
+    // <details>, so it must be opened before measuring: a closed disclosure has
+    // no layout, and a marginTop read from it would prove nothing.
+    let lineGap = "", detailsClosedByDefault = null, buttonAtTopLevel = null, historicButtonInDetails = null;
     if (withExpl) {
       document.body.appendChild(withExpl);
+      const det = withExpl.querySelector("details");
+      detailsClosedByDefault = !!det && !det.open;
+      // The action stays at the top level while the skips are ACTIVE — that is
+      // the state where pressing it is the fix.
+      buttonAtTopLevel = !!withExpl.querySelector(":scope > .warn-actions");
+      if (det) det.open = true;
       const line = withExpl.querySelector(".warn-line");
       lineGap = line ? getComputedStyle(line).marginTop : "";
       withExpl.remove();
     }
+    if (historic) {
+      document.body.appendChild(historic);
+      // ...and moves inside the disclosure once they are HISTORIC: it has been
+      // pressed already, and a button under the headline invites pressing it
+      // forever against a tally that will never move.
+      historicButtonInDetails = !historic.querySelector(":scope > .warn-actions")
+        && !!historic.querySelector("details .warn-actions");
+      historic.remove();
+    }
+    capsCache.schema_snapshot_trigger = keepCaps;
+    currentServer = keepServer;
     return {
       showsBackendProse: !!withExpl && /shop\.plugin_log/.test(withExpl.textContent)
         && /recovers what was already skipped/.test(withExpl.textContent),
@@ -460,6 +498,16 @@ try {
       okNone: okBox === null,
       nilNone: nilBox === null,
       lineGap,
+      detailsClosedByDefault,
+      buttonAtTopLevel,
+      historicButtonInDetails,
+      activeIsOrange: !!withExpl && withExpl.classList.contains("warn-box"),
+      historicIsQuiet: !!historic && historic.classList.contains("ok-box")
+        && !historic.classList.contains("warn-box"),
+      historicStillStatesLoss: !!historic && /missing from the index for good/.test(historic.textContent),
+      historicDatesTheSnapshot: !!historic && /2026-08-11 12:00:00/.test(historic.textContent),
+      // An old daemon sends no anchor: no claim, so it must stay loud.
+      legacyStaysLoud: !!legacy && legacy.classList.contains("warn-box"),
     };
   });
   cap.showsBackendProse ? ok("capture health: banner renders the backend's explanation (table named)") : bad("capture health: banner renders the backend's explanation (table named)", JSON.stringify(cap));
@@ -467,6 +515,14 @@ try {
   cap.legacyFallback ? ok("capture health: an old backend gets a fallback that promises nothing") : bad("capture health: an old backend gets a fallback that promises nothing", "fallback missing or invents advice");
   (cap.okNone && cap.nilNone) ? ok("capture health: ok/nil render no banner") : bad("capture health: ok/nil render no banner", `ok=${cap.okNone} nil=${cap.nilNone}`);
   (cap.lineGap && cap.lineGap !== "0px") ? ok("capture health: explanation paragraphs are spaced apart (CSS applied)") : bad("capture health: explanation paragraphs are spaced apart (CSS applied)", `marginTop=${cap.lineGap}`);
+  cap.detailsClosedByDefault ? ok("capture health: the long explanation starts collapsed") : bad("capture health: the long explanation starts collapsed", "details rendered open — the banner is a wall of text again");
+  cap.activeIsOrange ? ok("capture health: an active skip stays the orange alarm") : bad("capture health: an active skip stays the orange alarm", "active skips lost their alarm styling");
+  cap.historicIsQuiet ? ok("capture health: skips that predate the current snapshot go quiet") : bad("capture health: skips that predate the current snapshot go quiet", "historic skips still render as a live alarm");
+  cap.historicStillStatesLoss ? ok("capture health: the quiet box still states the events are gone for good") : bad("capture health: the quiet box still states the events are gone for good", "going quiet dropped the permanent-loss statement");
+  cap.historicDatesTheSnapshot ? ok("capture health: the quiet box names the snapshot it compared against") : bad("capture health: the quiet box names the snapshot it compared against", "no snapshot date — the operator cannot check the claim");
+  cap.legacyStaysLoud ? ok("capture health: a backend with no anchor stays loud") : bad("capture health: a backend with no anchor stays loud", "missing anchor was read as 'quiet' — that hides a live failure");
+  cap.buttonAtTopLevel ? ok("capture health: the fix button is under the headline while skips are active") : bad("capture health: the fix button is under the headline while skips are active", "the actionable state buried its action");
+  cap.historicButtonInDetails ? ok("capture health: the quiet box moves the button into the disclosure") : bad("capture health: the quiet box moves the button into the disclosure", "a pressed button still sits under the headline");
 
   // Scenario 8c — the remedy is reachable from the UI (#1296). The whole point
   // of the issue: the banner named an action with no button anywhere. It must


### PR DESCRIPTION
console: date the capture-skip tally against the schema snapshot

Pressing "Refresh schema snapshot" — the button this banner itself
offers — changed nothing on screen. The tally in stream_state.capture_skips
is monotonic: it counts skips that HAPPENED, not skips still happening, so
a successful re-snapshot leaves the box byte-identical. The banner knew
this and said so in a paragraph, which is documentation standing in for a
missing feature, and the escape hatch it named (stop the daemon, hand-edit
a JSON column) is not something a console user can do from the console.

The schema snapshot's own timestamp is the acknowledgement. No new column,
nothing erased: MAX(schema_snapshots.snapshot_time) against each reason's
last_at answers "is this still happening?" — and stream_state is single-row
per index database, so the newest snapshot there belongs to the same source
and the comparison cannot cross sources.

Neither wording says "resolved", and that restraint is the feature.
stream_state does not record WHICH snapshot capture is running on, so a
newer one proves it exists, not that the stream reloaded onto it —
refreshSchemaSnapshot already treats "snapshot taken, stream did NOT
reload" as its own outcome. And on a source with no writes, "nothing
skipped since" is true for the trivial reason. Both branches report the
comparison, which is a fact, and both keep saying the skipped events are
missing for good.

status stays "degraded" in both states: --fail-on-gap keys on it, and
turning a permanent-loss record into "ok" is a change to exit semantics,
not a rendering change.

Rendering, second half of the report: ~250 words of cause/remedy/scope
rendered flat and unconditionally inside an alarm box, which is the
reliable way to have none of it read. It moves behind a <details>, one
click away, never deleted. Historic renders in the quiet .ok-box and moves
the action into the disclosure — it has been pressed already, and a button
under the headline invites pressing it forever against a tally that will
never move. A backend sending no anchor stays loud and unchanged: no
claim, so no quieting.

The zero-anchor guard in SkipsPredateSnapshot was removed rather than
kept: mutation testing showed it could not be made to fail, because no
recorded skip predates the zero time and the comparison already returns
false. A guard no test can kill is one nobody can trust. The zero case is
load-bearing in acknowledgementLine, and is tested there.

Tests: table-driven verdict cases including the equal-second boundary
(NOT historic — a skip stamped in the snapshot's own second could have
come after it) and both cannot-tell shapes; JSON presence AND absence of
the two fields; a real-MySQL test that LoadStreamState actually reads the
column, which every fixture test would pass without (they set the field by
hand); and console e2e cases for quiet-vs-loud, the collapsed disclosure,
the button's placement in each state, and that going quiet does not drop
the permanent-loss statement.

Four of five mutations turn a test red; the fifth was the dead guard,
deleted.

Closes #1312.
