### PR TITLE
ci: take the five major action bumps dependabot cannot land

### DIFF
--- a/.github/workflows/demo-image.yml
+++ b/.github/workflows/demo-image.yml
@@ -82,19 +82,19 @@ jobs:
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.IMAGE }}
 
       - id: build
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: demo/image/Dockerfile
@@ -178,7 +178,7 @@ jobs:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests
 
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -223,7 +223,7 @@ jobs:
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -232,7 +232,7 @@ jobs:
       - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
       - id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.IMAGE }}
           tags: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -295,13 +295,13 @@ jobs:
       # QEMU lets the amd64 runner execute the arm64 image's RUN layer
       # (apt-get + useradd) when GoReleaser builds linux/arm64.
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -318,7 +318,7 @@ jobs:
         run: go test ./...
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: "~> v2"
           args: release --clean


### PR DESCRIPTION
Supersedes #1256, #1257, #1258, #1259, #1260.

Those five have been open for weeks for a reason that will never resolve on
its own: the **`license/cla` check blocks dependabot permanently** — the bot
cannot sign a CLA — so every dependabot PR in this repo is unmergeable as
opened. The bumps have to be taken by hand.

All five majors are the same change: **Node 24 default runtime + ESM**. Nothing
in our usage moves. The two genuine removals were checked against the tree, not
assumed:

| Change | Verified |
|---|---|
| build-push v7 drops `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS` | neither appears anywhere in `.github/` |
| metadata-action v6 changes list-input `#` handling — preserves `#` *inside* values, still supports full-line comments | our only such input is `demo-image.yml`'s `tags:`, whose three `#` lines are full-line comments (the case v6 keeps) |
| Node 24 needs Actions Runner >= v2.327.1 | every job runs on a GitHub-hosted runner (`ubuntu-22.04`, `ubuntu-latest`, `ubuntu-24.04-arm`) — no self-hosted runner to upgrade |

## What this PR cannot prove

These actions appear **only** in `release.yaml` and `demo-image.yml`, neither of
which runs on a pull request. `ci` going green here exercises none of them; the
first real proof is the next tag push. That is worth knowing before the next
release rather than during it.
