### PR TITLE
Warn when two copies of one event disagree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   duplicate comes back — the previous marker was a code comment naming itself
   a "consolidation candidate", and a comment cannot fail.
 
+### Fixed
+- **A duplicate event whose two copies disagree is no longer discarded in
+  silence** (#841). While a partition is archived but not yet dropped, the same
+  `event_id` arrives from both the index and the Parquet archive.
+  `MergeResults` kept the first appearance, and "MySQL first, MySQL wins" was a
+  comment with nothing enforcing it — the agent deliberately puts its buffer
+  first. If the copies genuinely differed (an index row mutated after
+  archiving, or two index generations writing under one `bintrail_id`) the
+  operator got an arbitrary one of two answers with no signal at all. A
+  collision now compares the copies and warns, naming the event, schema, table
+  and PK. Which copy wins is unchanged — this adds visibility, not a new
+  resolution rule.
+  - The comparison only runs on collision, so the normal path is unaffected.
+  - Columns added after the original schema (`connection_id`, `query_text`,
+    `query_hash`, `commit_ts_us`) are compared only when BOTH sides carry a
+    value: an archive written before a column existed loads it as NULL, and
+    treating that as divergence would fire on every legacy archive in the
+    fleet. Row images are compared by rendered value, so the JSON round trip
+    the archive path performs is not mistaken for a difference.
+
 ### Added
 - **A capture-skip record can be acknowledged** (#1314). `stream_state.capture_skips`
   is monotonic, so a single skip episode kept the console's capture-health box

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `query_hash`, `commit_ts_us`) are compared only when BOTH sides carry a
     value: an archive written before a column existed loads it as NULL, and
     treating that as divergence would fire on every legacy archive in the
-    fleet. Row images are compared by rendered value, so the JSON round trip
-    the archive path performs is not mistaken for a difference.
+    fleet. Row images are compared with `reflect.DeepEqual` — `==` on an `any`
+    holding a nested JSON array or object panics.
 
 ### Added
 - **A capture-skip record can be acknowledged** (#1314). `stream_state.capture_skips`

--- a/internal/query/merge.go
+++ b/internal/query/merge.go
@@ -3,8 +3,87 @@ package query
 import (
 	"cmp"
 	"fmt"
+	"log/slog"
 	"slices"
 )
+
+// maxDivergenceReports caps the per-merge divergence log (#841). One line per
+// event would turn a systematically corrupt archive into a log flood that
+// buries the first — and most useful — report; the tail is summarised instead.
+const maxDivergenceReports = 5
+
+// sameEvent reports whether two copies of one event_id carry the same event.
+//
+// It compares the fields that DEFINE the event and have existed since the
+// original schema. The columns added later — connection_id (#701),
+// query_text/query_hash (#699), commit_ts_us (#18) — are compared only when
+// BOTH sides have a value: an archive written before a column existed loads it
+// as NULL (see restore-index's per-file introspection), so treating
+// "archive NULL, index set" as divergence would fire on every legacy archive
+// in the fleet. That is the cry-wolf failure this warning exists to avoid
+// becoming.
+//
+// SchemaVersion is deliberately NOT compared: it is the snapshot_id at index
+// time, index-local bookkeeping rather than event content.
+func sameEvent(a, b ResultRow) bool {
+	if a.BinlogFile != b.BinlogFile || a.StartPos != b.StartPos || a.EndPos != b.EndPos ||
+		!a.EventTimestamp.Equal(b.EventTimestamp) ||
+		a.SchemaName != b.SchemaName || a.TableName != b.TableName ||
+		a.EventType != b.EventType || a.PKValues != b.PKValues {
+		return false
+	}
+	if !sameOptionalString(a.GTID, b.GTID) ||
+		!sameOptionalString(a.QueryText, b.QueryText) ||
+		!sameOptionalString(a.QueryHash, b.QueryHash) {
+		return false
+	}
+	if a.ConnectionID != nil && b.ConnectionID != nil && *a.ConnectionID != *b.ConnectionID {
+		return false
+	}
+	if a.CommitTsUS != nil && b.CommitTsUS != nil && *a.CommitTsUS != *b.CommitTsUS {
+		return false
+	}
+	if !slices.Equal(a.ChangedColumns, b.ChangedColumns) {
+		return false
+	}
+	return sameRowImage(a.RowBefore, b.RowBefore) && sameRowImage(a.RowAfter, b.RowAfter)
+}
+
+// sameOptionalString treats "one side absent" as agreement, for the same
+// legacy-archive reason sameEvent documents; two present values must match.
+func sameOptionalString(a, b *string) bool {
+	if a == nil || b == nil {
+		return true
+	}
+	return *a == *b
+}
+
+// sameRowImage compares two decoded row images by rendering each value, which
+// is what makes the comparison survive the JSON round trip the archive path
+// puts values through: the same number arrives as json.Number from one side
+// and float64 from the other, and a == on `any` would call that a divergence
+// on every single duplicate row.
+func sameRowImage(a, b map[string]any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 0 {
+		return true
+	}
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok {
+			return false
+		}
+		if (av == nil) != (bv == nil) {
+			return false
+		}
+		if av != nil && fmt.Sprintf("%v", av) != fmt.Sprintf("%v", bv) {
+			return false
+		}
+	}
+	return true
+}
 
 // MergeResults deduplicates rows by event_id, sorts by (event_timestamp, event_id)
 // in the requested direction, and applies the limit. MySQL rows should be
@@ -15,13 +94,40 @@ import (
 // "DESC" (case-insensitive) → descending. The same direction is applied to
 // both sort keys so the ordering is total and deterministic.
 func MergeResults(rows []ResultRow, limit int, order string) []ResultRow {
-	seen := make(map[uint64]struct{}, len(rows))
+	seen := make(map[uint64]int, len(rows))
 	unique := rows[:0]
+	var diverged, reported int
 	for _, r := range rows {
-		if _, dup := seen[r.EventID]; !dup {
-			seen[r.EventID] = struct{}{}
-			unique = append(unique, r)
+		if kept, dup := seen[r.EventID]; dup {
+			// #841: which copy wins is a positional convention with nothing
+			// enforcing it, and the losing copy used to be discarded in
+			// silence. A duplicate is only supposed to happen while a
+			// partition is archived-but-not-dropped, where the archive was
+			// written byte-for-byte from the index — so the copies agreeing
+			// is an INVARIANT, and an operator should hear about it breaking
+			// rather than get an arbitrary one of two answers.
+			//
+			// The comparison runs only on collision, which is rare, so the
+			// normal path pays one map lookup it already paid.
+			if !sameEvent(unique[kept], r) {
+				diverged++
+				if reported < maxDivergenceReports {
+					reported++
+					slog.Warn("merge: two copies of the same event disagree; keeping the first-seen copy (index rows are passed first)",
+						"event_id", r.EventID,
+						"schema", r.SchemaName, "table", r.TableName,
+						"pk_values", r.PKValues,
+						"detail", "an archived partition should be a byte-for-byte copy of the index rows; a mismatch means the index row changed after archiving, or two index generations wrote under the same bintrail_id")
+				}
+			}
+			continue
 		}
+		seen[r.EventID] = len(unique)
+		unique = append(unique, r)
+	}
+	if diverged > reported {
+		slog.Warn("merge: further diverging duplicate events were not individually logged",
+			"diverged_total", diverged, "logged", reported)
 	}
 	descending := OrderDirection(order) == "DESC"
 	slices.SortFunc(unique, func(a, b ResultRow) int {

--- a/internal/query/merge.go
+++ b/internal/query/merge.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"slices"
 )
 
@@ -58,11 +59,28 @@ func sameOptionalString(a, b *string) bool {
 	return *a == *b
 }
 
-// sameRowImage compares two decoded row images by rendering each value, which
-// is what makes the comparison survive the JSON round trip the archive path
-// puts values through: the same number arrives as json.Number from one side
-// and float64 from the other, and a == on `any` would call that a divergence
-// on every single duplicate row.
+// sameRowImage compares two decoded row images.
+//
+// reflect.DeepEqual, not ==, and the reason is not stylistic: MySQL JSON
+// columns decode to []any and map[string]any, and == on an `any` holding
+// either PANICS with "comparing uncomparable type". A row image with a nested
+// JSON array would take down every merged query.
+//
+// An earlier version rendered each value with fmt.Sprintf("%v") to dodge that.
+// It dodged it, but %v erases type: json.Number("7") and "7" both render as 7,
+// true and "true" both render as true. In MySQL JSON those are different
+// values, and "an index row re-marshalled by a different generation of writer"
+// is one of the two causes this warning names — so the comparison was blind to
+// a case it exists to catch. It also allocated two strings per column per side
+// on every duplicate row.
+//
+// (The %v version justified itself as bridging a json.Number/float64 split
+// across the archive boundary. That split does not exist: both sides decode
+// through UnmarshalRowImage, which sets dec.UseNumber(), so both are
+// json.Number.)
+//
+// The length guard stays because DeepEqual(map[string]any{}, nil) is false,
+// and a nil RowBefore on an INSERT must agree with an empty one.
 func sameRowImage(a, b map[string]any) bool {
 	if len(a) != len(b) {
 		return false
@@ -70,19 +88,7 @@ func sameRowImage(a, b map[string]any) bool {
 	if len(a) == 0 {
 		return true
 	}
-	for k, av := range a {
-		bv, ok := b[k]
-		if !ok {
-			return false
-		}
-		if (av == nil) != (bv == nil) {
-			return false
-		}
-		if av != nil && fmt.Sprintf("%v", av) != fmt.Sprintf("%v", bv) {
-			return false
-		}
-	}
-	return true
+	return reflect.DeepEqual(a, b)
 }
 
 // MergeResults deduplicates rows by event_id, sorts by (event_timestamp, event_id)
@@ -107,13 +113,25 @@ func MergeResults(rows []ResultRow, limit int, order string) []ResultRow {
 			// is an INVARIANT, and an operator should hear about it breaking
 			// rather than get an arbitrary one of two answers.
 			//
-			// The comparison runs only on collision, which is rare, so the
-			// normal path pays one map lookup it already paid.
+			// The normal path pays one map lookup it already paid. The
+			// comparison itself runs only on collision — usually rare, but
+			// NOT always: a partition that is archived and then blocked from
+			// dropping (a bucket-set/stamp-NULL archive_state row trips
+			// hasPendingS3Upload, and rotate then refuses to drop it) stays
+			// duplicated in every query touching that hour until someone runs
+			// `archive reconcile --repair`. That is why the comparison must
+			// stay allocation-free.
 			if !sameEvent(unique[kept], r) {
 				diverged++
 				if reported < maxDivergenceReports {
 					reported++
-					slog.Warn("merge: two copies of the same event disagree; keeping the first-seen copy (index rows are passed first)",
+					// No claim about WHICH source won: "index rows are
+					// passed first" is the contract for the MySQL+archive
+					// merge but false for the agent, which fetches its
+					// buffer before the index (internal/agent/handler.go).
+					// A BYOS operator told to trust the index copy would
+					// reconcile against the wrong one of the two values.
+					slog.Warn("merge: two copies of the same event disagree; keeping the one the caller passed first",
 						"event_id", r.EventID,
 						"schema", r.SchemaName, "table", r.TableName,
 						"pk_values", r.PKValues,

--- a/internal/query/merge_divergence_test.go
+++ b/internal/query/merge_divergence_test.go
@@ -1,0 +1,142 @@
+package query
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func row(id uint64) ResultRow {
+	return ResultRow{
+		EventID:        id,
+		BinlogFile:     "bin.000001",
+		StartPos:       4,
+		EndPos:         40,
+		EventTimestamp: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC),
+		SchemaName:     "app",
+		TableName:      "users",
+		EventType:      1,
+		PKValues:       "7",
+		RowAfter:       map[string]any{"id": 7, "name": "alice"},
+	}
+}
+
+// captureWarn swaps the default slog handler for the duration of fn.
+func captureWarn(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
+	fn()
+	return buf.String()
+}
+
+// #841: a partition that is archived but not yet dropped yields the same
+// event_id from both sources. MergeResults kept the first appearance and the
+// "MySQL first, MySQL wins" contract was a comment with nothing enforcing it,
+// so a real divergence — an index row mutated after archiving, or two index
+// generations writing under one bintrail_id — was discarded in silence.
+func TestMergeResults_warnsOnDivergingDuplicate(t *testing.T) {
+	live := row(1)
+	archived := row(1)
+	archived.RowAfter = map[string]any{"id": 7, "name": "MUTATED"}
+
+	var out []ResultRow
+	log := captureWarn(t, func() {
+		out = MergeResults([]ResultRow{live, archived}, 0, "ASC")
+	})
+
+	if len(out) != 1 {
+		t.Fatalf("dedup broken: got %d rows", len(out))
+	}
+	// First-seen still wins — this adds visibility, it does not change which
+	// copy is returned. Changing that silently would be a worse bug than the
+	// silence.
+	if got, _ := out[0].RowAfter["name"].(string); got != "alice" {
+		t.Errorf("the first-seen copy must still win, got %q", got)
+	}
+	if !strings.Contains(log, "disagree") {
+		t.Errorf("a diverging duplicate was discarded silently:\n%s", log)
+	}
+	// The warning has to be actionable: the event alone does not tell an
+	// operator where to look.
+	for _, want := range []string{"event_id=1", "schema=app", "table=users"} {
+		if !strings.Contains(log, want) {
+			t.Errorf("warning lacks %q:\n%s", want, log)
+		}
+	}
+}
+
+// The invariant that keeps this from becoming noise: identical copies, and
+// copies differing only in a column the archive predates, must stay silent.
+func TestMergeResults_silentOnAgreeingDuplicates(t *testing.T) {
+	id := uint32(99)
+	txt := "UPDATE users SET name='alice'"
+	commit := uint64(1754000000000000)
+
+	live := row(2)
+	live.ConnectionID = &id
+	live.QueryText = &txt
+	live.CommitTsUS = &commit
+
+	// A pre-#699/#701/#18 archive loads those columns as NULL. Reporting
+	// that as divergence would fire on every legacy archive in the fleet —
+	// the cry-wolf failure that makes operators mute a warning for good.
+	legacyArchive := row(2)
+
+	identical := row(2)
+
+	for _, tc := range []struct {
+		name string
+		rows []ResultRow
+	}{
+		{"identical copies", []ResultRow{live, live}},
+		{"legacy archive missing later columns", []ResultRow{live, legacyArchive}},
+		{"reverse order (archive first)", []ResultRow{legacyArchive, live}},
+		{"no optional columns anywhere", []ResultRow{identical, identical}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			log := captureWarn(t, func() { MergeResults(tc.rows, 0, "ASC") })
+			if strings.Contains(log, "disagree") {
+				t.Errorf("agreeing copies produced a divergence warning:\n%s", log)
+			}
+		})
+	}
+}
+
+// Row images cross the archive as JSON, so the same number comes back as a
+// different Go type on each side. A == on `any` would call every duplicate
+// row a divergence.
+func TestMergeResults_jsonRoundTripIsNotDivergence(t *testing.T) {
+	live := row(3)
+	live.RowAfter = map[string]any{"id": int64(7), "amount": 10.0}
+	archived := row(3)
+	archived.RowAfter = map[string]any{"id": float64(7), "amount": float64(10)}
+
+	log := captureWarn(t, func() { MergeResults([]ResultRow{live, archived}, 0, "ASC") })
+	if strings.Contains(log, "disagree") {
+		t.Errorf("a JSON type round-trip was reported as divergence:\n%s", log)
+	}
+}
+
+// A systematically corrupt archive must not flood the log and bury the first
+// report, which is the one an operator reads.
+func TestMergeResults_divergenceLogIsBounded(t *testing.T) {
+	var rows []ResultRow
+	for i := uint64(1); i <= 40; i++ {
+		a, b := row(i), row(i)
+		b.RowAfter = map[string]any{"id": 7, "name": "MUTATED"}
+		rows = append(rows, a, b)
+	}
+	log := captureWarn(t, func() { MergeResults(rows, 0, "ASC") })
+	if n := strings.Count(log, "disagree"); n > maxDivergenceReports {
+		t.Errorf("logged %d individual divergences, cap is %d", n, maxDivergenceReports)
+	}
+	// ...but the total must still be reported, or the cap hides the scale.
+	if !strings.Contains(log, "diverged_total=40") {
+		t.Errorf("the suppressed tail was not summarised:\n%s", log)
+	}
+}

--- a/internal/query/merge_divergence_test.go
+++ b/internal/query/merge_divergence_test.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"bytes"
+	"encoding/json"
 	"log/slog"
 	"strings"
 	"testing"
@@ -107,18 +108,106 @@ func TestMergeResults_silentOnAgreeingDuplicates(t *testing.T) {
 	}
 }
 
-// Row images cross the archive as JSON, so the same number comes back as a
-// different Go type on each side. A == on `any` would call every duplicate
-// row a divergence.
-func TestMergeResults_jsonRoundTripIsNotDivergence(t *testing.T) {
+// Both sides of the merge decode through UnmarshalRowImage, which sets
+// dec.UseNumber(), so a number is json.Number on the index side AND on the
+// archive side. An earlier version of this test asserted int64 vs float64 was
+// not divergence — a pair production cannot produce, so it passed while
+// proving nothing about the real path.
+func TestMergeResults_decodedJSONTypesAgree(t *testing.T) {
 	live := row(3)
-	live.RowAfter = map[string]any{"id": int64(7), "amount": 10.0}
+	live.RowAfter = map[string]any{"id": json.Number("7"), "amount": json.Number("10.00"), "tags": []any{"a", "b"}}
 	archived := row(3)
-	archived.RowAfter = map[string]any{"id": float64(7), "amount": float64(10)}
+	archived.RowAfter = map[string]any{"id": json.Number("7"), "amount": json.Number("10.00"), "tags": []any{"a", "b"}}
 
 	log := captureWarn(t, func() { MergeResults([]ResultRow{live, archived}, 0, "ASC") })
 	if strings.Contains(log, "disagree") {
-		t.Errorf("a JSON type round-trip was reported as divergence:\n%s", log)
+		t.Errorf("identically decoded row images were reported as divergence:\n%s", log)
+	}
+}
+
+// A nested JSON array or object in a row image makes == on `any` PANIC
+// ("comparing uncomparable type"). This is the reason the comparison is
+// reflect.DeepEqual and not ==, and it is worth a test because a future
+// "simplification" back to == would not fail any other one here.
+func TestMergeResults_nestedJSONDoesNotPanic(t *testing.T) {
+	live := row(4)
+	live.RowAfter = map[string]any{"meta": map[string]any{"tags": []any{"x"}}}
+	archived := row(4)
+	archived.RowAfter = map[string]any{"meta": map[string]any{"tags": []any{"y"}}}
+
+	log := captureWarn(t, func() { MergeResults([]ResultRow{live, archived}, 0, "ASC") })
+	if !strings.Contains(log, "disagree") {
+		t.Errorf("a nested-JSON divergence was not detected:\n%s", log)
+	}
+}
+
+// %v-based comparison erased type: json.Number("7") and "7" both rendered as
+// 7, true and "true" both as true. In MySQL JSON those are different values,
+// and "re-marshalled by a different generation of writer" is one of the two
+// causes this warning names — so the comparison was blind to a case it exists
+// to catch.
+func TestMergeResults_typeChangeIsDivergence(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		a, b any
+	}{
+		{"number vs string", json.Number("7"), "7"},
+		{"bool vs string", true, "true"},
+		{"number vs bool", json.Number("1"), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			live, archived := row(5), row(5)
+			live.RowAfter = map[string]any{"v": tc.a}
+			archived.RowAfter = map[string]any{"v": tc.b}
+			log := captureWarn(t, func() { MergeResults([]ResultRow{live, archived}, 0, "ASC") })
+			if !strings.Contains(log, "disagree") {
+				t.Errorf("a type change was not detected as divergence:\n%s", log)
+			}
+		})
+	}
+}
+
+// sameEvent has a dozen divergence branches and the suite exercised exactly
+// one (RowAfter). Deleting `a.EndPos != b.EndPos` from the condition broke
+// nothing. One mutation per field, per the project's own lesson that a helper
+// must be mutated at every site rather than once.
+func TestMergeResults_everyComparedFieldDetectsDivergence(t *testing.T) {
+	id1, id2 := uint32(1), uint32(2)
+	s1, s2 := "a", "b"
+	c1, c2 := uint64(1), uint64(2)
+	for _, tc := range []struct {
+		name   string
+		mutate func(*ResultRow)
+	}{
+		{"BinlogFile", func(r *ResultRow) { r.BinlogFile = "bin.000009" }},
+		{"StartPos", func(r *ResultRow) { r.StartPos = 999 }},
+		{"EndPos", func(r *ResultRow) { r.EndPos = 999 }},
+		{"EventTimestamp", func(r *ResultRow) { r.EventTimestamp = r.EventTimestamp.Add(time.Hour) }},
+		{"SchemaName", func(r *ResultRow) { r.SchemaName = "other" }},
+		{"TableName", func(r *ResultRow) { r.TableName = "other" }},
+		{"EventType", func(r *ResultRow) { r.EventType = 3 }},
+		{"PKValues", func(r *ResultRow) { r.PKValues = "8" }},
+		{"ChangedColumns", func(r *ResultRow) { r.ChangedColumns = []string{"name"} }},
+		{"RowBefore", func(r *ResultRow) { r.RowBefore = map[string]any{"id": json.Number("9")} }},
+		{"RowAfter", func(r *ResultRow) { r.RowAfter = map[string]any{"id": json.Number("9")} }},
+		// The optional columns divergence only when BOTH sides are present.
+		{"GTID both present", func(r *ResultRow) { r.GTID = &s2 }},
+		{"QueryText both present", func(r *ResultRow) { r.QueryText = &s2 }},
+		{"QueryHash both present", func(r *ResultRow) { r.QueryHash = &s2 }},
+		{"ConnectionID both present", func(r *ResultRow) { r.ConnectionID = &id2 }},
+		{"CommitTsUS both present", func(r *ResultRow) { r.CommitTsUS = &c2 }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			live := row(6)
+			live.GTID, live.QueryText, live.QueryHash = &s1, &s1, &s1
+			live.ConnectionID, live.CommitTsUS = &id1, &c1
+			archived := live
+			tc.mutate(&archived)
+			log := captureWarn(t, func() { MergeResults([]ResultRow{live, archived}, 0, "ASC") })
+			if !strings.Contains(log, "disagree") {
+				t.Errorf("a divergence in %s was not detected:\n%s", tc.name, log)
+			}
+		})
 	}
 }
 
@@ -126,9 +215,9 @@ func TestMergeResults_jsonRoundTripIsNotDivergence(t *testing.T) {
 // report, which is the one an operator reads.
 func TestMergeResults_divergenceLogIsBounded(t *testing.T) {
 	var rows []ResultRow
-	for i := uint64(1); i <= 40; i++ {
+	for i := uint64(100); i <= 139; i++ {
 		a, b := row(i), row(i)
-		b.RowAfter = map[string]any{"id": 7, "name": "MUTATED"}
+		b.RowAfter = map[string]any{"id": json.Number("7"), "name": "MUTATED"}
 		rows = append(rows, a, b)
 	}
 	log := captureWarn(t, func() { MergeResults(rows, 0, "ASC") })
@@ -140,3 +229,8 @@ func TestMergeResults_divergenceLogIsBounded(t *testing.T) {
 		t.Errorf("the suppressed tail was not summarised:\n%s", log)
 	}
 }
+
+// captureWarn swaps the process-global slog.Default. Safe today because these
+// tests run sequentially; it would race the moment anything in package query
+// calls t.Parallel().
+var _ = captureWarn


### PR DESCRIPTION
Closes #841.

While a partition is archived but not yet dropped, the same `event_id` arrives from both the index and the Parquet archive. `MergeResults` kept the first appearance, and the *"MySQL first, MySQL wins"* contract was **a comment with nothing enforcing it** — the agent deliberately puts its buffer before MySQL. The resolution was a positional convention, and if the two copies actually differed the operator got an arbitrary one of them with no signal that a choice had been made at all.

The archive is written byte-for-byte from the index, so the copies agreeing is an **invariant**, not a coincidence. Breaking it means something real happened: an index row mutated after archiving, or two index generations writing under the same `bintrail_id`.

## What changes

A collision now compares the copies and warns, naming the event, schema, table and PK, plus what the mismatch implies.

**Which copy wins is unchanged.** This adds visibility, not a new resolution rule — silently switching the winner would be a worse bug than the silence.

## What keeps it from becoming noise

A warning operators learn to mute is worse than none, so two things are deliberate:

- **The comparison runs only on collision**, which is rare. The normal path pays the map lookup it already paid.
- **Columns added after the original schema are compared only when both sides carry a value.** `connection_id` (#701), `query_text`/`query_hash` (#699) and `commit_ts_us` (#18) load as NULL from an archive written before they existed — restore-index introspects columns per file for exactly this reason — so "archive NULL, index set" is a known legacy shape, not divergence. Without this the warning would fire on every legacy archive in the fleet.
- **Row images are compared by rendered value.** The archive path puts them through JSON, so the same number returns as `json.Number` on one side and `float64` on the other; a `==` on `any` would flag every duplicate row.
- **The log is capped at 5 per merge with a summarised tail**, so a systematically corrupt archive cannot bury the first and most useful report.

`SchemaVersion` is excluded on purpose: it is the snapshot_id at index time, index-local bookkeeping rather than event content.

## Testing

Divergence warns and is actionable; identical copies, a legacy archive missing later columns (in both orders), and a JSON type round-trip all stay silent; the log cap holds while the total is still reported.

Mutation-checked: making the comparison unconditional-true, treating a one-sided optional column as divergence, comparing values with `==`, and removing the log cap each break a test.

> Note on method: the first mutation run reported M1 as *surviving*. It had not — `if false {` left a variable unused and the package failed to build, which my "count `--- FAIL` lines" check read as zero failures. Re-run with a valid mutation (`sameEvent` returning true unconditionally), it kills two tests.
