### PR TITLE
Let an operator acknowledge a capture-skip record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **A capture-skip record can be acknowledged** (#1314). `stream_state.capture_skips`
+  is monotonic, so a single skip episode kept the console's capture-health box
+  on screen and `status --fail-on-gap` exiting non-zero forever. The only escape
+  the product documented — stop the daemon and clear the column — is impossible
+  from the console and *destroys the loss record*, which is the one thing that
+  should survive. An alert nobody can clear is an alert everybody removes, and
+  the next real loss then lands in silence.
+  - `bintrail status --ack-capture-skips` and the console's **Mark as read**
+    button (`POST /api/capture-skips/ack`, `servers:write`) record the count and
+    the moment in a new `stream_state.capture_skips_ack` column. Nothing is
+    erased: the tally stays, `status` keeps printing it (`⚠ ON RECORD` instead
+    of `⚠ DEGRADED`), and the console renders it muted rather than as an alarm.
+  - An acknowledgement covers a **count**, not a fact, so a later skip lifts the
+    tally above it and the alarm — and the `--fail-on-gap` failure — return with
+    no operator action. It can retire a record; it cannot mute the next
+    incident.
+  - The console endpoint takes the total the page rendered and refuses with 409
+    if the live tally is higher, so a tab left open cannot acknowledge skips
+    nobody looked at.
+  - `status --format json` gains `capture_health.acknowledged` and
+    `capture_health.acknowledged_at`. `capture_health.status` deliberately stays
+    `"degraded"`: the events really are still missing, and a consumer keying on
+    the verdict must not read a human's "seen it" as the loss being undone.
+
 ## [0.53.0] - 2026-08-11
 
 ### Fixed

--- a/docs/rotation-and-status.md
+++ b/docs/rotation-and-status.md
@@ -409,10 +409,26 @@ also fails closed until acknowledged (same runbook as below).
 
 The drop counter is **monotonic for the life of the index** — fixing
 `binlog_format` stops new drops but does not clear the count (the dropped
-changes stay lost). To acknowledge after remediation: stop the capture daemon,
-clear the ledger (`UPDATE stream_state SET capture_skips = '{}' WHERE id = 1` on
-your index), and restart — clearing it with the daemon running is ineffective,
-the next checkpoint re-persists the in-memory tallies.
+changes stay lost). To retire the alert after remediation, **acknowledge** it:
+
+```sh
+bintrail status --index-dsn "$IDX" --ack-capture-skips
+```
+
+or press **Mark as read** on the capture-health box in the web console. Either
+one records the count you saw and the moment you saw it in
+`stream_state.capture_skips_ack`; nothing is erased, `status` keeps reporting
+the tally, and `--fail-on-gap` stops failing on it.
+
+Acknowledgement covers a **count**, not the problem: if anything is skipped
+afterwards the tally rises above what was acknowledged and both the alert and
+the console's alarm come back with no further action. That is what makes it
+safe to press — it can retire a record, it cannot mute the next incident.
+
+Do **not** clear `capture_skips` by hand. That was the old advice and it is
+worse in both directions: the counts are the only evidence those events were
+dropped, and clearing them with the daemon running is ineffective anyway (the
+next checkpoint re-persists the in-memory tallies).
 
 ```sh
 bintrail status --index-dsn "$IDX" --fail-on-gap || alert "dbtrail lost events"
@@ -475,6 +491,7 @@ that window.
 |---|---|
 | `OK — no events skipped` | A skip-aware daemon has evaluated the stream and dropped nothing |
 | `⚠ DEGRADED — N events skipped (<reasons>), last <ts>` | N events were read and discarded; the reasons and the most recent skip time follow |
+| `⚠ ON RECORD — N events skipped (<reasons>), last <ts>` | The same loss, acknowledged by an operator: still reported, no longer alerting. A later skip returns it to `DEGRADED` |
 | *(line absent)* | Unknown — a legacy index, or one no skip-aware daemon has written; `OK` is never asserted from absent data |
 
 Skip reasons include `column_count_mismatch` (stale/corrupt snapshot),

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/cliutil"
 	"github.com/dbtrail/dbtrail/internal/config"
+	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/status"
 )
 
@@ -55,7 +57,14 @@ var (
 	stFormat      string
 	stBaselineDir string
 	stFailOnGap   bool
-	stFailOnLag   time.Duration
+	// stAckCaptureSkips is the one WRITE this otherwise read-only command can
+	// perform (#1314). It lives on `status` rather than getting its own verb
+	// because this is the command that shows the tally: the operator reading
+	// the alarm is already holding the DSN, and a separate command they have
+	// to discover is a command they will not find. The flag name says the
+	// mutation out loud.
+	stAckCaptureSkips bool
+	stFailOnLag       time.Duration
 )
 
 func init() {
@@ -63,6 +72,7 @@ func init() {
 	statusCmd.Flags().StringVar(&stFormat, "format", "text", "Output format: text or json")
 	statusCmd.Flags().StringVar(&stBaselineDir, "baseline-dir", "", "Local directory of baseline Parquet snapshots (optional, shows baseline binlog positions)")
 	statusCmd.Flags().DurationVar(&stFailOnLag, "fail-on-lag", 0, "Exit non-zero if capture is not keeping up: a stalled checkpoint, an unevaluable verdict (fails closed), or a newest indexed event older than this duration (e.g. 15m). TRAFFIC-SENSITIVE: on a source with genuinely quiet periods the age check fires with nothing wrong, so pick a threshold above your quiet windows. Unset (0) never changes the exit code")
+	statusCmd.Flags().BoolVar(&stAckCaptureSkips, "ack-capture-skips", false, "Record that you have seen the current capture-skip tally, then report as usual. The tally is monotonic and never clears itself, so without this a single skip episode keeps `status` non-clean and --fail-on-gap non-zero forever. Nothing is erased: the counts stay, an acknowledgement timestamp is added, and any skip AFTER this one raises the alarm again")
 	statusCmd.Flags().BoolVar(&stFailOnGap, "fail-on-gap", false, "Exit non-zero if the stream lost data (a binlog gap or any recorded capture drops), or its continuity can't be confirmed (fails closed); for CI/cron alerting. By default a gap never changes the exit code")
 	_ = statusCmd.MarkFlagRequired("index-dsn")
 	BindCommandEnv(statusCmd)
@@ -94,6 +104,33 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 	defer db.Close()
 	slog.Debug("connected", "duration_ms", time.Since(t).Milliseconds())
+
+	// The acknowledgement (#1314) runs BEFORE the report is collected, so the
+	// status printed below is the state the operator just created rather than
+	// the one they are retiring — otherwise every acknowledgement is followed
+	// by a screen that looks like it did nothing, which is the exact confusion
+	// this feature exists to end.
+	if stAckCaptureSkips {
+		// EnsureSchema first: capture_skips_ack post-dates most indexes, and
+		// this is a CLI-typed DSN, the one place DDL is allowed to run.
+		if err := indexer.EnsureSchema(db); err != nil {
+			return indexer.WrapSchemaMigrationErr(err)
+		}
+		// -1: no stale-render guard. Unlike a console tab, this reads and
+		// writes in the same breath, so there is no earlier view to protect.
+		ackd, ackErr := status.AcknowledgeCaptureSkips(cmd.Context(), db, -1, time.Now())
+		switch {
+		case errors.Is(ackErr, status.ErrNothingToAcknowledge):
+			// Not an error: an operator who acknowledges a clean ledger got
+			// what they wanted. Saying so beats a non-zero exit on a no-op.
+			fmt.Fprintln(cmd.OutOrStdout(), "Nothing to acknowledge: no capture skips are recorded for this index.")
+		case ackErr != nil:
+			return fmt.Errorf("acknowledge capture skips: %w", ackErr)
+		default:
+			fmt.Fprintf(cmd.OutOrStdout(), "Acknowledged %d skipped event(s) (%s) at %s. The tally is kept; a later skip will alarm again.\n",
+				ackd.Total, strings.Join(ackd.Reasons, ", "), ackd.At.Format(status.TSFmt))
+		}
+	}
 
 	data, err := status.CollectStatus(cmd.Context(), db, dbName)
 	if err != nil {
@@ -186,7 +223,25 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		// a skip-aware daemon wrote it, it may be hiding a loss count, and
 		// "couldn't check" must not read as "fine" (the sibling branches'
 		// stance).
-		if skips, ok := data.Stream.ParseCaptureSkips(); ok {
+		// An ACKNOWLEDGED tally (#1314) does not fail the flag. This is a
+		// deliberate change to exit semantics, not a rendering one: the tally
+		// is monotonic, so before this an operator whose cron went red had
+		// exactly two options — hand-edit the column with the daemon stopped
+		// (destroying the loss record) or delete --fail-on-gap. An alert
+		// nobody can clear is an alert everybody removes, and the next real
+		// loss then lands in silence.
+		//
+		// It is safe because the acknowledgement records a COUNT: one more
+		// skipped event lifts the tally above it and every branch below fires
+		// again with no operator action. The check sits ahead of all of them
+		// because acknowledgement is not per-reason to the operator — they
+		// acknowledged the record, and re-failing on a sibling reason they
+		// already saw would be the same trap in a smaller box.
+		skips, skipsOK := data.Stream.ParseCaptureSkips()
+		switch {
+		case skipsOK && status.CaptureSkipsAcknowledged(skips, data.Stream.ParseCaptureSkipsAck()):
+			// Acknowledged: every branch below is deliberately skipped.
+		case skipsOK:
 			if st := skips[status.CaptureSkipReasonStatementFormatDML]; st.Count > 0 {
 				loc := ""
 				if st.LastFile != "" || st.LastStatementType != "" {
@@ -196,14 +251,14 @@ func runStatus(cmd *cobra.Command, args []string) error {
 					}
 					loc = fmt.Sprintf(" (last: %s at %s:%d, connection id %d)", st.LastStatementType, file, st.LastPos, st.LastConnectionID)
 				}
-				return fmt.Errorf("capture health: %d statement-format DML event(s) permanently uncaptured%s; set binlog_format=ROW server-wide on the source, then acknowledge by clearing stream_state.capture_skips with the daemon stopped (the counter is monotonic); failing closed under --fail-on-gap", st.Count, loc)
+				return fmt.Errorf("capture health: %d statement-format DML event(s) permanently uncaptured%s; set binlog_format=ROW server-wide on the source, then acknowledge this tally with `bintrail status --index-dsn <index> --ack-capture-skips` (it is monotonic and never clears itself; acknowledging erases nothing and a later skip fails this check again); failing closed under --fail-on-gap", st.Count, loc)
 			}
 			// #1206: the restart path stamps this meta-reason when the
 			// previously persisted ledger could not be parsed — a loss tally
 			// may have been destroyed, so a now-readable ledger carrying it
 			// must not read as "fine".
 			if st := skips[status.CaptureSkipReasonUnreadablePreviousLedger]; st.Count > 0 {
-				return fmt.Errorf("capture health: a previous capture ledger was unreadable at daemon restart and its tally is lost — permanent loss may be unrecorded; acknowledge by clearing stream_state.capture_skips with the daemon stopped; failing closed under --fail-on-gap")
+				return fmt.Errorf("capture health: a previous capture ledger was unreadable at daemon restart and its tally is lost — permanent loss may be unrecorded; acknowledge it with `bintrail status --index-dsn <index> --ack-capture-skips` once you have acted on the possibility of unrecorded loss; failing closed under --fail-on-gap")
 			}
 			// #1207: every remaining reason is the same permanent-loss class —
 			// an event read from the stream and dropped is absent from the
@@ -221,9 +276,9 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			}
 			if dropped > 0 {
 				sort.Strings(reasons)
-				return fmt.Errorf("capture health: %d event(s) read from the stream and permanently dropped (%s); most often the schema snapshot is stale or corrupt — run `bintrail snapshot` against the source and restart the stream, then acknowledge by clearing stream_state.capture_skips with the daemon stopped (the counter is monotonic); failing closed under --fail-on-gap", dropped, strings.Join(reasons, ", "))
+				return fmt.Errorf("capture health: %d event(s) read from the stream and permanently dropped (%s); most often the schema snapshot is stale or corrupt — run `bintrail snapshot` against the source and restart the stream, then acknowledge this tally with `bintrail status --index-dsn <index> --ack-capture-skips` (it is monotonic and never clears itself; acknowledging erases nothing and a later skip fails this check again); failing closed under --fail-on-gap", dropped, strings.Join(reasons, ", "))
 			}
-		} else if data.Stream.CaptureSkips.Valid && strings.TrimSpace(data.Stream.CaptureSkips.String) != "" {
+		case data.Stream.CaptureSkips.Valid && strings.TrimSpace(data.Stream.CaptureSkips.String) != "":
 			return fmt.Errorf("capture health: capture_skips ledger present but unreadable; cannot confirm statement-format DML drops; failing closed under --fail-on-gap")
 		}
 	}

--- a/internal/cli/status_ack_integration_test.go
+++ b/internal/cli/status_ack_integration_test.go
@@ -1,0 +1,148 @@
+//go:build integration
+
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestRunStatus_ackCaptureSkips drives the whole loop through the REAL command:
+// a skip tally fails --fail-on-gap forever, --ack-capture-skips retires it, and
+// one more skipped event brings the failure back with no operator action.
+//
+// The exit-code half is the point. Before #1314 an operator whose cron went red
+// on a monotonic tally had two options — hand-edit the column with the daemon
+// stopped, destroying the loss record, or delete --fail-on-gap. An alert nobody
+// can clear is an alert everybody removes, and this test is what pins that it
+// can now be cleared WITHOUT the alert losing its teeth.
+func TestRunStatus_ackCaptureSkips(t *testing.T) {
+	ctx := context.Background()
+	db, name := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO stream_state (id, mode, server_id, last_checkpoint, capture_skips)
+		 VALUES (1, 'gtid', 7, UTC_TIMESTAMP(), '{"column_count_mismatch":{"count":3,"last_at":"2026-08-04T10:00:00Z"}}')`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	saved := struct {
+		dsn, format, baselineDir string
+		failOnGap, ack           bool
+	}{stIndexDSN, stFormat, stBaselineDir, stFailOnGap, stAckCaptureSkips}
+	t.Cleanup(func() {
+		stIndexDSN, stFormat, stBaselineDir = saved.dsn, saved.format, saved.baselineDir
+		stFailOnGap, stAckCaptureSkips = saved.failOnGap, saved.ack
+	})
+	stIndexDSN = testutil.IntegrationDSN(name)
+	stFormat = "text"
+	stBaselineDir = ""
+	statusCmd.SetContext(ctx)
+
+	// Unacknowledged: --fail-on-gap fails, and names the acknowledgement rather
+	// than the old "clear the column with the daemon stopped" advice.
+	stFailOnGap, stAckCaptureSkips = true, false
+	captureStdout(t, func() {
+		err := runStatus(statusCmd, nil)
+		if err == nil {
+			t.Fatal("an unacknowledged skip tally must fail --fail-on-gap")
+		}
+		if !strings.Contains(err.Error(), "--ack-capture-skips") {
+			t.Errorf("the failure must name how to retire it, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "clearing stream_state.capture_skips") {
+			t.Errorf("the failure still tells operators to destroy the loss record: %v", err)
+		}
+	})
+
+	// Acknowledge, and report as usual in the same run.
+	stAckCaptureSkips = true
+	out := captureStdout(t, func() {
+		if err := runStatus(statusCmd, nil); err != nil {
+			t.Fatalf("acknowledging must also clear the --fail-on-gap failure in the same run: %v", err)
+		}
+	})
+	if !strings.Contains(out, "Acknowledged 3 skipped event(s)") {
+		t.Errorf("no acknowledgement was reported to the operator:\n%s", out)
+	}
+	// The report printed AFTER the write must show the acknowledged state —
+	// otherwise the operator's screen looks like the command did nothing, which
+	// is the exact confusion this feature exists to end.
+	if !strings.Contains(out, "ON RECORD") {
+		t.Errorf("the report printed after acknowledging still reads as an active alarm:\n%s", out)
+	}
+	// The tally itself is still on screen: acknowledging is not forgetting.
+	if !strings.Contains(out, "3 events skipped") {
+		t.Errorf("the loss record vanished from the report:\n%s", out)
+	}
+
+	// Acknowledged: repeated runs stay green.
+	stAckCaptureSkips = false
+	captureStdout(t, func() {
+		if err := runStatus(statusCmd, nil); err != nil {
+			t.Errorf("an acknowledged tally must keep exiting 0: %v", err)
+		}
+	})
+
+	// One more skipped event and the alert is back, untouched by the operator.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE stream_state SET capture_skips = '{"column_count_mismatch":{"count":4,"last_at":"2026-08-12T10:00:00Z"}}' WHERE id = 1`); err != nil {
+		t.Fatalf("record a later skip: %v", err)
+	}
+	captureStdout(t, func() {
+		if err := runStatus(statusCmd, nil); err == nil {
+			t.Error("a skip AFTER the acknowledgement did not re-fail --fail-on-gap; the acknowledgement is muting new loss")
+		}
+	})
+}
+
+// TestRunStatus_ackCaptureSkips_nothingRecorded pins that acknowledging a clean
+// index is a reported no-op, not an error: an operator who runs this on a
+// healthy system got what they wanted, and a non-zero exit there would be a
+// cron failure invented out of nothing.
+func TestRunStatus_ackCaptureSkips_nothingRecorded(t *testing.T) {
+	ctx := context.Background()
+	db, name := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO stream_state (id, mode, server_id, last_checkpoint, capture_skips)
+		 VALUES (1, 'gtid', 7, UTC_TIMESTAMP(), '{}')`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	saved := struct {
+		dsn, format, baselineDir string
+		failOnGap, ack           bool
+	}{stIndexDSN, stFormat, stBaselineDir, stFailOnGap, stAckCaptureSkips}
+	t.Cleanup(func() {
+		stIndexDSN, stFormat, stBaselineDir = saved.dsn, saved.format, saved.baselineDir
+		stFailOnGap, stAckCaptureSkips = saved.failOnGap, saved.ack
+	})
+	stIndexDSN = testutil.IntegrationDSN(name)
+	stFormat, stBaselineDir, stFailOnGap, stAckCaptureSkips = "text", "", false, true
+	statusCmd.SetContext(ctx)
+
+	out := captureStdout(t, func() {
+		if err := runStatus(statusCmd, nil); err != nil {
+			t.Fatalf("acknowledging a clean ledger must not be an error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "Nothing to acknowledge") {
+		t.Errorf("the no-op was not reported:\n%s", out)
+	}
+	// And nothing was stamped, so the NEXT skip is not pre-acknowledged.
+	var ack []byte
+	if err := db.QueryRowContext(ctx, "SELECT capture_skips_ack FROM stream_state WHERE id = 1").Scan(&ack); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if len(ack) != 0 {
+		t.Errorf("acknowledging a clean ledger stamped %q — the next skip would land pre-acknowledged", ack)
+	}
+}

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2295,16 +2295,20 @@ function continuityBox(stream, pg) {
 function captureHealthBox(stream) {
   if (!stream || !stream.capture_health || stream.capture_health.status !== "degraded") return null;
   const h = stream.capture_health;
+  const acked = h.acknowledged === true;
   const historic = h.skips_predate_snapshot === true;
-  const box = el("div", { class: historic ? "ok-box" : "warn-box" });
-  box.append(el("b", { text: historic
-    ? "Capture gap on record — nothing skipped since the current snapshot"
-    : "⚠ Capture incomplete — some changes were not indexed" }));
+  const box = el("div", { class: acked ? "muted-box" : (historic ? "ok-box" : "warn-box") });
+  box.append(el("b", { text: acked
+    ? "Capture gap on record (acknowledged)"
+    : historic
+      ? "Capture gap on record — nothing skipped since the current snapshot"
+      : "⚠ Capture incomplete — some changes were not indexed" }));
   const reasons = Object.keys(h.skipped || {}).sort().join(", ");
   box.append(el("div", { text: h.total_skipped + " event(s) were read from the stream but not indexed" +
     (reasons ? " (" + reasons + ")" : "") + (h.last_skip_at ? "; last " + h.last_skip_at : "") +
     ". Those changes are missing from the index for good." +
-    (historic && h.snapshot_at ? " The schema snapshot in force since " + h.snapshot_at + " has recorded none." : "") }));
+    (acked && h.acknowledged_at ? " Acknowledged " + h.acknowledged_at + "; anything skipped after that count raises this again." : "") +
+    (!acked && historic && h.snapshot_at ? " The schema snapshot in force since " + h.snapshot_at + " has recorded none." : "") }));
   // Cause, remedy and scope come from the backend (status.ExplainCaptureSkips),
   // the same strings `bintrail status` prints — the console must not re-author
   // this advice in JavaScript, because the half that drifts is always the half
@@ -2318,9 +2322,49 @@ function captureHealthBox(stream) {
   // The action sits inside the disclosure once the skips are historic: it has
   // already been pressed, and leaving it under the headline invites pressing it
   // again forever against a tally that will never move.
-  if (action) (historic ? details : box).append(action);
+  if (action) (historic || acked ? details : box).append(action);
+  // Mark-as-read (#1314) is the only action on an already-acknowledged record,
+  // so it is absent once acked — and it stays OUTSIDE the disclosure while
+  // unacknowledged, because it is the one thing an operator looking at a
+  // permanent record actually wants and it must not be five paragraphs down.
+  //
+  // seen_total is the count THIS render displayed: the endpoint refuses the
+  // acknowledgement if the live tally has since gone higher, so a tab left
+  // open cannot retire skips that happened while nobody was looking.
+  if (!acked) {
+    // A class of its own, NOT .warn-actions: the e2e pins where the
+    // schema-snapshot action sits by querying ":scope > .warn-actions", and a
+    // second wrapper sharing that class would make the assertion pass no
+    // matter where the snapshot button went.
+    const wrap = el("div", { class: "ack-actions" });
+    const ackBtn = el("button", { class: "btn btn-sm", type: "button", text: "Mark as read" });
+    ackBtn.onclick = () => acknowledgeCaptureSkips(h.total_skipped, ackBtn);
+    wrap.append(ackBtn);
+    box.append(wrap);
+  }
   box.append(details);
   return box;
+}
+
+// acknowledgeCaptureSkips records that the operator has seen this tally, so the
+// box stops being an alarm (#1314). It does not clear the tally and does not
+// pretend the events came back: the record stays, quietly, and a later skip
+// pushes the count above what was acknowledged and turns the alarm back on by
+// itself. That is why this is safe to offer as a plain button — it can retire a
+// record, it cannot suppress the next incident.
+async function acknowledgeCaptureSkips(total, btn) {
+  if (btn) { btn.disabled = true; btn.textContent = "Marking…"; }
+  try {
+    await api("/api/capture-skips/ack", { method: "POST", body: { seen_total: total } });
+  } catch (err) {
+    // The 409 here is the stale-tab refusal, and its message already says to
+    // reload — surfacing the server's own text keeps the two in one voice.
+    toast("Could not mark as read: " + ((err && err.message) || err));
+    if (btn) { btn.disabled = false; btn.textContent = "Mark as read"; }
+    return;
+  }
+  toast("Marked as read. The record stays — if anything is skipped from now on, the warning comes back.");
+  renderStatus();
 }
 
 // schemaSnapshotButton renders the Refresh-schema-snapshot action for the
@@ -2381,7 +2425,7 @@ async function refreshSchemaSnapshot(id, btn) {
   }
   // The banner is driven by a monotonic tally, so it stays up after a working
   // fix. Say so here or the operator concludes the button did nothing.
-  msg += " Events already skipped stay missing, and this warning stays up — it counts skips that happened.";
+  msg += " Events already skipped stay missing, and this warning stays up — it counts skips that happened; use \u201cMark as read\u201d once you have seen the count.";
   toast(msg);
   renderStatus();
 }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1256,8 +1256,19 @@ button { font-family: inherit; }
 /* One paragraph per explanation line (#1296). Without the gap the cause, the
    fix and the "this does not recover what was already skipped" caveat run
    together as one block — and the caveat is the part that gets skimmed past. */
-.warn-box .warn-line, .ok-box .warn-line { margin-top: 8px; }
-.warn-box .warn-actions, .ok-box .warn-actions { margin-top: 10px; }
+/* an ACKNOWLEDGED capture-skip record (#1314): the loss is still on the page,
+   in the page's own muted text — no colour, no border emphasis. An operator
+   who has read the alarm and said so should not keep being alarmed by it, and
+   deleting the box instead would trade an annoyance for lost evidence. */
+.muted-box {
+  font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-2);
+  background: var(--surface-3); border: 1px solid var(--line);
+  border-radius: var(--radius-sm); padding: 12px 14px; margin: 8px 0;
+  white-space: pre-wrap;
+}
+.warn-box .warn-line, .ok-box .warn-line, .muted-box .warn-line { margin-top: 8px; }
+.warn-box .warn-actions, .ok-box .warn-actions, .muted-box .warn-actions { margin-top: 10px; }
+.ack-actions { margin-top: 10px; }
 /* The long-form cause/remedy/scope, collapsed (#1312). It used to render flat
    and unconditionally — ~250 words inside an alarm box, which is the reliable
    way to have none of it read. The summary is the affordance; the caveat about

--- a/internal/console/authz.go
+++ b/internal/console/authz.go
@@ -78,6 +78,12 @@ var apiRoutePerms = []routePerm{
 	{"POST", "/api/recover", ext.PermRecoverExecute},
 	{"POST", "/api/recover-cascade", ext.PermRecoverExecute},
 
+	// Acknowledging a capture-skip tally (#1314) is tiered with the other
+	// actions on that box (servers:write). It writes no data and undoes no
+	// loss — it retires an alarm for every viewer of this server, which is a
+	// control-plane-shaped consequence even though the write is one column.
+	{"POST", "/api/capture-skips/ack", ext.PermServersWrite},
+
 	// Operator maintenance actions on a specific server. verify has no dedicated
 	// permission; it is an operator integrity action, tiered with baseline:create.
 	{"POST", "/api/servers/{}/baseline", ext.PermBaselineCreate},

--- a/internal/console/authz_test.go
+++ b/internal/console/authz_test.go
@@ -49,6 +49,7 @@ var registeredAPIPatterns = []struct{ method, pattern string }{
 	{"GET", "/api/servers/{}/baseline"},
 	{"POST", "/api/servers/{}/schema-snapshot"},
 	{"GET", "/api/servers/{}/schema-snapshot"},
+	{"POST", "/api/capture-skips/ack"},
 	{"POST", "/api/servers/{}/verify"},
 	{"GET", "/api/servers/{}/verify"},
 	{"GET", "/api/servers/{}/verify/explain"},

--- a/internal/console/capture_skips.go
+++ b/internal/console/capture_skips.go
@@ -1,0 +1,78 @@
+package console
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/status"
+)
+
+// captureSkipAckRequest is the acknowledge endpoint's body (#1314).
+type captureSkipAckRequest struct {
+	// SeenTotal is the total the CLIENT rendered. It is the stale-render
+	// guard: a tab left open for an hour must not be able to acknowledge
+	// skips that happened while nobody was looking. The server compares it
+	// against its own read and refuses with 409 when the live tally is
+	// higher — it never STAMPS this number, so a client cannot acknowledge
+	// more than actually happened either.
+	//
+	// Absent (or negative) means "acknowledge whatever is there". Kept as a
+	// pointer so a client that omits the field is distinguishable from one
+	// that honestly saw zero.
+	SeenTotal *int64 `json:"seen_total"`
+}
+
+// handleCaptureSkipsAck serves POST /api/capture-skips/ack: record that an
+// operator has seen this server's capture-skip tally.
+//
+// Server selection follows the X-Bintrail-Server header, exactly like
+// /api/status — NOT a path {id}. That is deliberate: the acknowledgement must
+// land on the same index whose numbers the operator is looking at, and reusing
+// the selection that produced those numbers is the only way to guarantee it.
+//
+// The write is a plain UPDATE. The console runs no DDL on a registry index (see
+// connManager), so an index that predates the column is refused with the CLI
+// command that migrates it rather than a driver error.
+func (s *Server) handleCaptureSkipsAck(w http.ResponseWriter, r *http.Request) {
+	b := s.resolveOr(w, r)
+	if b == nil {
+		return
+	}
+	seen := int64(-1)
+	if r.Body != nil {
+		var req captureSkipAckRequest
+		// A malformed body is ignored rather than rejected: the guard it
+		// carries is an optimization on top of a correct write, and failing
+		// the acknowledgement over it would leave the operator stuck with the
+		// alarm this endpoint exists to retire.
+		if err := json.NewDecoder(r.Body).Decode(&req); err == nil && req.SeenTotal != nil {
+			seen = *req.SeenTotal
+		}
+	}
+	ackd, err := status.AcknowledgeCaptureSkips(r.Context(), b.db, seen, time.Now())
+	switch {
+	case errors.Is(err, status.ErrAcknowledgeStale):
+		writeJSONError(w, http.StatusConflict,
+			"more events were skipped since this page loaded ("+err.Error()+"); reload and read the new count before acknowledging it")
+		return
+	case errors.Is(err, status.ErrNothingToAcknowledge):
+		writeJSONError(w, http.StatusBadRequest,
+			"there is no capture-skip tally to acknowledge on this server")
+		return
+	case errors.Is(err, status.ErrAckColumnMissing):
+		writeJSONError(w, http.StatusUnprocessableEntity,
+			"this index predates the acknowledgement column; run `bintrail status --index-dsn <index> --ack-capture-skips` once against it (the console does not alter index schemas)")
+		return
+	case err != nil:
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"acknowledged":    true,
+		"acknowledged_at": ackd.At.Format(status.TSFmt),
+		"total":           ackd.Total,
+		"reasons":         ackd.Reasons,
+	})
+}

--- a/internal/console/capture_skips_integration_test.go
+++ b/internal/console/capture_skips_integration_test.go
@@ -1,0 +1,117 @@
+//go:build integration
+
+package console
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// seedAckConsole is seedConsoleData without the event rows: this test needs the
+// server AND the index handle, and no events at all.
+func seedAckConsole(t *testing.T) (*Server, *sql.DB) {
+	t.Helper()
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	srv, err := New(Config{DB: db, DBName: dbName, Listen: "127.0.0.1:8090", Token: intToken, NoArchive: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv, db
+}
+
+// TestIntegrationCaptureSkipsAck drives the acknowledge endpoint (#1314) against
+// a real index: the write lands, /api/status reports it, the stale-render guard
+// refuses a tab that saw a smaller count, and a later skip re-arms the alarm.
+//
+// It goes through srv.Handler() rather than calling the handler directly so the
+// route registration and the authz table are exercised too — a handler nobody
+// can reach is the failure mode a direct call cannot see.
+func TestIntegrationCaptureSkipsAck(t *testing.T) {
+	srv, db := seedAckConsole(t)
+	ctx := context.Background()
+
+	// Nothing recorded: refused, and NOT stamped — an acknowledgement written
+	// over an empty ledger would pre-acknowledge the next skip.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO stream_state (id, mode, server_id, last_checkpoint, capture_skips)
+		 VALUES (1, 'gtid', 7, UTC_TIMESTAMP(), '{}')`); err != nil {
+		t.Fatalf("seed clean ledger: %v", err)
+	}
+	if rec, body := doReq(t, srv, "POST", "/api/capture-skips/ack", `{"seen_total":0}`); rec.Code != 400 {
+		t.Fatalf("acknowledging a clean ledger: code = %d, body = %s", rec.Code, body)
+	}
+
+	if _, err := db.ExecContext(ctx,
+		`UPDATE stream_state SET capture_skips = '{"column_count_mismatch":{"count":3,"last_at":"2026-08-04T10:00:00Z"}}' WHERE id = 1`); err != nil {
+		t.Fatalf("seed skips: %v", err)
+	}
+
+	captureHealth := func(t *testing.T) map[string]any {
+		t.Helper()
+		rec, body := doReq(t, srv, "GET", "/api/status", "")
+		if rec.Code != 200 {
+			t.Fatalf("status code = %d, body = %s", rec.Code, body)
+		}
+		var parsed struct {
+			Stream struct {
+				CaptureHealth map[string]any `json:"capture_health"`
+			} `json:"stream"`
+		}
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			t.Fatalf("status JSON: %v\n%s", err, body)
+		}
+		return parsed.Stream.CaptureHealth
+	}
+
+	if ch := captureHealth(t); ch["acknowledged"] == true {
+		t.Fatalf("a fresh tally reported as acknowledged: %v", ch)
+	}
+
+	// The stale-render guard: this tab rendered 2, the index holds 3.
+	rec, body := doReq(t, srv, "POST", "/api/capture-skips/ack", `{"seen_total":2}`)
+	if rec.Code != 409 {
+		t.Fatalf("a stale view must be refused with 409, got %d: %s", rec.Code, body)
+	}
+	if !strings.Contains(string(body), "reload") {
+		t.Errorf("the 409 must tell the operator what to do, got: %s", body)
+	}
+	if ch := captureHealth(t); ch["acknowledged"] == true {
+		t.Fatal("a refused acknowledgement was stamped anyway")
+	}
+
+	if rec, body := doReq(t, srv, "POST", "/api/capture-skips/ack", `{"seen_total":3}`); rec.Code != 200 {
+		t.Fatalf("acknowledge code = %d, body = %s", rec.Code, body)
+	}
+	ch := captureHealth(t)
+	if ch["acknowledged"] != true {
+		t.Fatalf("capture health did not report the acknowledgement: %v", ch)
+	}
+	if at, _ := ch["acknowledged_at"].(string); at == "" {
+		t.Errorf("acknowledged with no timestamp — the console has nothing to show: %v", ch)
+	}
+	// The verdict stays "degraded": the events are still missing, and a
+	// consumer keying on the status string must not read a human's "seen it"
+	// as the loss being undone.
+	if ch["status"] != "degraded" {
+		t.Errorf("acknowledging changed the verdict to %v; it must stay degraded", ch["status"])
+	}
+	if ch["total_skipped"] != float64(3) {
+		t.Errorf("the tally changed on acknowledgement: %v", ch["total_skipped"])
+	}
+
+	// A later skip re-arms it with no operator action — the property that makes
+	// a one-click "Mark as read" safe to offer at all.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE stream_state SET capture_skips = '{"column_count_mismatch":{"count":4,"last_at":"2026-08-12T10:00:00Z"}}' WHERE id = 1`); err != nil {
+		t.Fatalf("record a later skip: %v", err)
+	}
+	if ch := captureHealth(t); ch["acknowledged"] == true {
+		t.Error("a skip AFTER the acknowledgement stayed acknowledged — the console would keep hiding new loss")
+	}
+}

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -539,6 +539,10 @@ func (s *Server) buildHandler() http.Handler {
 	// action's signal entirely.
 	api.HandleFunc("POST /api/servers/{id}/schema-snapshot", s.recordAction("schema-snapshot", s.handleSchemaSnapshotTrigger))
 	api.HandleFunc("GET /api/servers/{id}/schema-snapshot", s.handleSchemaSnapshotStatus)
+	// Capture-skip acknowledgement (#1314): retire a monotonic skip tally that
+	// otherwise renders its alarm forever. Header-selected like /api/status —
+	// see the handler on why it is not a /api/servers/{id} route.
+	api.HandleFunc("POST /api/capture-skips/ack", s.recordAction("capture-skips-ack", s.handleCaptureSkipsAck))
 	api.HandleFunc("POST /api/servers/{id}/verify", s.recordAction("verify", s.handleVerifyTrigger))
 	api.HandleFunc("GET /api/servers/{id}/verify", s.handleVerifyStatus)
 	api.HandleFunc("GET /api/servers/{id}/verify/explain", s.handleVerifyExplain)

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -710,6 +710,18 @@ func EnsureSchema(db *sql.DB) error {
 	); err != nil {
 		return err
 	}
+	// capture_skips_ack (#1314) is the operator's acknowledgement of the tally
+	// above: {"<reason>":{"count":N,"at":"RFC3339"}}. It is a SEPARATE column
+	// and not a key inside capture_skips because saveCheckpoint rewrites that
+	// column from the daemon's in-memory tally on every checkpoint — anything
+	// stored there would be gone within seconds. Nothing in the capture path
+	// writes this one; only `status --ack-capture-skips` and the console's
+	// acknowledge endpoint do. NULL = never acknowledged.
+	if err := ensureColumn(db, "stream_state", "capture_skips_ack",
+		`ALTER TABLE stream_state ADD COLUMN capture_skips_ack JSON DEFAULT NULL COMMENT 'operator acknowledgement of capture_skips (#1314): {"<reason>":{"count":N,"at":"RFC3339"}}; a reason is acknowledged while ack.count >= skips.count' AFTER capture_skips`,
+	); err != nil {
+		return err
+	}
 	// flavor records the source database flavor (mysql/mariadb) so a resume
 	// parses the saved gtid_set with the correct GTID parser. NOT NULL DEFAULT
 	// 'mysql' means existing rows read back as mysql with no data migration,

--- a/internal/indexer/schema.go
+++ b/internal/indexer/schema.go
@@ -188,6 +188,7 @@ const ddlStreamState = `CREATE TABLE IF NOT EXISTS stream_state (
     gap_lost_detail  TEXT            DEFAULT NULL COMMENT 'human-readable description of the lost gap',
     source_health    JSON            DEFAULT NULL COMMENT 'latest source-side health snapshot (PostgreSQL: replication-slot wal_status/lag + REPLICA IDENTITY coverage) with an embedded checked_at; serialized payload, source-agnostic column',
     capture_skips    JSON            DEFAULT NULL COMMENT 'per-reason monotonic counters of events the daemon read and chose to drop (#1034): {"<reason>":{"count":N,"last_at":"RFC3339"}}; {} = evaluated and clean; NULL = no skip-aware daemon has written yet',
+    capture_skips_ack JSON           DEFAULT NULL COMMENT 'operator acknowledgement of capture_skips (#1314): {"<reason>":{"count":N,"at":"RFC3339"}}. Written ONLY by an explicit acknowledgement, never by the capture daemon — which is why it cannot live inside capture_skips, a column every checkpoint overwrites. A reason is acknowledged while ack.count >= skips.count, so a new skip raises the alarm again on its own',
     CONSTRAINT single_row CHECK (id = 1)
 ) ENGINE=InnoDB`
 

--- a/internal/status/acknowledge.go
+++ b/internal/status/acknowledge.go
@@ -1,0 +1,200 @@
+// Package status — this file implements the operator acknowledgement of a
+// capture-skip tally (#1314).
+//
+// The problem it solves: stream_state.capture_skips is MONOTONIC. It counts
+// events that were read and dropped, not events still being dropped, so it
+// reads identically before and after a successful fix and never goes away. The
+// only escape the product used to document was "stop the daemon and clear
+// stream_state.capture_skips" — impossible from the console, and it DESTROYS
+// the loss record, which is the one thing that should survive. An operator who
+// cannot retire the alarm eventually deletes --fail-on-gap from cron, and then
+// the next real loss is silent.
+//
+// Two decisions carry the design:
+//
+//   - The acknowledgement lives in its own column. capture_skips is rewritten
+//     from the daemon's in-memory tally on every checkpoint (streamrun's
+//     saveCheckpoint is its only writer), so an ack stored inside it would be
+//     overwritten within seconds.
+//   - An acknowledgement records a COUNT, not a fact: "I have seen these N".
+//     A later skip pushes the tally above the acknowledged number and the
+//     alarm comes back on its own. That is what makes it safe for the console
+//     to go quiet — an acknowledgement can retire a record, it cannot hide a
+//     fresh incident. A fact-shaped ack (a bare "acknowledged: true", or
+//     clearing the tally) would suppress the next loss too, which is exactly
+//     the failure the capture-health verdict exists to prevent.
+//
+// Nothing is erased. capture_skips keeps its counts, `status` keeps reporting
+// total/reasons/last-skip, and this adds a timestamp saying a human saw it.
+package status
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// CaptureSkipAck is one reason's acknowledgement, as persisted in
+// stream_state.capture_skips_ack.
+type CaptureSkipAck struct {
+	// Count is the skip count that was acknowledged. The reason reads as
+	// acknowledged while the live tally has not risen above it.
+	Count int64 `json:"count"`
+	// At is when the acknowledgement was made — the only new fact this feature
+	// records, and the one the console shows instead of the alarm.
+	At time.Time `json:"at"`
+}
+
+// Sentinels for the two refusals a caller must distinguish. Everything else is
+// a plain database error.
+var (
+	// ErrNothingToAcknowledge means there is no skip tally to acknowledge:
+	// either no skip-aware daemon has written the ledger, or it is clean.
+	// Acknowledging nothing would write a record that suppresses the NEXT
+	// skip, so it is refused rather than treated as a no-op.
+	ErrNothingToAcknowledge = errors.New("no capture skips to acknowledge")
+	// ErrAcknowledgeStale means the live tally is higher than the total the
+	// caller says it saw — events were skipped between the caller reading and
+	// acting. Acknowledging here would retire a record nobody looked at, so
+	// the caller is sent back to re-read.
+	ErrAcknowledgeStale = errors.New("capture skips rose since they were read")
+	// ErrAckColumnMissing means this index predates capture_skips_ack. It is
+	// its own sentinel because the console cannot fix it: the console never
+	// runs DDL on a registry index (see connManager), so it must tell the
+	// operator which CLI command migrates instead of failing opaquely.
+	ErrAckColumnMissing = errors.New("this index has no capture_skips_ack column")
+)
+
+// Acknowledgement is what an acknowledgement wrote, for the caller to report.
+type Acknowledgement struct {
+	Total   int64     // events acknowledged, summed across reasons
+	Reasons []string  // the reasons acknowledged, most events first
+	At      time.Time // the stamp written into every reason's entry
+}
+
+// ParseCaptureSkipsAck decodes the persisted acknowledgement. A missing column,
+// an empty value or an unparseable payload all yield nil — which reads as
+// UNACKNOWLEDGED, so a decode failure can only ever leave the alarm up. This is
+// deliberately the opposite tolerance from a verdict that could go quiet on bad
+// data.
+func (s *StreamStateInfo) ParseCaptureSkipsAck() map[string]CaptureSkipAck {
+	if !s.CaptureSkipsAck.Valid || strings.TrimSpace(s.CaptureSkipsAck.String) == "" {
+		return nil
+	}
+	m := map[string]CaptureSkipAck{}
+	if err := json.Unmarshal([]byte(s.CaptureSkipsAck.String), &m); err != nil {
+		slog.Warn("could not parse capture_skips_ack; capture skips read as unacknowledged", "error", err)
+		return nil
+	}
+	return m
+}
+
+// CaptureSkipsAcknowledged reports whether EVERY reason with a live count has
+// been acknowledged at or above that count.
+//
+// False when there is nothing skipped: "acknowledged" is a statement about a
+// record, and with no record there is nothing to say. Callers asking "should I
+// stay quiet?" must check the tally first — a clean ledger is already quiet.
+func CaptureSkipsAcknowledged(skips map[string]CaptureSkipStat, ack map[string]CaptureSkipAck) bool {
+	active := activeReasons(skips)
+	if len(active) == 0 {
+		return false
+	}
+	for _, r := range active {
+		if ack[r].Count < skips[r].Count {
+			return false
+		}
+	}
+	return true
+}
+
+// CaptureSkipsAcknowledgedAt returns the NEWEST acknowledgement stamp among the
+// active reasons — the moment the whole record became acknowledged. Zero when
+// it is not fully acknowledged.
+//
+// Newest, not oldest: acknowledging three reasons on Monday and a fourth on
+// Friday makes Friday the moment an operator had seen all of it.
+func CaptureSkipsAcknowledgedAt(skips map[string]CaptureSkipStat, ack map[string]CaptureSkipAck) time.Time {
+	if !CaptureSkipsAcknowledged(skips, ack) {
+		return time.Time{}
+	}
+	var newest time.Time
+	for _, r := range activeReasons(skips) {
+		if at := ack[r].At; at.After(newest) {
+			newest = at
+		}
+	}
+	return newest
+}
+
+// AcknowledgeCaptureSkips records that an operator has seen the current tally.
+//
+// expectTotal is the total the caller saw, and it is the stale-render guard: a
+// console tab rendered ten minutes ago must not be able to acknowledge skips
+// that happened since. Pass a negative value to acknowledge whatever is there
+// (the CLI's default — it reads and writes in the same breath, so there is no
+// stale view to protect against).
+//
+// The read and the write share one transaction with SELECT ... FOR UPDATE. The
+// capture daemon's checkpoint upsert touches the same single row, so without
+// the lock a checkpoint landing between our read and our write would leave us
+// acknowledging a count we never saw — the precise thing expectTotal exists to
+// prevent, arriving by another door.
+func AcknowledgeCaptureSkips(ctx context.Context, db *sql.DB, expectTotal int64, now time.Time) (Acknowledgement, error) {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return Acknowledgement{}, err
+	}
+	defer tx.Rollback() //nolint:errcheck // rolled back only when commit did not happen
+
+	var raw sql.NullString
+	err = tx.QueryRowContext(ctx, `SELECT capture_skips FROM stream_state WHERE id = 1 FOR UPDATE`).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Acknowledgement{}, ErrNothingToAcknowledge
+	}
+	if err != nil {
+		return Acknowledgement{}, err
+	}
+	state := StreamStateInfo{CaptureSkips: raw}
+	skips, ok := state.ParseCaptureSkips()
+	if !ok {
+		// An unreadable ledger is NOT acknowledgeable: it may be hiding a loss
+		// count, and stamping an ack over it would retire a number nobody —
+		// including us — could read.
+		return Acknowledgement{}, ErrNothingToAcknowledge
+	}
+	active := activeReasons(skips)
+	if len(active) == 0 {
+		return Acknowledgement{}, ErrNothingToAcknowledge
+	}
+	total := totalCaptureSkips(skips)
+	if expectTotal >= 0 && total > expectTotal {
+		return Acknowledgement{}, fmt.Errorf("%w: %d now, %d when read", ErrAcknowledgeStale, total, expectTotal)
+	}
+
+	at := now.UTC().Truncate(time.Second)
+	ack := make(map[string]CaptureSkipAck, len(active))
+	for _, r := range active {
+		ack[r] = CaptureSkipAck{Count: skips[r].Count, At: at}
+	}
+	payload, err := json.Marshal(ack)
+	if err != nil {
+		return Acknowledgement{}, err
+	}
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE stream_state SET capture_skips_ack = ? WHERE id = 1`, string(payload)); err != nil {
+		if isUnknownColumnErr(err) {
+			return Acknowledgement{}, ErrAckColumnMissing
+		}
+		return Acknowledgement{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Acknowledgement{}, err
+	}
+	return Acknowledgement{Total: total, Reasons: active, At: at}, nil
+}

--- a/internal/status/acknowledge_integration_test.go
+++ b/internal/status/acknowledge_integration_test.go
@@ -1,0 +1,137 @@
+//go:build integration
+
+package status_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/status"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// The acknowledgement (#1314) is verdict-tested against fixtures, and fixtures
+// cannot cover the half that actually matters here: that the column exists on a
+// freshly created index, that the write lands in it, and that LoadStreamState
+// reads it back. Delete loadCaptureSkipsAck and every fixture test still passes,
+// because they set the field by hand. This one goes to a real database.
+
+func TestAcknowledgeCaptureSkips_RoundTrip(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	db, _ := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	exec := func(q string, args ...any) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, q, args...); err != nil {
+			t.Fatalf("exec %q: %v", q, err)
+		}
+	}
+	exec("INSERT INTO stream_state (id, mode, server_id, last_checkpoint) VALUES (1, 'gtid', 7, UTC_TIMESTAMP())")
+
+	// Nothing recorded yet: refused rather than stamped. An acknowledgement
+	// written over an empty ledger would cover the NEXT skip.
+	if _, err := status.AcknowledgeCaptureSkips(ctx, db, -1, time.Now()); !errors.Is(err, status.ErrNothingToAcknowledge) {
+		t.Fatalf("acknowledging an empty ledger: got %v, want ErrNothingToAcknowledge", err)
+	}
+
+	exec(`UPDATE stream_state SET capture_skips = ? WHERE id = 1`,
+		`{"column_count_mismatch":{"count":3,"last_at":"2026-08-04T10:00:00Z"}}`)
+
+	// The stale-render guard: the caller says it saw 2, the ledger holds 3.
+	if _, err := status.AcknowledgeCaptureSkips(ctx, db, 2, time.Now()); !errors.Is(err, status.ErrAcknowledgeStale) {
+		t.Fatalf("acknowledging a stale view: got %v, want ErrAcknowledgeStale", err)
+	}
+	// Nothing was written on the refusal — a rejected acknowledgement must not
+	// half-land, or the next read reports a record as retired that nobody
+	// agreed to retire.
+	if st, err := status.LoadStreamState(ctx, db); err != nil {
+		t.Fatalf("LoadStreamState: %v", err)
+	} else if ack := st.ParseCaptureSkipsAck(); len(ack) != 0 {
+		t.Fatalf("a refused acknowledgement wrote %v", ack)
+	}
+
+	at := time.Date(2026, 8, 11, 20, 14, 30, 500, time.UTC)
+	ackd, err := status.AcknowledgeCaptureSkips(ctx, db, 3, at)
+	if err != nil {
+		t.Fatalf("AcknowledgeCaptureSkips: %v", err)
+	}
+	if ackd.Total != 3 || len(ackd.Reasons) != 1 || ackd.Reasons[0] != "column_count_mismatch" {
+		t.Errorf("acknowledgement report = %+v, want 3 events of column_count_mismatch", ackd)
+	}
+
+	st, err := status.LoadStreamState(ctx, db)
+	if err != nil {
+		t.Fatalf("LoadStreamState: %v", err)
+	}
+	skips, ok := st.ParseCaptureSkips()
+	if !ok {
+		t.Fatal("capture_skips became unreadable after acknowledging")
+	}
+	// The tally survives. Erasing it was the old advice and the thing this
+	// feature exists to stop: the counts ARE the evidence of loss.
+	if skips["column_count_mismatch"].Count != 3 {
+		t.Errorf("acknowledging changed the tally: %+v", skips)
+	}
+	ack := st.ParseCaptureSkipsAck()
+	if !status.CaptureSkipsAcknowledged(skips, ack) {
+		t.Fatalf("not acknowledged after a successful acknowledgement: skips=%+v ack=%+v", skips, ack)
+	}
+	// Seconds resolution is what the UI prints; sub-second precision here would
+	// only differ from what every surface shows.
+	if got := status.CaptureSkipsAcknowledgedAt(skips, ack); !got.Equal(at.Truncate(time.Second)) {
+		t.Errorf("acknowledged at %s, want %s", got, at.Truncate(time.Second))
+	}
+
+	// A LATER skip re-arms it with no operator action. This is the invariant
+	// that makes "Mark as read" safe to offer at all, and it is the one a
+	// future refactor is most likely to break.
+	exec(`UPDATE stream_state SET capture_skips = ? WHERE id = 1`,
+		`{"column_count_mismatch":{"count":4,"last_at":"2026-08-12T10:00:00Z"}}`)
+	st, err = status.LoadStreamState(ctx, db)
+	if err != nil {
+		t.Fatalf("LoadStreamState: %v", err)
+	}
+	skips, _ = st.ParseCaptureSkips()
+	if status.CaptureSkipsAcknowledged(skips, st.ParseCaptureSkipsAck()) {
+		t.Error("a skip AFTER the acknowledgement stayed silent — the acknowledgement is muting new loss")
+	}
+}
+
+// TestAcknowledgeCaptureSkips_MissingColumn pins the sentinel the console
+// depends on: it runs no DDL on a registry index, so it must be able to name
+// the CLI command that migrates instead of surfacing a driver error.
+func TestAcknowledgeCaptureSkips_MissingColumn(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	db, _ := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE stream_state DROP COLUMN capture_skips_ack`); err != nil {
+		t.Fatalf("simulate a pre-#1314 index: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO stream_state (id, mode, server_id, last_checkpoint, capture_skips)
+		 VALUES (1, 'gtid', 7, UTC_TIMESTAMP(), '{"no_resolver":{"count":2,"last_at":"2026-08-04T10:00:00Z"}}')`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := status.AcknowledgeCaptureSkips(ctx, db, -1, time.Now()); !errors.Is(err, status.ErrAckColumnMissing) {
+		t.Fatalf("got %v, want ErrAckColumnMissing", err)
+	}
+	// And EnsureSchema adds it, which is what the error tells the operator to
+	// run — an instruction nobody verified would be worse than none.
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	if _, err := status.AcknowledgeCaptureSkips(ctx, db, -1, time.Now()); err != nil {
+		t.Fatalf("acknowledging after the documented migration: %v", err)
+	}
+}

--- a/internal/status/acknowledge_test.go
+++ b/internal/status/acknowledge_test.go
@@ -1,0 +1,159 @@
+package status
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+)
+
+func skip(count int64) CaptureSkipStat               { return CaptureSkipStat{Count: count, LastAt: time.Now()} }
+func ackAt(count int64, at time.Time) CaptureSkipAck { return CaptureSkipAck{Count: count, At: at} }
+
+// TestCaptureSkipsAcknowledged pins the verdict, and in particular the one
+// property that makes it safe for the console to go quiet on an acknowledged
+// record: an acknowledgement covers a COUNT, so anything skipped afterwards
+// un-acknowledges it with no operator action.
+func TestCaptureSkipsAcknowledged(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name  string
+		skips map[string]CaptureSkipStat
+		ack   map[string]CaptureSkipAck
+		want  bool
+	}{
+		{
+			name:  "exact count acknowledged",
+			skips: map[string]CaptureSkipStat{"column_count_mismatch": skip(3)},
+			ack:   map[string]CaptureSkipAck{"column_count_mismatch": ackAt(3, now)},
+			want:  true,
+		},
+		{
+			// THE load-bearing case: three were acknowledged, a fourth was
+			// skipped. If this ever returns true the feature is a mute button
+			// on future data loss.
+			name:  "a later skip re-arms the alarm",
+			skips: map[string]CaptureSkipStat{"column_count_mismatch": skip(4)},
+			ack:   map[string]CaptureSkipAck{"column_count_mismatch": ackAt(3, now)},
+			want:  false,
+		},
+		{
+			// A reason that did not exist when the operator acknowledged is
+			// unacknowledged by construction: ack[missing].Count is zero and
+			// the live count is not.
+			name:  "a new reason is not covered by an older acknowledgement",
+			skips: map[string]CaptureSkipStat{"column_count_mismatch": skip(3), "no_resolver": skip(1)},
+			ack:   map[string]CaptureSkipAck{"column_count_mismatch": ackAt(3, now)},
+			want:  false,
+		},
+		{
+			name:  "all reasons must be covered",
+			skips: map[string]CaptureSkipStat{"column_count_mismatch": skip(3), "no_resolver": skip(1)},
+			ack:   map[string]CaptureSkipAck{"column_count_mismatch": ackAt(3, now), "no_resolver": ackAt(1, now)},
+			want:  true,
+		},
+		{
+			// An ack higher than the tally is not a fault worth alarming on
+			// (it cannot happen through either surface — both stamp what they
+			// read — and treating it as unacknowledged would strand the
+			// operator with an alarm they already retired).
+			name:  "an acknowledgement above the tally still counts",
+			skips: map[string]CaptureSkipStat{"column_count_mismatch": skip(2)},
+			ack:   map[string]CaptureSkipAck{"column_count_mismatch": ackAt(9, now)},
+			want:  true,
+		},
+		{
+			// "Acknowledged" is a statement about a record. With no record
+			// there is nothing to say, and a true here would let a caller
+			// render "acknowledged" over a perfectly clean ledger.
+			name:  "a clean ledger is not acknowledged",
+			skips: map[string]CaptureSkipStat{},
+			ack:   map[string]CaptureSkipAck{"column_count_mismatch": ackAt(3, now)},
+			want:  false,
+		},
+		{
+			// A zero-count entry is not an active reason (activeReasons skips
+			// it), so it must not demand an acknowledgement of its own.
+			name:  "a zero-count reason needs no acknowledgement",
+			skips: map[string]CaptureSkipStat{"column_count_mismatch": skip(3), "no_resolver": skip(0)},
+			ack:   map[string]CaptureSkipAck{"column_count_mismatch": ackAt(3, now)},
+			want:  true,
+		},
+		{
+			name:  "no acknowledgement at all",
+			skips: map[string]CaptureSkipStat{"column_count_mismatch": skip(3)},
+			ack:   nil,
+			want:  false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CaptureSkipsAcknowledged(tc.skips, tc.ack); got != tc.want {
+				t.Errorf("CaptureSkipsAcknowledged = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCaptureSkipsAcknowledgedAtIsNewest pins that the reported moment is when
+// the operator had seen ALL of it — acknowledging one reason on Monday and
+// another on Friday makes Friday the answer, not Monday.
+func TestCaptureSkipsAcknowledgedAtIsNewest(t *testing.T) {
+	mon := time.Date(2026, 8, 3, 9, 0, 0, 0, time.UTC)
+	fri := time.Date(2026, 8, 7, 9, 0, 0, 0, time.UTC)
+	skips := map[string]CaptureSkipStat{"column_count_mismatch": skip(3), "no_resolver": skip(1)}
+	ack := map[string]CaptureSkipAck{"column_count_mismatch": ackAt(3, mon), "no_resolver": ackAt(1, fri)}
+	if got := CaptureSkipsAcknowledgedAt(skips, ack); !got.Equal(fri) {
+		t.Errorf("acknowledged at %s, want the newest stamp %s", got, fri)
+	}
+	// Not fully acknowledged ⇒ zero, so no caller can print a stamp for a
+	// record that is still alarming.
+	partial := map[string]CaptureSkipAck{"column_count_mismatch": ackAt(3, mon)}
+	if got := CaptureSkipsAcknowledgedAt(skips, partial); !got.IsZero() {
+		t.Errorf("partially acknowledged reported %s, want zero", got)
+	}
+}
+
+// TestParseCaptureSkipsAckFailsUnacknowledged pins the tolerance DIRECTION: a
+// missing column, empty value or corrupt payload must all read as
+// unacknowledged, so a decode failure can only ever leave the alarm up. The
+// opposite (defaulting to acknowledged) would let one bad write silence a
+// permanent-loss record.
+func TestParseCaptureSkipsAckFailsUnacknowledged(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  sql.NullString
+	}{
+		{"legacy index without the column", sql.NullString{}},
+		{"empty value", sql.NullString{Valid: true, String: "  "}},
+		{"corrupt payload", sql.NullString{Valid: true, String: "{not json"}},
+		{"wrong shape", sql.NullString{Valid: true, String: `{"column_count_mismatch":42}`}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := StreamStateInfo{CaptureSkipsAck: tc.raw}
+			ack := s.ParseCaptureSkipsAck()
+			skips := map[string]CaptureSkipStat{"column_count_mismatch": skip(1)}
+			if CaptureSkipsAcknowledged(skips, ack) {
+				t.Error("an undecodable acknowledgement read as acknowledged; the alarm would be silenced by bad data")
+			}
+		})
+	}
+}
+
+// TestParseCaptureSkipsAckRoundTrip pins the persisted shape, since it is
+// written by one surface and read by another (and by whatever reads the column
+// directly during an incident).
+func TestParseCaptureSkipsAckRoundTrip(t *testing.T) {
+	s := StreamStateInfo{CaptureSkipsAck: sql.NullString{Valid: true,
+		String: `{"column_count_mismatch":{"count":7,"at":"2026-08-11T20:14:00Z"}}`}}
+	ack := s.ParseCaptureSkipsAck()
+	got, ok := ack["column_count_mismatch"]
+	if !ok {
+		t.Fatalf("reason missing from decoded acknowledgement: %#v", ack)
+	}
+	if got.Count != 7 {
+		t.Errorf("count = %d, want 7", got.Count)
+	}
+	if want := time.Date(2026, 8, 11, 20, 14, 0, 0, time.UTC); !got.At.Equal(want) {
+		t.Errorf("at = %s, want %s", got.At, want)
+	}
+}

--- a/internal/status/capture_health.go
+++ b/internal/status/capture_health.go
@@ -104,6 +104,22 @@ func SkipsPredateSnapshot(skips map[string]CaptureSkipStat, snapshotAt time.Time
 	return true
 }
 
+// ackAdvice is the one place that names how to retire a skip record (#1314),
+// shared by every sentence that used to say "stop the daemon and clear
+// stream_state.capture_skips". That advice was wrong twice over: a console
+// operator cannot do it at all, and it DESTROYS the loss record — the tally is
+// the only evidence those events were dropped. Acknowledging keeps it and adds
+// a timestamp.
+//
+// The sentence must carry the re-arming property, not just the button. An
+// operator who reads "mark as read" as "make it go away for good" would never
+// trust it on a system they are responsible for; the reason it is safe is that
+// it retires a COUNT, so the next skip alarms again by itself.
+const ackAdvice = "mark it as read — in the console, the \"Mark as read\" button on this box; on the " +
+	"command line, `bintrail status --index-dsn <index> --ack-capture-skips`. That records the count you " +
+	"saw and the time you saw it, and erases nothing: the tally stays, and if anything is skipped after " +
+	"this the warning comes back on its own."
+
 // acknowledgementLine answers the one question the tally cannot: is this still
 // happening, or am I looking at a record of something already fixed?
 //
@@ -119,9 +135,7 @@ func acknowledgementLine(skips map[string]CaptureSkipStat, snapshotAt time.Time)
 	if snapshotAt.IsZero() {
 		return "This warning does not clear on its own: the tally counts skips that happened, not skips " +
 			"still happening, so it stays after a successful fix. Confirm the fix by watching the count " +
-			"stop rising; to reset the tally, stop capture for this source and clear " +
-			"stream_state.capture_skips in its index."
-	}
+			"stop rising, then " + ackAdvice}
 	if SkipsPredateSnapshot(skips, snapshotAt) {
 		return "Nothing has been skipped since the current schema snapshot was taken (" +
 			snapshotAt.Format(TSFmt) + "). That is not proof the fix took hold — capture does not record " +
@@ -209,8 +223,8 @@ func remedyLine(reason string) string {
 		return "Fix: set binlog_format=ROW server-wide on the source (a session-level override can also " +
 			"produce row-less events)."
 	case CaptureSkipReasonUnreadablePreviousLedger:
-		return "Fix: with the capture daemon stopped, clear stream_state.capture_skips to acknowledge the " +
-			"lost tally; leaving it makes every later status report stay non-clean."
+		return "Fix: there is nothing to repair — the lost tally cannot be recovered. Once you have taken " +
+			"whatever the possibility of unrecorded loss calls for, " + ackAdvice
 	default:
 		return "Fix: see the capture daemon's log for this reason's detail."
 	}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -114,6 +114,12 @@ type StreamStateInfo struct {
 	// Capture health verdict is then unknown and the line is omitted rather
 	// than asserting OK from absent data (the GapColumnsPresent philosophy).
 	CaptureSkips sql.NullString
+	// CaptureSkipsAck is the raw capture_skips_ack JSON (#1314): the operator's
+	// acknowledgement of the tally above, shaped
+	// {"<reason>":{"count":N,"at":"RFC3339"}}. Invalid on a legacy index without
+	// the column, or one nobody has acknowledged. See acknowledge.go for why an
+	// acknowledgement records a COUNT rather than a fact.
+	CaptureSkipsAck sql.NullString
 	// SchemaSnapshotAt is when the newest schema snapshot in this index was
 	// taken — the layout capture decodes against today. It is the anchor that
 	// makes a monotonic skip tally answerable (#1312): a skip older than this
@@ -429,6 +435,12 @@ func LoadStreamState(ctx context.Context, db *sql.DB) (*StreamStateInfo, error) 
 	if err := loadCaptureSkips(ctx, db, s); err != nil {
 		slog.Warn("could not load capture_skips; keeping stream state without it", "error", err)
 	}
+	// The acknowledgement (#1314) is best-effort too, but note the direction it
+	// fails in: an unreadable ack leaves the verdict UNACKNOWLEDGED, so the
+	// alarm stays up. Losing this column can only ever over-report.
+	if err := loadCaptureSkipsAck(ctx, db, s); err != nil {
+		slog.Warn("could not load capture_skips_ack; capture skips will read as unacknowledged", "error", err)
+	}
 	// The snapshot anchor (#1312) is best-effort for the same reason: it only
 	// SHARPENS the capture verdict, so failing to read it must never cost the
 	// caller the stream state it already has.
@@ -503,6 +515,17 @@ func loadSourceHealth(ctx context.Context, db *sql.DB, s *StreamStateInfo) error
 // CaptureSkips invalid (verdict unknown); any other error is returned.
 func loadCaptureSkips(ctx context.Context, db *sql.DB, s *StreamStateInfo) error {
 	err := db.QueryRowContext(ctx, `SELECT capture_skips FROM stream_state WHERE id = 1`).Scan(&s.CaptureSkips)
+	if isUnknownColumnErr(err) || errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	return err
+}
+
+// loadCaptureSkipsAck augments an already-loaded StreamStateInfo with the
+// capture_skips_ack column (#1314) — same tolerance contract as
+// loadCaptureSkips above.
+func loadCaptureSkipsAck(ctx context.Context, db *sql.DB, s *StreamStateInfo) error {
+	err := db.QueryRowContext(ctx, `SELECT capture_skips_ack FROM stream_state WHERE id = 1`).Scan(&s.CaptureSkipsAck)
 	if isUnknownColumnErr(err) || errors.Is(err, sql.ErrNoRows) {
 		return nil
 	}
@@ -764,7 +787,22 @@ func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, arch
 		// written the counters — same never-a-false-ok stance as Continuity's
 		// "not evaluated".
 		if skips, ok := stream.ParseCaptureSkips(); ok {
-			if total := totalCaptureSkips(skips); total > 0 {
+			ack := stream.ParseCaptureSkipsAck()
+			switch total := totalCaptureSkips(skips); {
+			case total > 0 && CaptureSkipsAcknowledged(skips, ack):
+				// An ACKNOWLEDGED record (#1314) still prints its tally — the
+				// events are still missing and a restore window over them is
+				// still incomplete — but not the cause/remedy essay. An
+				// operator who read that advice and acted on it gets it
+				// re-printed on every status run forever otherwise, which is
+				// how advice stops being read at all.
+				fmt.Fprintf(w, "  Capture health:  ⚠ ON RECORD — %s events skipped (%s), last %s\n",
+					commaGroup(total), captureSkipReasons(skips), lastCaptureSkip(skips).Format(TSFmt))
+				fmt.Fprintf(w, "  Acknowledged:    %s — that count is retired; a later skip alarms again\n",
+					CaptureSkipsAcknowledgedAt(skips, ack).Format(TSFmt))
+				fmt.Fprintln(w, "  Those events were read from the stream but NOT indexed — a restore window")
+				fmt.Fprintln(w, "  over them is incomplete.")
+			case total > 0:
 				fmt.Fprintf(w, "  Capture health:  ⚠ DEGRADED — %s events skipped (%s), last %s\n",
 					commaGroup(total), captureSkipReasons(skips), lastCaptureSkip(skips).Format(TSFmt))
 				if attr := lastCaptureSkipAttribution(skips); attr != "" {
@@ -776,7 +814,7 @@ func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, arch
 				// builder (#1296) so this report and the console cannot tell
 				// two different stories about the same ledger.
 				writeCaptureSkipExplanation(w, skips, stream.SchemaSnapshotAt.Time)
-			} else {
+			default:
 				fmt.Fprintln(w, "  Capture health:  OK — no events skipped")
 			}
 		}
@@ -1197,6 +1235,18 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		// change to exit semantics, not a rendering change.
 		SnapshotAt           string `json:"snapshot_at,omitempty"`
 		SkipsPredateSnapshot bool   `json:"skips_predate_snapshot,omitempty"`
+		// Acknowledged / AcknowledgedAt (#1314): an operator has seen this
+		// exact count and retired it. Status stays "degraded" here too, for
+		// the reason above and one more — the events really are still missing,
+		// and a consumer keying on the verdict must not read a human's "seen
+		// it" as the loss being undone. What acknowledgement changes is
+		// LOUDNESS: the console collapses its alarm and --fail-on-gap stops
+		// exiting non-zero, both of which read these fields, not Status.
+		//
+		// The count is what was acknowledged, so a later skip lifts the tally
+		// above it and both surfaces go loud again with no further action.
+		Acknowledged   bool   `json:"acknowledged,omitempty"`
+		AcknowledgedAt string `json:"acknowledged_at,omitempty"`
 	}
 	type jsonStream struct {
 		BintrailID     *string        `json:"bintrail_id"`
@@ -1366,6 +1416,13 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 					ch.SkipsPredateSnapshot = SkipsPredateSnapshot(skips, stream.SchemaSnapshotAt.Time)
 				}
 				ch.Explanation = ExplainCaptureSkips(skips, stream.SchemaSnapshotAt.Time)
+				// Explanation ships even when acknowledged: the console keeps
+				// it behind a disclosure so an operator who wants the cause
+				// back does not have to leave the page for it.
+				if ack := stream.ParseCaptureSkipsAck(); CaptureSkipsAcknowledged(skips, ack) {
+					ch.Acknowledged = true
+					ch.AcknowledgedAt = CaptureSkipsAcknowledgedAt(skips, ack).Format(TSFmt)
+				}
 			}
 			jstr.CaptureHealth = ch
 		}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -331,6 +331,7 @@ func InitIndexTables(t *testing.T, db *sql.DB) {
 		gap_lost_detail  TEXT            DEFAULT NULL,
 		source_health    JSON            DEFAULT NULL,
 		capture_skips    JSON            DEFAULT NULL,
+		capture_skips_ack JSON           DEFAULT NULL,
 		CONSTRAINT single_row CHECK (id = 1)
 	) ENGINE=InnoDB`)
 

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -498,13 +498,33 @@ try {
         && !!historic.querySelector("details .warn-actions");
       historic.remove();
     }
-    let ackedGap = "";
+    let ackedGap = "", ackedPaint = null;
     if (acked) {
       document.body.appendChild(acked);
       const det = acked.querySelector("details");
       if (det) det.open = true;
       const line = acked.querySelector(".warn-line");
       ackedGap = line ? getComputedStyle(line).marginTop : "";
+      // The whole point of the muted box is that it is QUIET, and a CSS
+      // custom property that does not exist resolves to nothing — the rule
+      // matches, the spacing assertion above passes, and the box paints with
+      // the page's default colours. (That is not hypothetical: the first
+      // draft of this rule referenced three tokens this stylesheet has never
+      // defined.) Read the real computed paint and compare it against the
+      // orange alarm's.
+      const mc = getComputedStyle(acked);
+      let wc = null;
+      if (withExpl) {
+        document.body.appendChild(withExpl);
+        const w = getComputedStyle(withExpl);
+        wc = { color: w.color, bg: w.backgroundColor, border: w.borderTopColor };
+        withExpl.remove();
+      }
+      ackedPaint = {
+        color: mc.color, bg: mc.backgroundColor, border: mc.borderTopColor,
+        transparentBg: mc.backgroundColor === "rgba(0, 0, 0, 0)" || mc.backgroundColor === "transparent",
+        differsFromAlarm: !!wc && (mc.color !== wc.color && mc.backgroundColor !== wc.bg && mc.borderTopColor !== wc.border),
+      };
       acked.remove();
     }
     capsCache.schema_snapshot_trigger = keepCaps;
@@ -542,6 +562,7 @@ try {
       // The muted box must inherit the paragraph spacing, or its disclosure is
       // the wall of text the orange one stopped being.
       ackedGap,
+      ackedPaint,
     };
   });
   cap.showsBackendProse ? ok("capture health: banner renders the backend's explanation (table named)") : bad("capture health: banner renders the backend's explanation (table named)", JSON.stringify(cap));
@@ -563,6 +584,9 @@ try {
   cap.ackedStillStatesLoss ? ok("capture health: acknowledging keeps the permanent-loss statement on screen") : bad("capture health: acknowledging keeps the permanent-loss statement on screen", "going quiet erased the evidence");
   cap.ackedNamesTheMoment ? ok("capture health: the acknowledged box names when it was acknowledged") : bad("capture health: the acknowledged box names when it was acknowledged", "no timestamp — the operator cannot tell who saw what when");
   (cap.ackedGap && cap.ackedGap !== "0px") ? ok("capture health: the muted box inherits the paragraph spacing (CSS applied)") : bad("capture health: the muted box inherits the paragraph spacing (CSS applied)", `marginTop=${cap.ackedGap}`);
+  (cap.ackedPaint && !cap.ackedPaint.transparentBg && cap.ackedPaint.differsFromAlarm)
+    ? ok("capture health: the muted box paints its own quiet palette (every token resolves)")
+    : bad("capture health: the muted box paints its own quiet palette (every token resolves)", JSON.stringify(cap.ackedPaint));
 
   // Scenario 8c — the remedy is reachable from the UI (#1296). The whole point
   // of the issue: the banner named an action with no button anywhere. It must

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -460,6 +460,18 @@ try {
         explanation: ["Nothing has been skipped since the current schema snapshot was taken (2026-08-11 12:00:00)."],
       },
     });
+    // Acknowledged (#1314): the same permanent loss, retired by an operator.
+    // It must go MUTED (not the green "nothing since the snapshot" box — that
+    // one is a claim about capture, this one is a claim about a human), keep
+    // stating the loss, and stop offering the button it already consumed.
+    const acked = captureHealthBox({
+      capture_health: {
+        status: "degraded", total_skipped: 3, last_skip_at: "2026-08-04 19:49:33",
+        acknowledged: true, acknowledged_at: "2026-08-11 20:14:00",
+        skipped: { table_not_in_snapshot: { count: 3 } },
+        explanation: ["Nothing has been skipped since the current schema snapshot was taken (2026-08-11 12:00:00)."],
+      },
+    });
     // Render it to confirm the per-paragraph spacing rule resolves — without it
     // the caveat merges into the wall of text above it. The lines now live in a
     // <details>, so it must be opened before measuring: a closed disclosure has
@@ -486,6 +498,15 @@ try {
         && !!historic.querySelector("details .warn-actions");
       historic.remove();
     }
+    let ackedGap = "";
+    if (acked) {
+      document.body.appendChild(acked);
+      const det = acked.querySelector("details");
+      if (det) det.open = true;
+      const line = acked.querySelector(".warn-line");
+      ackedGap = line ? getComputedStyle(line).marginTop : "";
+      acked.remove();
+    }
     capsCache.schema_snapshot_trigger = keepCaps;
     currentServer = keepServer;
     return {
@@ -508,6 +529,19 @@ try {
       historicDatesTheSnapshot: !!historic && /2026-08-11 12:00:00/.test(historic.textContent),
       // An old daemon sends no anchor: no claim, so it must stay loud.
       legacyStaysLoud: !!legacy && legacy.classList.contains("warn-box"),
+      // Mark-as-read (#1314). The button must be reachable WITHOUT opening the
+      // disclosure while the record is unacknowledged: it is the one thing an
+      // operator staring at a permanent record actually wants.
+      ackButtonAtTopLevel: !!withExpl && !!withExpl.querySelector(":scope > .ack-actions button"),
+      ackedIsMuted: !!acked && acked.classList.contains("muted-box")
+        && !acked.classList.contains("warn-box") && !acked.classList.contains("ok-box"),
+      // ...and gone once acknowledged: pressing it again would 400.
+      ackedHasNoAckButton: !!acked && !acked.querySelector(".ack-actions"),
+      ackedStillStatesLoss: !!acked && /missing from the index for good/.test(acked.textContent),
+      ackedNamesTheMoment: !!acked && /2026-08-11 20:14:00/.test(acked.textContent),
+      // The muted box must inherit the paragraph spacing, or its disclosure is
+      // the wall of text the orange one stopped being.
+      ackedGap,
     };
   });
   cap.showsBackendProse ? ok("capture health: banner renders the backend's explanation (table named)") : bad("capture health: banner renders the backend's explanation (table named)", JSON.stringify(cap));
@@ -523,6 +557,12 @@ try {
   cap.legacyStaysLoud ? ok("capture health: a backend with no anchor stays loud") : bad("capture health: a backend with no anchor stays loud", "missing anchor was read as 'quiet' — that hides a live failure");
   cap.buttonAtTopLevel ? ok("capture health: the fix button is under the headline while skips are active") : bad("capture health: the fix button is under the headline while skips are active", "the actionable state buried its action");
   cap.historicButtonInDetails ? ok("capture health: the quiet box moves the button into the disclosure") : bad("capture health: the quiet box moves the button into the disclosure", "a pressed button still sits under the headline");
+  cap.ackButtonAtTopLevel ? ok("capture health: Mark-as-read is reachable without opening the disclosure") : bad("capture health: Mark-as-read is reachable without opening the disclosure", "the only action on a permanent record is buried");
+  cap.ackedIsMuted ? ok("capture health: an acknowledged record renders muted, not as an alarm") : bad("capture health: an acknowledged record renders muted, not as an alarm", "acknowledging did not calm the box");
+  cap.ackedHasNoAckButton ? ok("capture health: an acknowledged record stops offering Mark-as-read") : bad("capture health: an acknowledged record stops offering Mark-as-read", "a button that would now 400 is still on screen");
+  cap.ackedStillStatesLoss ? ok("capture health: acknowledging keeps the permanent-loss statement on screen") : bad("capture health: acknowledging keeps the permanent-loss statement on screen", "going quiet erased the evidence");
+  cap.ackedNamesTheMoment ? ok("capture health: the acknowledged box names when it was acknowledged") : bad("capture health: the acknowledged box names when it was acknowledged", "no timestamp — the operator cannot tell who saw what when");
+  (cap.ackedGap && cap.ackedGap !== "0px") ? ok("capture health: the muted box inherits the paragraph spacing (CSS applied)") : bad("capture health: the muted box inherits the paragraph spacing (CSS applied)", `marginTop=${cap.ackedGap}`);
 
   // Scenario 8c — the remedy is reachable from the UI (#1296). The whole point
   // of the issue: the banner named an action with no button anywhere. It must


### PR DESCRIPTION
Closes #1314.

## The problem

`stream_state.capture_skips` is monotonic — it counts skips that *happened*,
not skips still happening. #1312 dated the tally against the newest schema
snapshot so a re-snapshot became visible, but the record itself never goes
away: the console keeps rendering a capture-health box and
`status --fail-on-gap` keeps exiting non-zero, forever.

The only escape the product documented was in three error strings and the
explanation prose — *"acknowledge by clearing `stream_state.capture_skips`
with the daemon stopped"*. A console user cannot do that at all, and for a CLI
operator it means stopping capture and hand-editing a JSON column while
**destroying the loss record**, which is the one thing that should survive.
(It is also ineffective with the daemon running: the next checkpoint
re-persists the in-memory tallies.)

An alert nobody can clear is an alert everybody removes.

## The design

New `stream_state.capture_skips_ack JSON` column, `{"<reason>":{"count":N,"at":"RFC3339"}}`,
written only by an explicit acknowledgement.

**It is a separate column** because `saveCheckpoint` rewrites `capture_skips`
from the daemon's in-memory tally on every checkpoint — anything stored inside
it would be overwritten within seconds.

**The acknowledgement records a count, not a fact.** A reason is acknowledged
while `ack[reason].count >= skips[reason].count`, so one more skipped event
lifts the tally above it and both the console alarm and the `--fail-on-gap`
failure return with no operator action. An acknowledgement can retire a
record; it cannot mute the next incident. That is the property that makes a
one-click button safe to offer, and it is pinned at every layer (unit,
integration, e2e) plus a mutation check.

Nothing is erased: the counts stay, `status` keeps printing them, and the only
new fact is a timestamp saying a human saw it.

## Surfaces

| | |
|---|---|
| CLI | `bintrail status --ack-capture-skips` — writes, then reports as usual in the same run, so the screen shows the state the operator just created |
| Console | **Mark as read** on the capture-health box → `POST /api/capture-skips/ack` (`servers:write`) |
| `status` text | `⚠ ON RECORD` instead of `⚠ DEGRADED`, plus the acknowledgement time; the cause/remedy essay stops re-printing |
| `status --format json` | `capture_health.acknowledged` + `acknowledged_at` |
| `--fail-on-gap` | passes once acknowledged, fails again on the next skip |
| Console rendering | muted box instead of the orange alarm; the explanation stays behind its disclosure |

Server selection for the endpoint follows the `X-Bintrail-Server` header like
`/api/status`, not a path `{id}` — the acknowledgement must land on the same
index whose numbers are on screen.

## Two races, closed

- **Stale tab.** The client sends the total it rendered; the server refuses
  with 409 if the live tally is higher, so a tab left open cannot acknowledge
  skips nobody looked at. The stamped counts always come from the server's own
  read, never from the request body.
- **Concurrent checkpoint.** The read and the write share one transaction with
  `SELECT ... FOR UPDATE` on the single `stream_state` row, so a checkpoint
  landing between them cannot make us acknowledge a count we never saw.

## Deliberate non-changes

- `capture_health.status` stays `"degraded"`. The events really are still
  missing, and a consumer keying on the verdict must not read a human's "seen
  it" as the loss being undone. What acknowledgement changes is *loudness*, and
  both surfaces read the new fields, not the status string.
- The console runs no DDL on a registry index, so a pre-#1314 index gets a 422
  naming the CLI command that migrates it (and the integration test runs that
  command to prove the instruction works).
- A decode failure of the ack column reads as **unacknowledged**, so bad data
  can only ever leave the alarm up.

## Exit-semantics change

`--fail-on-gap` no longer fails on an acknowledged tally. This is deliberate
and is the point of the issue; it re-fails the moment a count exceeds its
acknowledgement.

## Testing

- Unit: the verdict, including the later-skip re-arm, a new reason not covered
  by an older acknowledgement, and every decode-failure shape.
- Integration (real MySQL): the round trip through `LoadStreamState`, the stale
  refusal writing nothing, the missing-column sentinel *and* that `EnsureSchema`
  fixes it, plus the full CLI loop (fail → ack → pass → new skip → fail).
- Console integration: through `srv.Handler()`, so the route registration and
  the authz table are exercised too.
- Console e2e: 6 new assertions — 157/157 pass.
- Mutation-checked: inverting the count comparison, deleting the stale guard,
  and dropping the column read each break tests.
