### PR TITLE
docs(pg): record attribution as a settled decision, not a pending gap

### DIFF
--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -740,8 +740,14 @@ coerce, but verify your own round-trip.
   are captured as ordinary row changes — see
   [Querying and recovering](#querying-and-recovering).)
 - **No connection attribution.** `pgoutput` does not carry the backend PID, so
-  the `connection_id` column is empty for PostgreSQL sources — nothing upstream
-  can add it.
+  the `connection_id` column is empty for PostgreSQL sources. Forensic
+  attribution ("which session made this change") is therefore a MySQL-only
+  capability today, and this is a **settled decision, not a pending gap**
+  ([#1212](https://github.com/dbtrail/dbtrail/issues/1212)): the only way to
+  recover the backend PID is to install something into your database, and
+  bintrail installs nothing into a source. Everything else forensics offers —
+  the full before/after row images, the change timeline, `--query-hash`
+  grouping where the source logs statements — works identically on PostgreSQL.
 - **One database per slot.** A logical slot is scoped to a single database; to
   capture multiple databases on one cluster, run one `bintrail-pg stream` (and
   slot/publication) per database.


### PR DESCRIPTION
Closes #1212 with **stance 1: document the gap.**

The issue asked for a call between documenting the PostgreSQL attribution gap and building an opt-in, self-hosted-only event-trigger helper pack to close it. The decision is to document it, and the point of this PR is to write it down so it is not re-litigated.

The line already in `docs/postgres.md` said the `connection_id` gap is something *"nothing upstream can add"*. That is stronger than the truth and it hides the reasoning — something **could** add it. An operator-installed event-trigger pack (SQL/PLpgSQL, never a C extension) is precisely the one server-side tier the ratified capture red line permits. We are declining to build it, and the reason is the promise SUPPORT.md already makes to every customer:

> We install nothing in your source database.

Framed as a protocol limitation, the question gets reopened by anyone who reads `pgoutput`'s docs and notices the PID is obtainable another way. Framed as a decision, with the reason and the issue reference attached, it is answered once.

The line now also says what PostgreSQL forensics **does** do. "No connection attribution" on its own reads like forensics is unavailable on PG, when the full before/after row images, the change timeline and `--query-hash` grouping all work identically — only "which session did this" is MySQL-only.

Docs only; no code change.
