### PR TITLE
Distinguish an unreadable archive tier from no archive tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- **`bintrail-console` no longer carries its own copy of the env-file loader**
-  (#963). `consoleapp/env.go` held `loadEnvFile`/`parseAndSetEnv` byte-for-byte
-  identical to `internal/cli/env.go`, plus its own `sync.Once`, so any change
-  to env-file semantics would land in one binary and silently not the other.
-  Both now call the exported `cli.LoadEnvFile`. Sharing the `sync.Once` is also
-  more correct: `consoleapp` imports `internal/cli`, so two of them in one
-  process meant the file could be read twice. A guard test fails if the
-  duplicate comes back — the previous marker was a code comment naming itself
-  a "consolidation candidate", and a comment cannot fail.
-
-### Fixed
-
-
 ### Added
 - **A capture-skip record can be acknowledged** (#1314). `stream_state.capture_skips`
   is monotonic, so a single skip episode kept the console's capture-health box
@@ -46,6 +32,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `"degraded"`: the events really are still missing, and a consumer keying on
     the verdict must not read a human's "seen it" as the loss being undone.
 
+### Changed
+- **`bintrail-console` no longer carries its own copy of the env-file loader**
+  (#963). `consoleapp/env.go` held `loadEnvFile`/`parseAndSetEnv` byte-for-byte
+  identical to `internal/cli/env.go`, plus its own `sync.Once`, so any change
+  to env-file semantics would land in one binary and silently not the other.
+  Both now call the exported `cli.LoadEnvFile`. Sharing the `sync.Once` is also
+  more correct: `consoleapp` imports `internal/cli`, so two of them in one
+  process meant the file could be read twice. A guard test fails if the
+  duplicate comes back — the previous marker was a code comment naming itself
+  a "consolidation candidate", and a comment cannot fail.
+
+### Fixed
+- **`status` no longer reports an unreadable archive tier as no archive tier**
+  (#816). `LoadCoverage` degraded every `archive_state` failure to live-only
+  coverage behind a `slog.Warn`, so "this index has no archives" and "I could
+  not read the archives" printed identically — a restore window SHORTER than
+  reality, which an operator reads as "that incident is beyond recovery" while
+  the Parquet covering it is still in the bucket. Only a genuinely missing
+  table now counts as no archive tier; any other outcome — including an
+  `archive_state` row whose `partition_name` will not parse, which left the
+  floor silently live-only — sets
+  `CoverageInfo.ArchiveUnavailable`, and both renderings say the window is a
+  lower bound (`⚠ NOT READ` in the text report, `coverage.archives_unavailable`
+  plus `archives_error` in JSON). The "(includes archives)" label is withheld
+  in that state rather than claiming coverage that was never read.
 ## [0.53.0] - 2026-08-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,24 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a "consolidation candidate", and a comment cannot fail.
 
 ### Fixed
-- **A duplicate event whose two copies disagree is no longer discarded in
-  silence** (#841). While a partition is archived but not yet dropped, the same
-  `event_id` arrives from both the index and the Parquet archive.
-  `MergeResults` kept the first appearance, and "MySQL first, MySQL wins" was a
-  comment with nothing enforcing it — the agent deliberately puts its buffer
-  first. If the copies genuinely differed (an index row mutated after
-  archiving, or two index generations writing under one `bintrail_id`) the
-  operator got an arbitrary one of two answers with no signal at all. A
-  collision now compares the copies and warns, naming the event, schema, table
-  and PK. Which copy wins is unchanged — this adds visibility, not a new
-  resolution rule.
-  - The comparison only runs on collision, so the normal path is unaffected.
-  - Columns added after the original schema (`connection_id`, `query_text`,
-    `query_hash`, `commit_ts_us`) are compared only when BOTH sides carry a
-    value: an archive written before a column existed loads it as NULL, and
-    treating that as divergence would fire on every legacy archive in the
-    fleet. Row images are compared with `reflect.DeepEqual` — `==` on an `any`
-    holding a nested JSON array or object panics.
+
 
 ### Added
 - **A capture-skip record can be acknowledged** (#1314). `stream_state.capture_skips`

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -169,8 +169,10 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			// available delta coverage — the live-partition floor (partition
 			// existence = coverage) extended backwards by archives. The floor
 			// comes from OldestDeltaFromDB, NOT data.Coverage: coverage is
-			// best-effort display data that swallows archive_state errors,
-			// and a floor built on it would fabricate "broken" on healthy
+			// best-effort display data that reports an archive_state failure
+			// as a flag rather than an error (#816), so a floor built on it
+			// still cannot distinguish the cases and would fabricate "broken"
+			// on healthy
 			// archives whenever that one read fails. A floor error degrades
 			// every verdict to unknown.
 			floor, fErr := status.OldestDeltaFromDB(cmd.Context(), db, dbName)

--- a/internal/status/coverage_render_test.go
+++ b/internal/status/coverage_render_test.go
@@ -1,0 +1,106 @@
+package status
+
+import (
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The rendering of an unreadable archive tier (#816) is a pure function over
+// *CoverageInfo, so it belongs in a plain unit test — not behind
+// //go:build integration, where `go test ./...` skips it silently on a machine
+// with no MySQL.
+//
+// The integration test that shipped first put the rendering assertions there
+// AND never inserted a binlog_events row, so EarliestEvent was invalid, the
+// report took the "(none live)" branch, and the switch this change adds for
+// the normal populated-index case was executed by nothing. Its
+// "(includes archives)" assertion could not fail for the same reason.
+func TestWriteStatus_archiveUnavailable(t *testing.T) {
+	earliest := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	populated := func() *CoverageInfo {
+		return &CoverageInfo{
+			EarliestEvent: sql.NullTime{Time: earliest, Valid: true},
+			LatestEvent:   sql.NullTime{Time: earliest.Add(48 * time.Hour), Valid: true},
+			TotalEvents:   1200,
+		}
+	}
+
+	t.Run("populated index, archives unreadable", func(t *testing.T) {
+		c := populated()
+		c.ArchiveUnavailable = true
+		c.ArchiveError = "Error 1142: SELECT command denied"
+		var buf strings.Builder
+		(&StatusData{Coverage: c}).Write(&buf)
+		out := buf.String()
+
+		// THE branch: a live floor IS printed, and it must be labelled as
+		// live-only rather than presented as the restore reach.
+		if !strings.Contains(out, "2026-08-01 09:00:00 (LIVE INDEX ONLY") {
+			t.Errorf("the earliest-event line does not mark itself live-only:\n%s", out)
+		}
+		if strings.Contains(out, "(includes archives)") {
+			t.Errorf("claimed the window includes archives that were never read:\n%s", out)
+		}
+		if !strings.Contains(out, "NOT READ") || !strings.Contains(out, "LOWER BOUND") {
+			t.Errorf("the report does not qualify the window:\n%s", out)
+		}
+		if !strings.Contains(out, "1142") {
+			t.Errorf("the reason is not shown, so the operator cannot act:\n%s", out)
+		}
+	})
+
+	t.Run("archives read and present", func(t *testing.T) {
+		c := populated()
+		c.ArchiveEarliestHour = sql.NullTime{Time: earliest.Add(-72 * time.Hour), Valid: true}
+		c.ArchiveTotalRows = 900
+		var buf strings.Builder
+		(&StatusData{Coverage: c}).Write(&buf)
+		out := buf.String()
+		if !strings.Contains(out, "(includes archives)") {
+			t.Errorf("a healthy archive tier lost its label:\n%s", out)
+		}
+		if strings.Contains(out, "NOT READ") {
+			t.Errorf("a healthy archive tier was reported as unread:\n%s", out)
+		}
+	})
+
+	t.Run("no archive tier at all stays quiet", func(t *testing.T) {
+		var buf strings.Builder
+		(&StatusData{Coverage: populated()}).Write(&buf)
+		out := buf.String()
+		if strings.Contains(out, "NOT READ") || strings.Contains(out, "LIVE INDEX ONLY") {
+			t.Errorf("an index with no archives was given a scary banner:\n%s", out)
+		}
+	})
+
+	t.Run("JSON carries the verdict and omits it when healthy", func(t *testing.T) {
+		read := func(c *CoverageInfo) map[string]any {
+			t.Helper()
+			var buf strings.Builder
+			if err := (&StatusData{Coverage: c}).WriteJSON(&buf); err != nil {
+				t.Fatalf("WriteJSON: %v", err)
+			}
+			var parsed struct {
+				Coverage map[string]any `json:"coverage"`
+			}
+			if err := json.Unmarshal([]byte(buf.String()), &parsed); err != nil {
+				t.Fatalf("decode: %v\n%s", err, buf.String())
+			}
+			return parsed.Coverage
+		}
+		bad := populated()
+		bad.ArchiveUnavailable = true
+		bad.ArchiveError = "boom"
+		if got := read(bad); got["archives_unavailable"] != true || got["archives_error"] != "boom" {
+			t.Errorf("JSON lacks the unavailable verdict: %v", got)
+		}
+		// omitempty: a monitor's schema depends on the key being ABSENT when
+		// the figures are complete, not present-and-false.
+		if got := read(populated()); got["archives_unavailable"] != nil {
+			t.Errorf("archives_unavailable present on a healthy report: %v", got)
+		}
+	})
+}

--- a/internal/status/coverage_unavailable_integration_test.go
+++ b/internal/status/coverage_unavailable_integration_test.go
@@ -1,0 +1,123 @@
+//go:build integration
+
+package status_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/status"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// #816: LoadCoverage degraded EVERY archive_state failure to live-only
+// coverage with nothing but a slog.Warn. The two causes are not the same
+// fact — "this index has no archive tier" is true and describable, "I could
+// not read the archive tier" is not — and collapsing them makes `status`
+// print a restore window SHORTER than reality. An operator reads it and
+// concludes an old incident is unrecoverable while the Parquet covering it is
+// sitting in the bucket.
+//
+// This goes to a real database because the discrimination is on a driver
+// error code; a fixture would assert the mapping we wrote rather than the one
+// MySQL produces.
+func TestLoadCoverage_DistinguishesUnreadableArchivesFromNone(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	db, _ := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	exec := func(q string) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, q); err != nil {
+			t.Fatalf("exec %q: %v", q, err)
+		}
+	}
+
+	// Healthy: a real archive row extends the window and nothing is flagged.
+	exec(`INSERT INTO archive_state (partition_name, bintrail_id, row_count)
+	      VALUES ('p_2020010203', 'src', 41)`)
+	c, err := status.LoadCoverage(ctx, db)
+	if err != nil {
+		t.Fatalf("LoadCoverage: %v", err)
+	}
+	if c.ArchiveUnavailable {
+		t.Error("a readable archive_state was reported as unavailable")
+	}
+	if c.ArchiveTotalRows != 41 || !c.ArchiveEarliestHour.Valid {
+		t.Errorf("archive coverage not read: rows=%d earliest=%v", c.ArchiveTotalRows, c.ArchiveEarliestHour)
+	}
+
+	// No archive tier at all: the zeros ARE the truth, so no flag. This is
+	// the case the old blanket warn was written for, and it must not regress
+	// into a scary banner on every pre-archive index.
+	exec(`DROP TABLE archive_state`)
+	c, err = status.LoadCoverage(ctx, db)
+	if err != nil {
+		t.Fatalf("LoadCoverage (no table): %v", err)
+	}
+	if c.ArchiveUnavailable {
+		t.Error("an index with no archive_state was flagged unavailable; 'no archive tier' is a fact, not a failure")
+	}
+	if c.ArchiveTotalRows != 0 || c.ArchiveEarliestHour.Valid {
+		t.Errorf("archive fields should be zero with no table: rows=%d earliest=%v", c.ArchiveTotalRows, c.ArchiveEarliestHour)
+	}
+
+	// Present but unreadable — here a legacy shape missing row_count (1054),
+	// which is exactly the "table exists, query fails" class. THE regression:
+	// before #816 this was indistinguishable from the case above.
+	exec(`CREATE TABLE archive_state (
+	        partition_name VARCHAR(64) NOT NULL,
+	        bintrail_id    VARCHAR(64) NOT NULL,
+	        PRIMARY KEY (partition_name, bintrail_id))`)
+	exec(`INSERT INTO archive_state (partition_name, bintrail_id) VALUES ('p_2019010203', 'src')`)
+	c, err = status.LoadCoverage(ctx, db)
+	if err != nil {
+		t.Fatalf("LoadCoverage must stay non-fatal — coverage is a report, not a gate: %v", err)
+	}
+	if !c.ArchiveUnavailable {
+		t.Fatal("an unreadable archive_state was reported as 'no archives'; the restore window silently understates reality")
+	}
+	if c.ArchiveError == "" {
+		t.Error("no reason recorded — an operator cannot act on 'unavailable' alone")
+	}
+
+	// Both renderings must carry it. The text report is what an operator
+	// reads during an incident; the JSON is what a monitor keys on.
+	var buf strings.Builder
+	data := &status.StatusData{Coverage: c}
+	data.Write(&buf)
+	out := buf.String()
+	if !strings.Contains(out, "NOT READ") {
+		t.Errorf("the text report does not say the archives were not read:\n%s", out)
+	}
+	if !strings.Contains(out, "LOWER BOUND") {
+		t.Errorf("the text report does not qualify the restore window:\n%s", out)
+	}
+	if strings.Contains(out, "(includes archives)") {
+		t.Errorf("the text report claims the window includes archives it could not read:\n%s", out)
+	}
+
+	var jbuf strings.Builder
+	if err := data.WriteJSON(&jbuf); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	var parsed struct {
+		Coverage struct {
+			ArchivesUnavailable bool   `json:"archives_unavailable"`
+			ArchivesError       string `json:"archives_error"`
+		} `json:"coverage"`
+	}
+	if err := json.Unmarshal([]byte(jbuf.String()), &parsed); err != nil {
+		t.Fatalf("status JSON: %v\n%s", err, jbuf.String())
+	}
+	if !parsed.Coverage.ArchivesUnavailable || parsed.Coverage.ArchivesError == "" {
+		t.Errorf("the JSON report does not carry the unavailable verdict: %s", jbuf.String())
+	}
+}

--- a/internal/status/coverage_unavailable_integration_test.go
+++ b/internal/status/coverage_unavailable_integration_test.go
@@ -4,8 +4,6 @@ package status_test
 
 import (
 	"context"
-	"encoding/json"
-	"strings"
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -88,36 +86,28 @@ func TestLoadCoverage_DistinguishesUnreadableArchivesFromNone(t *testing.T) {
 		t.Error("no reason recorded — an operator cannot act on 'unavailable' alone")
 	}
 
-	// Both renderings must carry it. The text report is what an operator
-	// reads during an incident; the JSON is what a monitor keys on.
-	var buf strings.Builder
-	data := &status.StatusData{Coverage: c}
-	data.Write(&buf)
-	out := buf.String()
-	if !strings.Contains(out, "NOT READ") {
-		t.Errorf("the text report does not say the archives were not read:\n%s", out)
+	// The RENDERING assertions live in coverage_render_test.go, as a plain
+	// unit test: they are pure functions over *CoverageInfo, and behind
+	// //go:build integration they are skipped in silence on any machine
+	// without MySQL. Only the discrimination below needs a real driver error.
+
+	// A partition name that will not parse is the same class, reached one
+	// step later: the row was read, and the archives still cannot be placed
+	// in time.
+	exec(`DROP TABLE archive_state`)
+	exec(`CREATE TABLE archive_state (
+	        partition_name VARCHAR(64) NOT NULL,
+	        bintrail_id    VARCHAR(64) NOT NULL,
+	        row_count      BIGINT DEFAULT 0,
+	        PRIMARY KEY (partition_name, bintrail_id))`)
+	exec(`INSERT INTO archive_state (partition_name, bintrail_id, row_count)
+	      VALUES ('not-a-partition', 'src', 5)`)
+	c, err = status.LoadCoverage(ctx, db)
+	if err != nil {
+		t.Fatalf("LoadCoverage (unparseable name): %v", err)
 	}
-	if !strings.Contains(out, "LOWER BOUND") {
-		t.Errorf("the text report does not qualify the restore window:\n%s", out)
-	}
-	if strings.Contains(out, "(includes archives)") {
-		t.Errorf("the text report claims the window includes archives it could not read:\n%s", out)
+	if !c.ArchiveUnavailable {
+		t.Error("an unplaceable archive floor was reported as no archives; the restore window silently understates reality")
 	}
 
-	var jbuf strings.Builder
-	if err := data.WriteJSON(&jbuf); err != nil {
-		t.Fatalf("WriteJSON: %v", err)
-	}
-	var parsed struct {
-		Coverage struct {
-			ArchivesUnavailable bool   `json:"archives_unavailable"`
-			ArchivesError       string `json:"archives_error"`
-		} `json:"coverage"`
-	}
-	if err := json.Unmarshal([]byte(jbuf.String()), &parsed); err != nil {
-		t.Fatalf("status JSON: %v\n%s", err, jbuf.String())
-	}
-	if !parsed.Coverage.ArchivesUnavailable || parsed.Coverage.ArchivesError == "" {
-		t.Errorf("the JSON report does not carry the unavailable verdict: %s", jbuf.String())
-	}
 }

--- a/internal/status/staleness.go
+++ b/internal/status/staleness.go
@@ -118,8 +118,9 @@ func OldestLivePartitionHour(parts []PartitionStat) time.Time {
 // OldestDeltaFromDB computes the delta-coverage floor: the live-partition
 // floor extended backwards by contiguous archives. It is the ONLY floor
 // implementation — the CLI, console, and watcher all use it (CoverageInfo's
-// ArchiveEarliestHour is a best-effort DISPLAY figure whose errors are
-// swallowed, which a verdict must never be built on). Error semantics are
+// ArchiveEarliestHour is a best-effort DISPLAY figure that reports a read
+// failure as ArchiveUnavailable rather than returning it, so a verdict must
+// never be built on it). Error semantics are
 // strict in the anti-cry-wolf direction: any failure that could make the
 // floor read LATER than reality — and so fabricate "broken" on healthy
 // archives — is returned (the caller degrades to unknown), never swallowed.

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -202,16 +202,24 @@ type CoverageInfo struct {
 	// Archive-derived fields (from archive_state partition names and row counts).
 	ArchiveEarliestHour sql.NullTime // earliest hour derived from MIN(partition_name)
 	ArchiveTotalRows    int64
-	// ArchiveUnavailable marks archive coverage as UNREAD rather than absent
+	// ArchiveUnavailable marks archive coverage as UNREAD or UNPLACEABLE rather
+	// than absent
 	// (#816). Both states leave the two fields above zero, and reporting them
 	// the same way understates the restore window: an operator reads a
 	// too-recent "Earliest event" and concludes an old incident is beyond
 	// recovery while the Parquet that covers it is sitting in the bucket.
 	//
 	// Only a genuinely missing archive_state (ER_NO_SUCH_TABLE on an index
-	// that never archived) counts as "no archives"; every other failure —
-	// permissions, a transient network error, a corrupt table — is unknown,
-	// and unknown is never rendered as a fact.
+	// that never archived) counts as "no archives"; every other outcome —
+	// a table-level permission denial, a corrupt table, a legacy shape
+	// missing a column, or a partition_name that will not parse — is
+	// unknown, and unknown is never rendered as a fact.
+	//
+	// Note the scope: a dead connection or a query timeout fails the
+	// binlog_events read at the top of LoadCoverage and never reaches here,
+	// so this flag is specific to archive_state. That outer failure drops
+	// the whole coverage section instead, which is its own gap (see the
+	// CoverageErr follow-up).
 	ArchiveUnavailable bool
 	ArchiveError       string
 
@@ -364,9 +372,24 @@ func LoadCoverage(ctx context.Context, db *sql.DB) (*CoverageInfo, error) {
 		return &c, nil
 	}
 	if minPartition.Valid {
-		if t, ok := parsePartitionName(minPartition.String); ok {
-			c.ArchiveEarliestHour = sql.NullTime{Time: t, Valid: true}
+		t, ok := parsePartitionName(minPartition.String)
+		if !ok {
+			// Same class as an unreadable table, reached three lines later:
+			// the archives exist, we read the row, and we still cannot place
+			// them in time — so the floor below is live-only and the window
+			// is a lower bound. Dropping this silently printed a too-recent
+			// "Earliest event" as fact, which is the whole of #816.
+			//
+			// staleness.go's OldestDeltaFromDB hard-errors on the identical
+			// parse of the identical value ("our own naming scheme failing to
+			// parse is drift"). Two readers of one value must not take
+			// opposite stances, and the silent one was the one an operator
+			// reads mid-incident.
+			c.ArchiveUnavailable = true
+			c.ArchiveError = fmt.Sprintf("archive_state MIN(partition_name) %q is not a partition name", minPartition.String)
+			return &c, nil
 		}
+		c.ArchiveEarliestHour = sql.NullTime{Time: t, Valid: true}
 	}
 
 	return &c, nil

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -202,6 +202,18 @@ type CoverageInfo struct {
 	// Archive-derived fields (from archive_state partition names and row counts).
 	ArchiveEarliestHour sql.NullTime // earliest hour derived from MIN(partition_name)
 	ArchiveTotalRows    int64
+	// ArchiveUnavailable marks archive coverage as UNREAD rather than absent
+	// (#816). Both states leave the two fields above zero, and reporting them
+	// the same way understates the restore window: an operator reads a
+	// too-recent "Earliest event" and concludes an old incident is beyond
+	// recovery while the Parquet that covers it is sitting in the bucket.
+	//
+	// Only a genuinely missing archive_state (ER_NO_SUCH_TABLE on an index
+	// that never archived) counts as "no archives"; every other failure —
+	// permissions, a transient network error, a corrupt table — is unknown,
+	// and unknown is never rendered as a fact.
+	ArchiveUnavailable bool
+	ArchiveError       string
 
 	// IndexSizeBytes is the on-disk size of the binlog_events table
 	// (DATA_LENGTH + INDEX_LENGTH, an InnoDB estimate). Surfaced so an operator
@@ -336,8 +348,19 @@ func LoadCoverage(ctx context.Context, db *sql.DB) (*CoverageInfo, error) {
 		SELECT MIN(partition_name), COALESCE(SUM(row_count), 0)
 		FROM archive_state`).Scan(&minPartition, &c.ArchiveTotalRows)
 	if err != nil {
-		// archive_state may not exist in older indexes — treat as non-fatal.
-		slog.Warn("could not load archive coverage", "error", err)
+		// Non-fatal either way — coverage is a report, not a gate — but the
+		// two causes are NOT the same fact (#816). A missing table is an
+		// index with no archive tier, which the zeroed fields describe
+		// correctly. Anything else means the archives may exist and we could
+		// not see them, so the report must say the window it prints is a
+		// LOWER BOUND rather than quietly printing the live-only one.
+		if isMissingTableErr(err) {
+			slog.Debug("archive_state not present; reporting live-only coverage", "error", err)
+			return &c, nil
+		}
+		slog.Warn("could not load archive coverage; the restore window will be reported as a lower bound", "error", err)
+		c.ArchiveUnavailable = true
+		c.ArchiveError = err.Error()
 		return &c, nil
 	}
 	if minPartition.Valid {
@@ -912,10 +935,16 @@ func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, arch
 		}
 		if earliest.Valid {
 			label := earliest.Time.Format(TSFmt)
-			if hasArchive {
+			switch {
+			case coverage.ArchiveUnavailable:
+				// Never "(includes archives)" here: we could not read them.
+				label += " (LIVE INDEX ONLY — archives not read, see below)"
+			case hasArchive:
 				label += " (includes archives)"
 			}
 			fmt.Fprintf(w, "  Earliest event: %s\n", label)
+		} else if coverage.ArchiveUnavailable {
+			fmt.Fprintln(w, "  Earliest event: (none live; archives not read, see below)")
 		} else {
 			fmt.Fprintln(w, "  Earliest event: (none)")
 		}
@@ -934,6 +963,16 @@ func WriteStatus(w io.Writer, files []IndexStateRow, parts []PartitionStat, arch
 		}
 		if coverage.IndexSizeBytes > 0 {
 			fmt.Fprintf(w, "  Index size:     %s (MySQL binlog_events)\n", formatBytes(coverage.IndexSizeBytes))
+		}
+		if coverage.ArchiveUnavailable {
+			fmt.Fprintln(w, "  Archives:       ⚠ NOT READ — archive_state could not be queried, so any")
+			fmt.Fprintln(w, "                  archived hours are missing from the figures above. The")
+			fmt.Fprintln(w, "                  restore window is a LOWER BOUND, not the real reach:")
+			fmt.Fprintln(w, "                  data older than the earliest event shown may still be")
+			fmt.Fprintln(w, "                  recoverable from Parquet.")
+			for _, line := range wrapAt("Error: "+coverage.ArchiveError, 60) {
+				fmt.Fprintf(w, "                  %s\n", line)
+			}
 		}
 		fmt.Fprintf(w, "  Schema changes: %d\n", coverage.SchemaChanges)
 		if coverage.UncoveredDDLs > 0 {
@@ -1155,6 +1194,14 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		IndexSizeHuman       string  `json:"index_size_human,omitempty"`
 		SchemaChanges        int     `json:"schema_changes"`
 		UncoveredDDLs        int     `json:"uncovered_ddls"`
+		// ArchivesUnavailable says the archive tier could NOT be read (#816),
+		// so every figure above is live-index-only and earliest_event is a
+		// LOWER BOUND on the restore reach rather than the reach itself.
+		// Absent (omitted) means the figures are complete: an index with no
+		// archives at all reports zeros without this flag, because "no
+		// archive tier" is a fact and "could not look" is not.
+		ArchivesUnavailable bool   `json:"archives_unavailable,omitempty"`
+		ArchivesError       string `json:"archives_error,omitempty"`
 	}
 	type jsonServer struct {
 		BintrailID       string  `json:"bintrail_id"`
@@ -1455,6 +1502,11 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 			IndexSizeBytes: coverage.IndexSizeBytes,
 			SchemaChanges:  coverage.SchemaChanges,
 			UncoveredDDLs:  coverage.UncoveredDDLs,
+			// #816: the figures above are live-only and a LOWER BOUND when
+			// this is set. A monitor that treats earliest_event as the
+			// recovery horizon must be able to tell the difference.
+			ArchivesUnavailable: coverage.ArchiveUnavailable,
+			ArchivesError:       coverage.ArchiveError,
 		}
 		if coverage.IndexSizeBytes > 0 {
 			jc.IndexSizeHuman = formatBytes(coverage.IndexSizeBytes)


### PR DESCRIPTION
Closes #816.

`LoadCoverage` caught every `archive_state` failure with one blanket `slog.Warn` and returned live-only coverage, so two different facts rendered identically:

| state | what the report showed |
|---|---|
| this index has no archive tier | zeros — **correct** |
| the archive tier could not be read | zeros — **not a fact about coverage at all** |

The second printing as the first means `status` reports a restore window **shorter than reality**. It fails in the safe direction for *data* — it never invents coverage — but not for *decisions*: an operator reads a too-recent `Earliest event` and concludes an old incident is beyond recovery while the Parquet covering it is sitting in the bucket. That is the whole question `status` is being run to answer during an incident.

## Change

Only `ER_NO_SUCH_TABLE` counts as "no archive tier". Every other cause — permissions, a transient error, a legacy table missing a column — sets `CoverageInfo.ArchiveUnavailable` with the reason, and both renderings carry it:

- **Text**: an `Archives: ⚠ NOT READ` block stating the window is a **lower bound** and that older data may still be recoverable, with the error wrapped underneath.
- **JSON**: `coverage.archives_unavailable` + `coverage.archives_error`, both `omitempty`, so an index with no archives at all is unchanged on the wire.

The `(includes archives)` label is withheld in that state rather than claiming coverage that was never read.

It stays **non-fatal**: coverage is a report, not a gate, and failing `status` outright would take away the live-index picture the operator ran it for.

## Testing

Integration test against real MySQL, because the discrimination is on a driver error code — a fixture would assert the mapping we wrote rather than the one MySQL produces. It walks all three states in one index: healthy (window extended, no flag), table dropped (zeros, **no** flag — the pre-archive index must not start crying wolf), and present-but-unreadable (flag + reason + both renderings).

Mutation-checked: restoring the blanket warn, flipping the missing-table branch so every pre-archive index alarms, and dropping the text banner each break the test.
