### PR TITLE
Scope archive coverage to the archives a read will open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,12 +59,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   has more than one archive destination and nothing makes them archive the same
   partitions. `loadArchiveCoverage` read `archive_state` unscoped, so an hour
   archived by one rotation was classified as covered for a read that opens a
-  different destination — the read fetched nothing for that hour, `GapHours`
-  came back empty, and a strict `AllowGaps=false` `reconstruct` proceeded over
-  data it could not see. Coverage is now scoped to the archive sources the read
-  will actually fetch from (`query.SourceIDsFromPaths` over the set
-  `resolveMergeSources` already resolved), which closes the gap between what the
-  planner counts and what the fetch opens.
+  different destination — the read fetched nothing for that hour and `GapHours`
+  came back empty. Coverage is now scoped to the archive sources the read will
+  actually fetch from, closing the gap between what the planner counts and what
+  the fetch opens. Concretely this fixes: `bintrail query` scoped to a subset
+  with `--archive-dir`/`--archive-s3` + `--bintrail-id`; `bintrail query
+  --profile`, which opens no archives at all yet was credited with every
+  registered one; and, on every merged read, `archive_state` rows with a NULL
+  `bintrail_id` or with paths that resolve to nothing on this host, which
+  previously counted as coverage for files nobody could open.
   - Single-source indexes are byte-identical to before, as are the index-wide
     callers that legitimately read every archive (the
     `bintrail_index_gap_hours` gauge and the console's activity caveat), which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   duplicate comes back — the previous marker was a code comment naming itself
   a "consolidation candidate", and a comment cannot fail.
 
+- **`bintrail-console` no longer carries its own copy of the env-file loader**
+  (#963). `consoleapp/env.go` held `loadEnvFile`/`parseAndSetEnv` byte-for-byte
+  identical to `internal/cli/env.go`, plus its own `sync.Once`, so any change
+  to env-file semantics would land in one binary and silently not the other.
+  Both now call the exported `cli.LoadEnvFile`. Sharing the `sync.Once` is also
+  more correct: `consoleapp` imports `internal/cli`, so two of them in one
+  process meant the file could be read twice. A guard test fails if the
+  duplicate comes back — the previous marker was a code comment naming itself
+  a "consolidation candidate", and a comment cannot fail.
+
 ### Fixed
+- **The query planner no longer counts archives the read will never open**
+  (#1232). Rotation is per-process, so an index capturing more than one source
+  has more than one archive destination and nothing makes them archive the same
+  partitions. `loadArchiveCoverage` read `archive_state` unscoped, so an hour
+  archived by one rotation was classified as covered for a read that opens a
+  different destination — the read fetched nothing for that hour, `GapHours`
+  came back empty, and a strict `AllowGaps=false` `reconstruct` proceeded over
+  data it could not see. Coverage is now scoped to the archive sources the read
+  will actually fetch from (`query.SourceIDsFromPaths` over the set
+  `resolveMergeSources` already resolved), which closes the gap between what the
+  planner counts and what the fetch opens.
+  - Single-source indexes are byte-identical to before, as are the index-wide
+    callers that legitimately read every archive (the
+    `bintrail_index_gap_hours` gauge and the console's activity caveat), which
+    pass an explicit unscoped nil.
+  - Note this is **not** scoping by which source produced the events:
+    `binlog_events` has no source discriminator and `ArchivePartition` archives
+    the whole shared partition, so one source's archive of an hour holds every
+    source's rows for it. `archive_state.bintrail_id` records who archived a
+    partition, not whose rows are inside — scoping by data ownership would
+    report gaps over data that is present.
 - **`status` no longer reports an unreadable archive tier as no archive tier**
   (#816). `LoadCoverage` degraded every `archive_state` failure to live-only
   coverage behind a `slog.Warn`, so "this index has no archives" and "I could

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -302,7 +302,11 @@ func (h *DefaultHandler) HandleRecover(ctx context.Context, req RecoverRequest) 
 		// out-of-range hour label must survive date/file pruning. Best-effort:
 		// without an index DB (archive-only handlers) this stays nil and
 		// pruning falls back to labels.
-		hours, mErr := query.MisfiledArchiveHours(ctx, h.IndexDB, opts.Since, opts.Until)
+		// nil scope (#1232). Misfiled hours are a WIDENING hint — "do not
+		// prune these files" — so an over-broad set costs a few unpruned
+		// reads while a narrow one silently skips backfilled rows. Unscoped is
+		// the safe direction for a hint, the opposite of coverage.
+		hours, mErr := query.MisfiledArchiveHours(ctx, h.IndexDB, opts.Since, opts.Until, nil)
 		if mErr != nil {
 			h.logger().Warn("could not check archive_state for misfiled archives", "error", mErr)
 		} else {

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -323,12 +323,17 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	// (archive queries do not enforce DenyTables/RedactColumns rules; explicit
 	// archive flags are already blocked by the --profile validation above).
 	var archSources []string
+	// discoveryFailed keeps the coverage scope honest (#1232): with an
+	// unknown source set the planner must stay unscoped, because an
+	// empty scope would report every rotated hour as a gap.
+	discoveryFailed := false
 	if !qNoArchive {
 		archSources = archiveSources()
 		if len(archSources) == 0 && qArchiveDir == "" && qArchiveS3 == "" && qProfile == "" {
 			var rerr error
 			archSources, rerr = query.ResolveArchiveSources(cmd.Context(), db)
 			if rerr != nil {
+				discoveryFailed = true
 				// bintrail query is deliberately permissive (multi-region
 				// operators shouldn't lose a query to one bad registry
 				// read) — but the failure is surfaced on both channels,
@@ -346,7 +351,17 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		if parseErr != nil {
 			slog.Warn("could not parse DSN for query planning", "error", parseErr)
 		} else if cfg.DBName != "" {
-			plan = query.RunPlanAndWarn(cmd.Context(), db, cfg.DBName, since, until)
+			// Scope the coverage read to the archives this query will
+			// actually open (#1232): an hour recorded by a rotation whose
+			// destination is not in --archive-dir/--archive-s3 (or in what
+			// discovery resolved) is not coverage for THIS read, and
+			// counting it suppressed the gap warning over data the fetch
+			// never opens.
+			var scope []string
+			if !discoveryFailed {
+				scope = query.SourceIDsFromPaths(archSources)
+			}
+			plan = query.RunPlanAndWarn(cmd.Context(), db, cfg.DBName, since, until, scope)
 		}
 	}
 

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -357,8 +357,25 @@ func runQuery(cmd *cobra.Command, args []string) error {
 			// discovery resolved) is not coverage for THIS read, and
 			// counting it suppressed the gap warning over data the fetch
 			// never opens.
+			// scope nil = "every archive in the index"; non-nil empty =
+			// "this query opens none". Both are reachable here and the
+			// difference decides whether a rotated hour is a gap.
 			var scope []string
-			if !discoveryFailed {
+			switch {
+			case discoveryFailed:
+				// Unknown set. An empty scope would report every rotated hour
+				// as a gap, so stay unscoped and let the warning path be
+				// permissive, as it already is for the failed discovery
+				// itself.
+			case qProfile != "":
+				// An active profile skips archive discovery entirely (archive
+				// reads enforce no redaction rules), so this query provably
+				// opens NO archives. Leaving it unscoped credited every
+				// registered archive as coverage for a fetch that reads only
+				// live MySQL — the same false OK this change removes,
+				// reachable from the command line with one flag.
+				scope = []string{}
+			default:
 				scope = query.SourceIDsFromPaths(archSources)
 			}
 			plan = query.RunPlanAndWarn(cmd.Context(), db, cfg.DBName, since, until, scope)

--- a/internal/cli/query_scope_integration_test.go
+++ b/internal/cli/query_scope_integration_test.go
@@ -1,0 +1,78 @@
+//go:build integration
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// `bintrail query --profile` skips archive discovery entirely: archive reads
+// enforce no redaction rules, so a profiled query provably opens NO archives.
+// The planner was still handed a nil scope, which it reads as "every archive in
+// the index" — so a rotated hour the query cannot reach was credited as
+// coverage and the gap warning never fired.
+//
+// That is the same false OK #1232 removes, reachable from the command line with
+// one flag, at a call site the fix already touched.
+func TestRunQuery_profileScopesToNoArchives(t *testing.T) {
+	ctx := context.Background()
+	db, name := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	// An hour that is neither live nor reachable by this query.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO archive_state (partition_name, bintrail_id, local_path)
+		 VALUES ('p_2020010203', 'src-a', '/archives/bintrail_id=src-a/x.parquet')`); err != nil {
+		t.Fatalf("seed archive_state: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO profiles (name) VALUES ('analyst')`); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+
+	saved := struct{ dsn, format, profile, since, until string }{qIndexDSN, qFormat, qProfile, qSince, qUntil}
+	t.Cleanup(func() {
+		qIndexDSN, qFormat, qProfile, qSince, qUntil = saved.dsn, saved.format, saved.profile, saved.since, saved.until
+	})
+	qIndexDSN = testutil.IntegrationDSN(name)
+	qFormat = "table"
+	qSince = "2020-01-02 03:00:00"
+	qUntil = "2020-01-02 03:30:00"
+	queryCmd.SetContext(ctx)
+
+	// The gap verdict is emitted through slog, so swap the default handler.
+	gapWarned := func(t *testing.T) bool {
+		t.Helper()
+		var buf bytes.Buffer
+		prev := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+		defer slog.SetDefault(prev)
+		captureStdout(t, func() {
+			if err := runQuery(queryCmd, nil); err != nil {
+				t.Fatalf("runQuery: %v", err)
+			}
+		})
+		return strings.Contains(buf.String(), "rotated and not archived")
+	}
+
+	// Control: without a profile the query DOES open the archive, so the hour
+	// is covered and no gap is warned. Without this the assertion below could
+	// pass for the wrong reason.
+	qProfile = ""
+	if gapWarned(t) {
+		t.Error("an unprofiled query warned about a gap over an hour it can fetch")
+	}
+
+	// The regression: profiled, the query opens nothing, so the hour is a gap.
+	qProfile = "analyst"
+	if !gapWarned(t) {
+		t.Error("a --profile query credited an archive it never opens as coverage; the gap warning is silent over an unreachable hour")
+	}
+}

--- a/internal/console/activity_api.go
+++ b/internal/console/activity_api.go
@@ -179,7 +179,11 @@ func (s *Server) handleActivity(w http.ResponseWriter, r *http.Request) {
 	// what makes the caveat honest. Passing the bundle's noArchive would
 	// reclassify those hours as gaps and silence the caveat.
 	resp.Complete = !resp.Truncated
-	plan, perr := query.Plan(r.Context(), b.db, b.dbName, &since, &until, false)
+	// nil scope (#1232), for the same reason noArchive is false above: this
+	// reads archive_state as INDEX METADATA to caveat a count, not to decide
+	// what a fetch will open. Scoping it would drop hours that are archived
+	// and silence the caveat they exist to raise.
+	plan, perr := query.Plan(r.Context(), b.db, b.dbName, &since, &until, false, nil)
 	switch {
 	case perr != nil:
 		// Never assume completeness we could not check.

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -1120,7 +1120,9 @@ func EnvArchiveSources(ctx context.Context, db *sql.DB) ([]string, bool) {
 // knowingly-possibly-incomplete class as its other two archive gates. Never
 // fails without a time filter (since/until both nil): nothing is pruned then.
 func misfiledArchiveHours(ctx context.Context, db *sql.DB, since, until *time.Time) ([]time.Time, bool) {
-	hours, err := query.MisfiledArchiveHours(ctx, db, since, until)
+	// nil scope (#1232): a widening pruning hint, safe over-broad and unsafe
+	// narrow — see the agent handler's call site.
+	hours, err := query.MisfiledArchiveHours(ctx, db, since, until, nil)
 	if err != nil {
 		slog.Warn("could not check archive_state for misfiled archives (backfilled events); time-scoped archive pruning may skip them", "error", err)
 		return nil, true

--- a/internal/query/archive.go
+++ b/internal/query/archive.go
@@ -192,3 +192,54 @@ func extractBasePath(path string) string {
 	}
 	return path[:idx+len(marker)+slashIdx]
 }
+
+// SourceIDsFromPaths extracts the bintrail_ids embedded in resolved archive
+// source paths — the set of archives a read will actually OPEN (#1232).
+//
+// The id is in the path because every archive base ends at the Hive marker
+// `bintrail_id=<id>` (extractBasePath is what puts it there, for both local
+// dirs and `s3://bucket/prefix` sources), so the caller that resolved the
+// sources already holds the scope without a second database read.
+//
+// Returns a non-nil EMPTY slice for a non-nil input that yields no ids, and
+// nil only for a nil input. That distinction is load-bearing: the planner
+// reads nil as "every archive in the index" and empty as "this read opens
+// none", and collapsing the two would turn "I resolved nothing" into "I
+// resolved everything" — the false-OK this exists to prevent. A path with no
+// marker is therefore DROPPED rather than silently widening the scope; it can
+// only come from a caller that bypassed extractBasePath, and counting an
+// unidentifiable archive as "all archives" is the same false OK.
+func SourceIDsFromPaths(paths []string) []string {
+	if paths == nil {
+		return nil
+	}
+	seen := make(map[string]bool, len(paths))
+	ids := make([]string, 0, len(paths))
+	for _, p := range paths {
+		id := sourceIDFromBase(p)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// sourceIDFromBase pulls the id out of a base path ending in
+// `bintrail_id=<id>`. It matches on the marker rather than on the id's shape:
+// rotate's --bintrail-id takes an arbitrary string verbatim, and a reader
+// stricter than the writer would silently skip every archive under a
+// human-named id (the #392 review lesson, in the discovery direction).
+func sourceIDFromBase(base string) string {
+	const marker = "bintrail_id="
+	i := strings.LastIndex(base, marker)
+	if i < 0 {
+		return ""
+	}
+	id := strings.TrimSuffix(base[i+len(marker):], "/")
+	if strings.Contains(id, "/") {
+		return ""
+	}
+	return id
+}

--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -494,7 +494,24 @@ func resolveMergeSources(ctx context.Context, db *sql.DB, o FetchMergedOptions) 
 	// detection for --no-archive callers (observability win for recover,
 	// correctness win for reconstruct under AllowGaps=false).
 	if o.DBName != "" && (len(src.archSources) > 0 || o.Opts.Since != nil || o.Opts.Until != nil) {
-		p, err := Plan(ctx, db, o.DBName, o.Opts.Since, o.Opts.Until, o.NoArchive)
+		// Scope coverage to the archives THIS read will open (#1232). The
+		// set is src.archSources, already resolved a few lines up, so the
+		// planner and the fetch can no longer disagree about which archives
+		// exist — an hour recorded in archive_state by a rotation whose
+		// destination this read does not open is not coverage, and counting
+		// it was letting a strict reconstruct proceed over data it would
+		// never fetch.
+		//
+		// nil (unscoped, the old behaviour) is deliberate on the
+		// discovery-failure path: we do not know the set, and inventing an
+		// empty one would report every rotated hour as a gap. AllowGaps=false
+		// has already refused above in that case, and AllowGaps=true asked
+		// for best-effort.
+		var scope []string
+		if !src.discoveryFailed {
+			scope = SourceIDsFromPaths(src.archSources)
+		}
+		p, err := Plan(ctx, db, o.DBName, o.Opts.Since, o.Opts.Until, o.NoArchive, scope)
 		if err != nil {
 			if !o.AllowGaps {
 				return src, fmt.Errorf("query planner failed, cannot verify coverage: %w", err)

--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -494,13 +494,19 @@ func resolveMergeSources(ctx context.Context, db *sql.DB, o FetchMergedOptions) 
 	// detection for --no-archive callers (observability win for recover,
 	// correctness win for reconstruct under AllowGaps=false).
 	if o.DBName != "" && (len(src.archSources) > 0 || o.Opts.Since != nil || o.Opts.Until != nil) {
-		// Scope coverage to the archives THIS read will open (#1232). The
-		// set is src.archSources, already resolved a few lines up, so the
+		// Scope coverage to the archives THIS read will open (#1232), so the
 		// planner and the fetch can no longer disagree about which archives
-		// exist — an hour recorded in archive_state by a rotation whose
-		// destination this read does not open is not coverage, and counting
-		// it was letting a strict reconstruct proceed over data it would
-		// never fetch.
+		// exist.
+		//
+		// Be precise about what this closes HERE. resolveMergeSources always
+		// resolves via ResolveArchiveSources, which enumerates every non-NULL
+		// bintrail_id, so on this path the scope normally equals the full set
+		// and the filter is inert. What it is not inert for is the rows that
+		// set never contains: an archive_state row with a NULL bintrail_id,
+		// or one whose paths resolve to nothing on this host. Those used to
+		// count as coverage for a fetch that could not open them, and now
+		// classify as gaps. The subset case the scope really exists for lives
+		// on `bintrail query --archive-dir/--archive-s3 --bintrail-id`.
 		//
 		// nil (unscoped, the old behaviour) is deliberate on the
 		// discovery-failure path: we do not know the set, and inventing an
@@ -509,7 +515,18 @@ func resolveMergeSources(ctx context.Context, db *sql.DB, o FetchMergedOptions) 
 		// for best-effort.
 		var scope []string
 		if !src.discoveryFailed {
-			scope = SourceIDsFromPaths(src.archSources)
+			// Non-nil even when discovery resolved NOTHING. This is the sharp
+			// edge of the nil/empty contract: ResolveArchiveSources builds its
+			// result with append, so "succeeded, found zero sources" comes
+			// back as a nil slice — which SourceIDsFromPaths faithfully maps
+			// to nil, which the planner reads as "every archive in the index".
+			// A successful discovery that found nothing means this read opens
+			// nothing, and it must not be spelled the same way as "opens
+			// everything".
+			scope = []string{}
+			if ids := SourceIDsFromPaths(src.archSources); ids != nil {
+				scope = ids
+			}
 		}
 		p, err := Plan(ctx, db, o.DBName, o.Opts.Since, o.Opts.Until, o.NoArchive, scope)
 		if err != nil {

--- a/internal/query/planner.go
+++ b/internal/query/planner.go
@@ -68,7 +68,22 @@ type QueryPlan struct {
 // only in archives are then classified as GAPS, because those archives will not
 // be fetched. Counting them as covered would let a strict (AllowGaps=false)
 // reconstruct silently return incomplete state.
-func Plan(ctx context.Context, db *sql.DB, dbName string, since, until *time.Time, noArchive bool) (*QueryPlan, error) {
+//
+// sourceIDs names the archive sources this read will actually OPEN, as
+// bintrail_ids (#1232). It is the same rule as noArchive applied at a finer
+// grain: coverage recorded by an archive the fetch will not read is not
+// coverage. nil means "every archive registered in the index", which is the
+// only honest answer for a caller that reads them all — or that cannot
+// enumerate the set. An EMPTY non-nil slice means "this read opens no
+// archives", so every rotated hour is a gap.
+//
+// Note what this deliberately does NOT scope by: which source PRODUCED the
+// events. binlog_events carries no source discriminator and ArchivePartition
+// archives the whole shared partition, so one source's archive of hour H holds
+// every source's events for H. archive_state.bintrail_id records who archived
+// a partition, not whose rows are in it — scoping by data ownership would
+// report gaps over data that is present.
+func Plan(ctx context.Context, db *sql.DB, dbName string, since, until *time.Time, noArchive bool, sourceIDs []string) (*QueryPlan, error) {
 	if db == nil || dbName == "" {
 		return nil, nil
 	}
@@ -102,7 +117,7 @@ func Plan(ctx context.Context, db *sql.DB, dbName string, since, until *time.Tim
 	// covered. Leaving archivedHours nil makes buildPlan classify them as gaps.
 	var cov []archiveCoverage
 	if !noArchive {
-		cov, err = loadArchiveCoverage(ctx, db)
+		cov, err = loadArchiveCoverage(ctx, db, sourceIDs)
 		if err != nil {
 			slog.Debug("archive_state not available for planning", "error", err)
 			cov = nil
@@ -225,10 +240,10 @@ func (p *QueryPlan) SkipMySQL() bool {
 // applicable or fails (callers should fall back to the default path).
 //
 // parseDSN is a function that extracts the database name from the DSN.
-func RunPlanAndWarn(ctx context.Context, db *sql.DB, dbName string, since, until *time.Time) *QueryPlan {
+func RunPlanAndWarn(ctx context.Context, db *sql.DB, dbName string, since, until *time.Time, sourceIDs []string) *QueryPlan {
 	// Callers that exclude archives (bintrail query --no-archive) skip planning
 	// entirely, so this warn path is always archive-aware (noArchive=false).
-	plan, err := Plan(ctx, db, dbName, since, until, false)
+	plan, err := Plan(ctx, db, dbName, since, until, false, sourceIDs)
 	if err != nil {
 		slog.Warn("query planner failed; coverage gaps may not be detected", "error", err)
 		return nil
@@ -315,19 +330,42 @@ type archiveCoverage struct {
 // back to label-only coverage (the pre-#1037 behavior).
 const maxCoverageSpan = 20 * 366 * 24 * time.Hour
 
+// sourceScopeClause builds the optional `WHERE bintrail_id IN (...)` that
+// restricts coverage to the archives a read will open (#1232). A nil scope
+// yields no clause at all — every registered archive counts, which is correct
+// for a caller that reads them all. The empty-scope case never reaches here:
+// callers return early, because `IN ()` is a syntax error, not an empty set.
+func sourceScopeClause(sourceIDs []string) (string, []any) {
+	if len(sourceIDs) == 0 {
+		return "", nil
+	}
+	args := make([]any, len(sourceIDs))
+	for i, id := range sourceIDs {
+		args[i] = id
+	}
+	return " WHERE bintrail_id IN (?" + strings.Repeat(", ?", len(sourceIDs)-1) + ")", args
+}
+
 // loadArchiveCoverage returns per-row archive coverage from archive_state.
 // On an index whose archive_state predates the min/max_event_ts columns
 // (error 1054 — the migration only runs where EnsureSchema does, e.g. rotate),
 // it falls back to label-only coverage so planning keeps working unchanged.
-func loadArchiveCoverage(ctx context.Context, db *sql.DB) ([]archiveCoverage, error) {
+func loadArchiveCoverage(ctx context.Context, db *sql.DB, sourceIDs []string) ([]archiveCoverage, error) {
+	if sourceIDs != nil && len(sourceIDs) == 0 {
+		// Scoped to nothing: this read opens no archives, so no archive_state
+		// row can describe coverage it will see. Returning early (rather than
+		// building an `IN ()`, which is a syntax error) keeps that explicit.
+		return nil, nil
+	}
+	where, args := sourceScopeClause(sourceIDs)
 	rows, err := db.QueryContext(ctx, `
 		SELECT partition_name, min_event_ts, max_event_ts
-		FROM archive_state
-		ORDER BY partition_name`)
+		FROM archive_state`+where+`
+		ORDER BY partition_name`, args...)
 	if err != nil {
 		var myErr *mysql.MySQLError
 		if errors.As(err, &myErr) && myErr.Number == 1054 {
-			return loadArchiveCoverageLegacy(ctx, db)
+			return loadArchiveCoverageLegacy(ctx, db, sourceIDs)
 		}
 		return nil, err
 	}
@@ -356,11 +394,15 @@ func loadArchiveCoverage(ctx context.Context, db *sql.DB) ([]archiveCoverage, er
 
 // loadArchiveCoverageLegacy is loadArchiveCoverage for pre-#1037 archive_state
 // schemas: partition names only, no content range.
-func loadArchiveCoverageLegacy(ctx context.Context, db *sql.DB) ([]archiveCoverage, error) {
+func loadArchiveCoverageLegacy(ctx context.Context, db *sql.DB, sourceIDs []string) ([]archiveCoverage, error) {
+	if sourceIDs != nil && len(sourceIDs) == 0 {
+		return nil, nil
+	}
+	where, args := sourceScopeClause(sourceIDs)
 	rows, err := db.QueryContext(ctx, `
 		SELECT DISTINCT partition_name
-		FROM archive_state
-		ORDER BY partition_name`)
+		FROM archive_state`+where+`
+		ORDER BY partition_name`, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -452,11 +494,11 @@ func misfiledHours(cov []archiveCoverage, rangeStart, rangeEnd time.Time) []time
 // hour labels of misfiled archives overlapping [since, until]; nil bounds are
 // open. Returns (nil, nil) when db is nil or no time bound is set (no pruning
 // happens then, so nothing can be missed).
-func MisfiledArchiveHours(ctx context.Context, db *sql.DB, since, until *time.Time) ([]time.Time, error) {
+func MisfiledArchiveHours(ctx context.Context, db *sql.DB, since, until *time.Time, sourceIDs []string) ([]time.Time, error) {
 	if db == nil || (since == nil && until == nil) {
 		return nil, nil
 	}
-	cov, err := loadArchiveCoverage(ctx, db)
+	cov, err := loadArchiveCoverage(ctx, db, sourceIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/query/planner_scope_integration_test.go
+++ b/internal/query/planner_scope_integration_test.go
@@ -1,0 +1,89 @@
+//go:build integration
+
+package query_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// The bug (#1232): rotation is per-process, so on an index two sources rotate
+// into two destinations. Source A archives hour H into A's destination and
+// drops the partition; B never archived it. A read that opens only B's
+// archives fetches nothing for H — but the planner read archive_state
+// unscoped, saw A's row, and called H covered. A strict AllowGaps=false
+// reconstruct then proceeded over data it would never fetch.
+//
+// The fixture is deliberately the SAME archive_state either way; only the
+// scope moves. That is what makes this a test of the scoping rule rather than
+// of the fixture.
+func TestPlanScopesCoverageToTheArchivesTheReadOpens(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	db, dbName := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+
+	// An hour that is NOT a live partition (rotated out) but is recorded in
+	// archive_state under source A only.
+	hour := time.Date(2020, 1, 2, 3, 0, 0, 0, time.UTC)
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO archive_state (partition_name, bintrail_id, local_path)
+		 VALUES (?, 'source-a', '/archives/bintrail_id=source-a/x.parquet')`,
+		indexer.PartitionName(hour)); err != nil {
+		t.Fatalf("seed archive_state: %v", err)
+	}
+
+	since, until := hour, hour.Add(30*time.Minute)
+	gapHours := func(t *testing.T, scope []string) int {
+		t.Helper()
+		p, err := query.Plan(ctx, db, dbName, &since, &until, false, scope)
+		if err != nil {
+			t.Fatalf("Plan: %v", err)
+		}
+		if p == nil {
+			t.Fatal("Plan returned nil for a bounded range")
+		}
+		return len(p.GapHours)
+	}
+
+	// A read that opens A's archives sees the hour as covered — it really
+	// will fetch that file.
+	if n := gapHours(t, []string{"source-a"}); n != 0 {
+		t.Errorf("a read scoped to the source that archived the hour reported %d gap hour(s); it will fetch that archive", n)
+	}
+
+	// THE REGRESSION: a read that opens only B's archives must NOT inherit
+	// A's coverage. Before #1232 this returned 0 and a strict reconstruct
+	// proceeded over an hour it could not read.
+	if n := gapHours(t, []string{"source-b"}); n != 1 {
+		t.Errorf("a read scoped to a source that never archived the hour reported %d gap hour(s), want 1 — A's archive is being counted as B's coverage", n)
+	}
+
+	// A read that opens NO archives (non-nil, empty) is the same statement in
+	// its strongest form.
+	if n := gapHours(t, []string{}); n != 1 {
+		t.Errorf("a read that opens no archives reported %d gap hour(s), want 1", n)
+	}
+
+	// nil is "every archive in the index", the honest answer for a caller
+	// that reads them all — and the one that keeps single-source indexes and
+	// the index-wide gauges byte-identical to before.
+	if n := gapHours(t, nil); n != 0 {
+		t.Errorf("an unscoped plan reported %d gap hour(s), want 0 — this is the pre-#1232 behaviour every index-wide caller still relies on", n)
+	}
+
+	// Scoping must be a filter, not a rename: a source that archived the hour
+	// is still covered when named alongside one that did not.
+	if n := gapHours(t, []string{"source-b", "source-a"}); n != 0 {
+		t.Errorf("a read opening both destinations reported %d gap hour(s), want 0", n)
+	}
+}

--- a/internal/query/planner_test.go
+++ b/internal/query/planner_test.go
@@ -156,7 +156,7 @@ func TestQueryPlan_SkipMySQL(t *testing.T) {
 
 func TestPlan_nilDB(t *testing.T) {
 	since := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
-	p, err := Plan(t.Context(), nil, "testdb", &since, nil, false)
+	p, err := Plan(t.Context(), nil, "testdb", &since, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ func TestPlan_nilDB(t *testing.T) {
 
 func TestPlan_noTimeRange(t *testing.T) {
 	// Nil since and until should produce nil plan (no routing possible).
-	p, err := Plan(t.Context(), nil, "testdb", nil, nil, false)
+	p, err := Plan(t.Context(), nil, "testdb", nil, nil, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/query/scope_wiring_integration_test.go
+++ b/internal/query/scope_wiring_integration_test.go
@@ -1,0 +1,67 @@
+//go:build integration
+
+package query_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// The scope rule is tested directly against Plan. This tests the WIRING: that
+// FetchMerged actually derives a scope and hands it over.
+//
+// It exists because replacing `scope` with `nil` inside resolveMergeSources was
+// invisible to the entire suite — the unit tests set DBName:"" so the planner
+// never runs, and the sqlmock expectations are unanchored regexes with no
+// WithArgs, so a scoped query with bound arguments matched identically.
+//
+// The lever is an archive_state row with a NULL bintrail_id. ResolveArchiveSources
+// filters those out (`WHERE bintrail_id IS NOT NULL`), so such a row can never
+// describe an archive this read opens — yet unscoped coverage counted it.
+func TestFetchMerged_scopesCoverageToResolvedSources(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	db, dbName := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	hour := time.Date(2020, 1, 2, 3, 0, 0, 0, time.UTC)
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO archive_state (partition_name, bintrail_id, local_path)
+		 VALUES (?, NULL, '/archives/orphan/x.parquet')`,
+		indexer.PartitionName(hour)); err != nil {
+		t.Fatalf("seed archive_state: %v", err)
+	}
+
+	since, until := hour, hour.Add(30*time.Minute)
+	_, plan, err := query.FetchMerged(ctx, db, query.New(db), query.FetchMergedOptions{
+		Opts:      query.Options{Since: &since, Until: &until, Limit: 10},
+		DBName:    dbName,
+		AllowGaps: true,
+		// A fetcher that opens nothing: the point is the PLAN, and the
+		// orphan row resolves to no source, so nothing is ever fetched.
+		ArchiveFetcher: func(context.Context, query.Options, string) ([]query.ResultRow, error) {
+			return nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("FetchMerged: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("planner did not run; this test would prove nothing")
+	}
+	// The row cannot describe an archive this read opens, so the hour is a
+	// gap. Unscoped — the pre-#1232 behaviour, and what a `nil` slipped in at
+	// the call site restores — it counted as coverage and this is 0.
+	if len(plan.GapHours) != 1 {
+		t.Errorf("got %d gap hour(s), want 1: an archive_state row this read can never open is being counted as coverage",
+			len(plan.GapHours))
+	}
+}

--- a/internal/query/sourceids_test.go
+++ b/internal/query/sourceids_test.go
@@ -1,0 +1,50 @@
+package query_test
+
+import (
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// SourceIDsFromPaths is what turns the resolved source PATHS a caller already
+// holds into that scope, so the fix needs no second database read. The nil vs
+// empty distinction is the whole safety property and is asserted directly.
+func TestSourceIDsFromPaths(t *testing.T) {
+	if got := query.SourceIDsFromPaths(nil); got != nil {
+		t.Errorf("nil input must stay nil (unscoped), got %#v", got)
+	}
+	got := query.SourceIDsFromPaths([]string{})
+	if got == nil {
+		t.Error("an empty input must yield an empty NON-nil scope; collapsing it to nil turns 'I resolved nothing' into 'I resolved everything'")
+	}
+	for _, tc := range []struct {
+		name  string
+		paths []string
+		want  []string
+	}{
+		{"local base", []string{"/archives/bintrail_id=abc"}, []string{"abc"}},
+		{"trailing slash", []string{"/archives/bintrail_id=abc/"}, []string{"abc"}},
+		{"s3 base", []string{"s3://bucket/prefix/bintrail_id=abc"}, []string{"abc"}},
+		// rotate --bintrail-id takes an arbitrary string verbatim, so a
+		// reader stricter than the writer would silently drop real archives.
+		{"human-named id", []string{"/a/bintrail_id=prod-eu-1"}, []string{"prod-eu-1"}},
+		{"dedup", []string{"/a/bintrail_id=x", "/b/bintrail_id=x"}, []string{"x"}},
+		{"multiple", []string{"/a/bintrail_id=x", "/b/bintrail_id=y"}, []string{"x", "y"}},
+		// No marker: DROPPED, never widened to "all". Counting an
+		// unidentifiable archive as every archive is the false OK this
+		// scoping exists to remove.
+		{"no marker", []string{"/archives/plain"}, []string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := query.SourceIDsFromPaths(tc.paths)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %#v, want %#v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("got %#v, want %#v", got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/streamrun/index_metrics.go
+++ b/internal/streamrun/index_metrics.go
@@ -101,7 +101,12 @@ func scrapeIndexMetrics(ctx context.Context, db *sql.DB, dbName string, m *obser
 		archiveEarliest = data.Coverage.ArchiveEarliestHour
 	}
 	if since, until, ok := gapScrapeRange(snap.OldestEvent, archiveEarliest, newestExplicit); ok {
-		if plan, err := query.Plan(ctx, db, dbName, &since, &until, false); err != nil {
+		// nil scope (#1232): this gauge is about the INDEX, not about any one
+		// reader's archive set. bintrail_index_gap_hours answers "is there a
+		// hole in what this index retains", so every registered archive counts
+		// — scoping it to a reader's subset would make the daemon's metric
+		// depend on who happens to be querying.
+		if plan, err := query.Plan(ctx, db, dbName, &since, &until, false, nil); err != nil {
 			slog.Warn("index metrics scrape: could not plan gap hours", "error", err)
 		} else if plan != nil { // belt-and-suspenders: Plan can still return nil
 			snap.GapHours = len(plan.GapHours)


### PR DESCRIPTION
Closes #1232.

**Read [the grooming comment on the issue](https://github.com/dbtrail/dbtrail/issues/1232#issuecomment-5286316953) first** — the issue's original premise was wrong, and the fix here is not the one it proposed.

## The bug

Rotation is per-process, so an index capturing more than one source has more than one archive destination, and nothing makes them archive the same partitions.

1. Source A rotates, archives `p_H` into A's destination, records `(p_H, A)`, drops the partition.
2. Source B never archived `p_H`. Those rows are gone from live MySQL and absent from B's destination.
3. A read that resolves only B's archives fetches nothing for hour H.
4. `loadArchiveCoverage` reads `archive_state` **unscoped**, sees `(p_H, A)`, classifies H as covered. `GapHours` comes back empty and a strict `AllowGaps=false` `reconstruct` proceeds over data it cannot read.

The mismatch is between **what the planner counts as covered** and **what the fetch will actually open** — not between sources.

## What this does not do

Scope by *which source produced the events*, which is what the issue asked for. That concept does not exist in the index:

- `binlog_events` has no source discriminator — no `bintrail_id`, no `server_id` (`internal/indexer/schema.go:108-131`).
- `ArchivePartition` archives the whole partition — `SELECT … FROM binlog_events PARTITION (p_H) ORDER BY event_id`, no `WHERE` (`internal/archive/archive.go:110`).

So A's archive of hour H already contains B's rows. `archive_state.bintrail_id` records **who archived a partition**, not whose rows are in it, and scoping by data ownership would report gaps over data that is present — the cry-wolf failure #1219 avoided one layer up.

## The fix

`Plan` and `MisfiledArchiveHours` take the `bintrail_id`s the read will actually open. `resolveMergeSources` already resolved that set a few lines before calling the planner, so the scope costs no extra query: `SourceIDsFromPaths` pulls the ids out of the resolved base paths, which end at the Hive `bintrail_id=` marker by construction.

### nil vs empty is the safety property

| scope | meaning |
|---|---|
| `nil` | every archive registered in the index |
| `[]` (non-nil, empty) | this read opens no archives → every rotated hour is a gap |

Collapsing the two would turn *"I resolved nothing"* into *"I resolved everything"* — exactly the false OK being removed. `SourceIDsFromPaths` therefore returns a non-nil empty slice for a non-nil input, and a path with no marker is **dropped** rather than silently widening the scope.

The discovery-failure path passes `nil` on purpose: with an unknown source set an empty scope would report every rotated hour as a gap, and `AllowGaps=false` has already refused above.

## What stays byte-identical

- **Single-source indexes** — the scoped set is the only set.
- **Callers that read every archive** — `bintrail_index_gap_hours` (a gauge about the *index*, which must not depend on who is querying) and the console's activity caveat (which reads `archive_state` as index *metadata* to qualify a count, not to decide what a fetch opens). Both pass an explicit `nil` with the reason at the call site.
- **`MisfiledArchiveHours`' standalone callers** (agent, mcptools) — misfiled hours are a *widening* hint, "do not prune these files", where an over-broad set costs a few unpruned reads and a narrow one silently skips backfilled rows. Unscoped is the safe direction for a hint, the opposite of coverage. Inside `Plan` the hint does follow the scoped coverage, correctly, because the fetch there is scoped identically.

## Testing

- Integration test against real MySQL drives the exact scenario: **the same `archive_state` fixture, only the scope moves.** A read scoped to the archiving source sees 0 gaps; one scoped to a source that never archived sees 1; empty sees 1; `nil` sees 0.
- Unit table for `SourceIDsFromPaths` including the nil/empty distinction, `s3://` bases, trailing slashes, a human-named id (rotate's `--bintrail-id` takes an arbitrary string, and a reader stricter than the writer silently drops real archives — the #392 lesson), dedup, and the no-marker drop.
- Mutation-checked: ignoring the scope, collapsing empty to nil, and dropping the empty-scope early return (which would emit `IN ()`) each break a test.
- Full unit suite plus the integration suite for all six touched packages.
