### PR TITLE
Say when a console read excludes the archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     source's rows for it. `archive_state.bintrail_id` records who archived a
     partition, not whose rows are inside — scoping by data ownership would
     report gaps over data that is present.
+- **A console session with an RBAC data profile now says it reads the live
+  index only** (#1311). Such a session is served with `NoArchive` because the
+  Parquet path cannot apply per-column redaction — the right call, and it fails
+  in the safe direction — but the response never said so. Hours rotated into
+  archive storage still exist; the session simply does not open them, and a
+  short or empty result reads as "nothing happened in that window", which is
+  the one conclusion the data does not support. `/api/events` and
+  `/api/recover` now carry a warning that states the scope and denies that
+  inference in words.
+  - The warning does **not** depend on the query planner. The planner only runs
+    with a time range, so the default browse — newest N events — produced no
+    plan and therefore no warning at all, which was the worst case.
+  - Gap hours under an archive-excluded read are no longer explained as
+    "rotated and not archived". The planner classifies archived-only hours as
+    gaps for such a read by design; naming rotation as the cause sends the
+    operator to audit a rotation that is working. The hours are still named,
+    with the cause left open.
+  - A console started with `--no-archive` announces itself only once the plan
+    actually finds hours it could not read, so a whole-deployment setting does
+    not become a permanent banner on every response — which is read by nobody,
+    including on the day it matters.
 - **`status` no longer reports an unreadable archive tier as no archive tier**
   (#816). `LoadCoverage` degraded every `archive_state` failure to live-only
   coverage behind a `slog.Warn`, so "this index has no archives" and "I could

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `"degraded"`: the events really are still missing, and a consumer keying on
     the verdict must not read a human's "seen it" as the loss being undone.
 
+- **A capture-skip record can be acknowledged** (#1314). `stream_state.capture_skips`
+  is monotonic, so a single skip episode kept the console's capture-health box
+  on screen and `status --fail-on-gap` exiting non-zero forever. The only escape
+  the product documented — stop the daemon and clear the column — is impossible
+  from the console and *destroys the loss record*, which is the one thing that
+  should survive. An alert nobody can clear is an alert everybody removes, and
+  the next real loss then lands in silence.
+  - `bintrail status --ack-capture-skips` and the console's **Mark as read**
+    button (`POST /api/capture-skips/ack`, `servers:write`) record the count and
+    the moment in a new `stream_state.capture_skips_ack` column. Nothing is
+    erased: the tally stays, `status` keeps printing it (`⚠ ON RECORD` instead
+    of `⚠ DEGRADED`), and the console renders it muted rather than as an alarm.
+  - An acknowledgement covers a **count**, not a fact, so a later skip lifts the
+    tally above it and the alarm — and the `--fail-on-gap` failure — return with
+    no operator action. It can retire a record; it cannot mute the next
+    incident.
+  - The console endpoint takes the total the page rendered and refuses with 409
+    if the live tally is higher, so a tab left open cannot acknowledge skips
+    nobody looked at.
+  - `status --format json` gains `capture_health.acknowledged` and
+    `capture_health.acknowledged_at`. `capture_health.status` deliberately stays
+    `"degraded"`: the events really are still missing, and a consumer keying on
+    the verdict must not read a human's "seen it" as the loss being undone.
+
 ### Changed
 - **`bintrail-console` no longer carries its own copy of the env-file loader**
   (#963). `consoleapp/env.go` held `loadEnvFile`/`parseAndSetEnv` byte-for-byte
@@ -98,7 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - A console started with `--no-archive` announces itself only once the plan
     actually finds hours it could not read, so a whole-deployment setting does
     not become a permanent banner on every response — which is read by nobody,
-    including on the day it matters.
+including on the day it matters.
 - **`status` no longer reports an unreadable archive tier as no archive tier**
   (#816). `LoadCoverage` degraded every `archive_state` failure to live-only
   coverage behind a `slog.Warn`, so "this index has no archives" and "I could
@@ -112,6 +136,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lower bound (`⚠ NOT READ` in the text report, `coverage.archives_unavailable`
   plus `archives_error` in JSON). The "(includes archives)" label is withheld
   in that state rather than claiming coverage that was never read.
+    including on the day it matters. A session profile is announced regardless,
+    because it is the one the reader cannot otherwise discover.
+  - The events view now renders the response's `warnings`, and Preview no
+    longer clears the notice Generate-undo rendered. The server had been
+    computing the right sentence for `/api/events` and the browser was dropping
+    it, so the flagship case — a profiled session's default browse — stayed
+    silent on screen.
 ## [0.53.0] - 2026-08-11
 
 ### Fixed

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -229,7 +229,8 @@ func (s *Server) buildOptions(p filterParams, defaultLimit, maxLimit int) (query
 // AllowGaps is true for both events and recover, matching the CLI `recover`
 // (warn-and-continue — a human reviews the script). Coverage gaps the planner
 // detects are returned in the QueryPlan and surfaced to the caller as warnings
-// via gapWarnings(plan); the recover UI renders them prominently, so an
+// via restrictedFetchWarnings(plan, excl); the recover view and the events
+// view both render response warnings (#1311 added the events container), so an
 // incomplete-coverage undo is never presented as a clean success.
 //
 // One residual case for these permissive endpoints: when several archive

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -295,7 +295,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	// row is not a paging escape hatch for pulling the index into a browser.
 	pageLimit := opts.Limit
 	opts.Limit = pageLimit + 1
-	rows, plan, err := s.fetchRestricted(r.Context(), r, b, opts)
+	rows, plan, excl, err := s.fetchRestricted(r.Context(), r, b, opts)
 	if err != nil {
 		writeFetchError(w, err)
 		return
@@ -309,7 +309,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		Count:    len(rows),
 		Limit:    pageLimit,
 		HasMore:  hasMore,
-		Warnings: gapWarnings(plan),
+		Warnings: restrictedFetchWarnings(plan, excl),
 	}
 	// The cursor comes from the last row of the page the client is about to
 	// see, in the direction it is reading. Built server-side from a served row
@@ -389,12 +389,12 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 	// Coverage gaps come back in plan.GapHours and are surfaced as warnings
 	// below — the recover UI renders them, so an incomplete-coverage undo is
 	// flagged to the operator rather than silently presented as complete.
-	rows, plan, err := s.fetchRestricted(r.Context(), r, b, opts)
+	rows, plan, excl, err := s.fetchRestricted(r.Context(), r, b, opts)
 	if err != nil {
 		writeFetchError(w, err)
 		return
 	}
-	warnings := gapWarnings(plan)
+	warnings := restrictedFetchWarnings(plan, excl)
 
 	// The fetch above ran Order=DESC so the limit kept the newest suffix of
 	// the window (#981). Detect truncation on the FETCHED row count — before
@@ -843,7 +843,8 @@ func writeRecoverError(w http.ResponseWriter, err error) {
 }
 
 // gapWarnings renders coverage-gap hours from a query plan into a warning list
-// for the API response, or nil when there are none.
+// for the API response, or nil when there are none. Callers that fetch through
+// fetchRestricted must use restrictedFetchWarnings instead — see its doc.
 func gapWarnings(plan *query.QueryPlan) []string {
 	if plan == nil || len(plan.GapHours) == 0 {
 		return nil

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1126,6 +1126,14 @@ function renderEvents(params) {
     onclick: (e) => exportEvents("csv", e.target) }));
   v.append(bar);
 
+  // Scope/coverage notices for this result set (#1311). The response has
+  // carried a `warnings` array all along and this view dropped it, which meant
+  // the default browse -- the exact case a profiled session reads live-index
+  // only with no time filter -- computed the right sentence server-side and
+  // threw it away at the browser. Above the list on purpose: a caveat about
+  // what a result does NOT include is worthless below the result.
+  v.append(el("div", { id: "ev-warnings", class: "warnings" }));
+
   // events list
   const list = el("div", { class: "events", id: "events-list" });
   const head = el("div", { class: "ev-head" });
@@ -1445,6 +1453,7 @@ async function runEventsQuery(form, keepPage) {
     return;
   }
   if (gen !== serverGen) return;
+  renderWarnings($("#ev-warnings", VIEW()), data.warnings);
 
   // Client-side refine: unscoped pk/col + free terms.
   const events = refineEvents(data.events || [], refine);
@@ -1769,13 +1778,16 @@ async function previewRecover(form) {
     // Truncation warning (#967): more matches than the preview's limit means
     // the actual undo script (same limit, applied server-side) may cover more
     // events than are shown here.
+    // Preview and Generate-undo share #recover-warnings, so this must render
+    // the server's OWN warnings (the archive-exclusion notice among them)
+    // alongside its truncation note -- not clear the box. Clearing it made the
+    // caveat vanish the moment an operator adjusted a filter and re-previewed,
+    // which is exactly when it is most load-bearing.
+    const notes = (data.warnings || []).slice();
     if (data.count >= data.limit) {
-      renderWarnings(warns, [
-        "Only the newest " + data.limit + " events are shown. The actual undo script may include more if you increase the limit."
-      ]);
-    } else {
-      clear(warns);
+      notes.push("Only the newest " + data.limit + " events are shown. The actual undo script may include more if you increase the limit.");
     }
+    renderWarnings(warns, notes);
   } catch (err) {
     if (gen !== serverGen) return;
     renderError(container, err);

--- a/internal/console/coverage_warnings.go
+++ b/internal/console/coverage_warnings.go
@@ -44,8 +44,8 @@ func coverageWarnings(plan *query.QueryPlan, skippedSources []string, allowGaps 
 //  1. NO PLAN, NO WARNING. The planner only runs with a time range, so the
 //     default browse — newest N events, no since/until — produced no plan and
 //     therefore said nothing at all, even though the session was reading half
-//     the index. The exclusion notice does not depend on the plan, so it is
-//     emitted first and unconditionally.
+//     the index. A session profile is therefore announced without consulting
+//     the plan at all (see archiveExclusion.announce).
 //
 //  2. THE PLAN MISATTRIBUTES. Under an exclusion, Plan deliberately classifies
 //     archived-only hours as gaps (they will not be fetched), and
@@ -53,32 +53,20 @@ func coverageWarnings(plan *query.QueryPlan, skippedSources []string, allowGaps 
 //     reader that is the wrong cause: the hours very likely ARE archived, and
 //     the operator gets sent to audit a rotation that is working. The hours are
 //     still worth naming, so they are reported with the cause left open.
+//
+// The notice is emitted FIRST here, but callers may prepend their own — the
+// recover handler puts cascade caveats ahead of it — so "first" is this
+// function's contract, not the response's.
 func restrictedFetchWarnings(plan *query.QueryPlan, excl archiveExclusion) []string {
 	var out []string
-	// The two exclusions are announced ASYMMETRICALLY, on purpose.
-	//
-	// A session data profile is invisible to the person reading the screen:
-	// they did not set it, the UI does not show it, and nothing else in the
-	// response hints that half the index is out of scope. That one is always
-	// announced.
-	//
-	// A console started with --no-archive is a property of the whole
-	// deployment. Announcing it on every response would put a permanent
-	// banner on every page of that console — and a banner that is always
-	// there is read by nobody, including on the day it matters. It is
-	// announced only when the plan actually found hours this read could not
-	// see, which is when it stops being configuration and becomes an
-	// incomplete answer.
 	gaps := plan != nil && len(plan.GapHours) > 0
-	if excl == archivesExcludedByProfile || (excl == archivesExcludedByServer && gaps) {
-		if n := excl.notice(); n != "" {
-			out = append(out, n)
-		}
+	if excl.announce(gaps) {
+		out = append(out, excl.notice())
 	}
 	if !gaps {
 		return out
 	}
-	if excl == archivesRead {
+	if !excl.any() {
 		return append(out, query.FormatGapWarning(plan.GapHours))
 	}
 	first, last := query.GapRange(plan.GapHours)

--- a/internal/console/coverage_warnings.go
+++ b/internal/console/coverage_warnings.go
@@ -37,3 +37,52 @@ func coverageWarnings(plan *query.QueryPlan, skippedSources []string, allowGaps 
 	}
 	return w
 }
+
+// restrictedFetchWarnings is gapWarnings for a fetch that may have excluded the
+// archives (#1311). It closes two holes the plan alone cannot:
+//
+//  1. NO PLAN, NO WARNING. The planner only runs with a time range, so the
+//     default browse — newest N events, no since/until — produced no plan and
+//     therefore said nothing at all, even though the session was reading half
+//     the index. The exclusion notice does not depend on the plan, so it is
+//     emitted first and unconditionally.
+//
+//  2. THE PLAN MISATTRIBUTES. Under an exclusion, Plan deliberately classifies
+//     archived-only hours as gaps (they will not be fetched), and
+//     FormatGapWarning explains gaps as "rotated and not archived". For this
+//     reader that is the wrong cause: the hours very likely ARE archived, and
+//     the operator gets sent to audit a rotation that is working. The hours are
+//     still worth naming, so they are reported with the cause left open.
+func restrictedFetchWarnings(plan *query.QueryPlan, excl archiveExclusion) []string {
+	var out []string
+	// The two exclusions are announced ASYMMETRICALLY, on purpose.
+	//
+	// A session data profile is invisible to the person reading the screen:
+	// they did not set it, the UI does not show it, and nothing else in the
+	// response hints that half the index is out of scope. That one is always
+	// announced.
+	//
+	// A console started with --no-archive is a property of the whole
+	// deployment. Announcing it on every response would put a permanent
+	// banner on every page of that console — and a banner that is always
+	// there is read by nobody, including on the day it matters. It is
+	// announced only when the plan actually found hours this read could not
+	// see, which is when it stops being configuration and becomes an
+	// incomplete answer.
+	gaps := plan != nil && len(plan.GapHours) > 0
+	if excl == archivesExcludedByProfile || (excl == archivesExcludedByServer && gaps) {
+		if n := excl.notice(); n != "" {
+			out = append(out, n)
+		}
+	}
+	if !gaps {
+		return out
+	}
+	if excl == archivesRead {
+		return append(out, query.FormatGapWarning(plan.GapHours))
+	}
+	first, last := query.GapRange(plan.GapHours)
+	return append(out, "Hours in this window returned no live-index data: "+first+" – "+last+
+		". They are outside what this session reads, so this is NOT a finding that the changes are "+
+		"missing — they may be sitting in archive storage.")
+}

--- a/internal/console/restricted_fetch_warnings_test.go
+++ b/internal/console/restricted_fetch_warnings_test.go
@@ -24,7 +24,7 @@ func TestRestrictedFetchWarnings(t *testing.T) {
 		// THE hole this closes. The planner only runs with a time range, so
 		// the default browse (newest N, no since/until) produced a nil plan
 		// and therefore said NOTHING, while reading half the index.
-		w := restrictedFetchWarnings(nil, archivesExcludedByProfile)
+		w := restrictedFetchWarnings(nil, archiveExclusion{profile: true})
 		if len(w) != 1 {
 			t.Fatalf("want exactly the exclusion notice with no plan, got %#v", w)
 		}
@@ -39,7 +39,7 @@ func TestRestrictedFetchWarnings(t *testing.T) {
 	})
 
 	t.Run("gap hours are not attributed to rotation", func(t *testing.T) {
-		w := restrictedFetchWarnings(planWithGap, archivesExcludedByProfile)
+		w := restrictedFetchWarnings(planWithGap, archiveExclusion{profile: true})
 		joined := strings.Join(w, "\n")
 		// Plan classifies archived-only hours as gaps under an exclusion, by
 		// design. Explaining them as "rotated and not archived" sends the
@@ -56,14 +56,14 @@ func TestRestrictedFetchWarnings(t *testing.T) {
 	})
 
 	t.Run("unrestricted keeps the original wording", func(t *testing.T) {
-		w := restrictedFetchWarnings(planWithGap, archivesRead)
+		w := restrictedFetchWarnings(planWithGap, archiveExclusion{})
 		if len(w) != 1 || !strings.Contains(w[0], "rotated and not archived") {
 			t.Errorf("a normal read must keep the planner's own gap sentence, got %#v", w)
 		}
 	})
 
 	t.Run("clean unrestricted read warns about nothing", func(t *testing.T) {
-		if w := restrictedFetchWarnings(nil, archivesRead); len(w) != 0 {
+		if w := restrictedFetchWarnings(nil, archiveExclusion{}); len(w) != 0 {
 			t.Errorf("an unrestricted read with no plan must warn about nothing, got %#v", w)
 		}
 	})
@@ -73,13 +73,32 @@ func TestRestrictedFetchWarnings(t *testing.T) {
 	// the day it matters — and it would train users to skip the profile
 	// notice too, which is the one they cannot otherwise discover.
 	t.Run("server-wide exclusion stays quiet with nothing to report", func(t *testing.T) {
-		if w := restrictedFetchWarnings(nil, archivesExcludedByServer); len(w) != 0 {
+		if w := restrictedFetchWarnings(nil, archiveExclusion{server: true}); len(w) != 0 {
 			t.Errorf("a --no-archive console warned with no gap to show, on every response: %#v", w)
 		}
 	})
 
+	// THE composed case. `serve --profile` sets NoArchive console-wide, so a
+	// profiled session on such a console has BOTH causes. Collapsing them to
+	// one winner let the server-wide cause win, and the server-wide notice is
+	// conditional on gaps, which the default browse never produces -- so the
+	// profiled user got nothing at all. The exact silence #1311 was filed for,
+	// restored by the fix for it.
+	t.Run("profiled session on a --no-archive console is never silent", func(t *testing.T) {
+		w := restrictedFetchWarnings(nil, archiveExclusion{server: true, profile: true})
+		if len(w) == 0 {
+			t.Fatal("a profiled session on a --no-archive console got no warning at all")
+		}
+		// The WORDING still names the console-wide cause: removing the
+		// profile would change nothing while --no-archive stands, so blaming
+		// the profile would send the operator somewhere useless.
+		if !strings.Contains(w[0], "--no-archive") {
+			t.Errorf("want the console-wide cause named as the operative one, got %q", w[0])
+		}
+	})
+
 	t.Run("server-wide exclusion speaks up once there IS a gap", func(t *testing.T) {
-		w := restrictedFetchWarnings(planWithGap, archivesExcludedByServer)
+		w := restrictedFetchWarnings(planWithGap, archiveExclusion{server: true})
 		joined := strings.Join(w, "\n")
 		if !strings.Contains(joined, "--no-archive") {
 			t.Errorf("want the server-wide cause named, got %#v", w)
@@ -93,9 +112,8 @@ func TestRestrictedFetchWarnings(t *testing.T) {
 	})
 }
 
-// The precedence rule: --no-archive makes EVERY session archive-blind, so
-// naming the session's own profile would point the operator at something that
-// is not the reason and whose removal would change nothing.
+// archiveExclusionFor records BOTH causes. Precedence now lives only in the
+// WORDING (notice()), never in whether the operator is told at all.
 func TestArchiveExclusionFor(t *testing.T) {
 	profiled := httptest.NewRequest("GET", "/api/events", nil)
 	profiled = profiled.WithContext(context.WithValue(profiled.Context(),
@@ -108,10 +126,12 @@ func TestArchiveExclusionFor(t *testing.T) {
 		profiled  bool
 		want      archiveExclusion
 	}{
-		{"neither", false, false, archivesRead},
-		{"profile only", false, true, archivesExcludedByProfile},
-		{"server only", true, false, archivesExcludedByServer},
-		{"both — server wins", true, true, archivesExcludedByServer},
+		{"neither", false, false, archiveExclusion{}},
+		{"profile only", false, true, archiveExclusion{profile: true}},
+		{"server only", true, false, archiveExclusion{server: true}},
+		// BOTH are recorded. An earlier version collapsed this to
+		// "server wins" and that is what made the composed case silent.
+		{"both are kept", true, true, archiveExclusion{server: true, profile: true}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			r := plain
@@ -119,7 +139,7 @@ func TestArchiveExclusionFor(t *testing.T) {
 				r = profiled
 			}
 			if got := archiveExclusionFor(r, &bundle{noArchive: tc.noArchive}); got != tc.want {
-				t.Errorf("got %q, want %q", got, tc.want)
+				t.Errorf("got %+v, want %+v", got, tc.want)
 			}
 		})
 	}

--- a/internal/console/restricted_fetch_warnings_test.go
+++ b/internal/console/restricted_fetch_warnings_test.go
@@ -1,0 +1,126 @@
+package console
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// #1311: a profiled session reads live MySQL only, and the response never said
+// so. The exclusion is correct — the archive path runs no redaction, so it
+// fails in the safe direction — but an unstated restriction turns a short or
+// empty result into an answer about the DATA. Hours that rotated into archive
+// storage still exist; the session simply does not open them.
+func TestRestrictedFetchWarnings(t *testing.T) {
+	hour := time.Date(2026, 8, 1, 3, 0, 0, 0, time.UTC)
+	planWithGap := &query.QueryPlan{GapHours: []time.Time{hour}}
+
+	t.Run("no plan still warns", func(t *testing.T) {
+		// THE hole this closes. The planner only runs with a time range, so
+		// the default browse (newest N, no since/until) produced a nil plan
+		// and therefore said NOTHING, while reading half the index.
+		w := restrictedFetchWarnings(nil, archivesExcludedByProfile)
+		if len(w) != 1 {
+			t.Fatalf("want exactly the exclusion notice with no plan, got %#v", w)
+		}
+		if !strings.Contains(w[0], "LIVE INDEX ONLY") {
+			t.Errorf("notice does not state the scope: %q", w[0])
+		}
+		// The wrong inference must be denied in words, because making it is
+		// the failure mode.
+		if !strings.Contains(w[0], "does not mean nothing happened") {
+			t.Errorf("notice does not deny the wrong inference: %q", w[0])
+		}
+	})
+
+	t.Run("gap hours are not attributed to rotation", func(t *testing.T) {
+		w := restrictedFetchWarnings(planWithGap, archivesExcludedByProfile)
+		joined := strings.Join(w, "\n")
+		// Plan classifies archived-only hours as gaps under an exclusion, by
+		// design. Explaining them as "rotated and not archived" sends the
+		// operator to audit a rotation that is working fine.
+		if strings.Contains(joined, "rotated and not archived") {
+			t.Errorf("gap hours misattributed to rotation for an archive-excluded read:\n%s", joined)
+		}
+		if !strings.Contains(joined, "2026-08-01 03:00") {
+			t.Errorf("the hours are not named, so the operator cannot check them:\n%s", joined)
+		}
+		if !strings.Contains(joined, "NOT a finding") {
+			t.Errorf("the warning reads as a data-loss finding:\n%s", joined)
+		}
+	})
+
+	t.Run("unrestricted keeps the original wording", func(t *testing.T) {
+		w := restrictedFetchWarnings(planWithGap, archivesRead)
+		if len(w) != 1 || !strings.Contains(w[0], "rotated and not archived") {
+			t.Errorf("a normal read must keep the planner's own gap sentence, got %#v", w)
+		}
+	})
+
+	t.Run("clean unrestricted read warns about nothing", func(t *testing.T) {
+		if w := restrictedFetchWarnings(nil, archivesRead); len(w) != 0 {
+			t.Errorf("an unrestricted read with no plan must warn about nothing, got %#v", w)
+		}
+	})
+
+	// The asymmetry: a --no-archive console must not stamp a banner on every
+	// response forever. A permanent banner is read by nobody, including on
+	// the day it matters — and it would train users to skip the profile
+	// notice too, which is the one they cannot otherwise discover.
+	t.Run("server-wide exclusion stays quiet with nothing to report", func(t *testing.T) {
+		if w := restrictedFetchWarnings(nil, archivesExcludedByServer); len(w) != 0 {
+			t.Errorf("a --no-archive console warned with no gap to show, on every response: %#v", w)
+		}
+	})
+
+	t.Run("server-wide exclusion speaks up once there IS a gap", func(t *testing.T) {
+		w := restrictedFetchWarnings(planWithGap, archivesExcludedByServer)
+		joined := strings.Join(w, "\n")
+		if !strings.Contains(joined, "--no-archive") {
+			t.Errorf("want the server-wide cause named, got %#v", w)
+		}
+		if strings.Contains(joined, "data profile") {
+			t.Errorf("blamed the session profile for a server-wide setting: %q", joined)
+		}
+		if strings.Contains(joined, "rotated and not archived") {
+			t.Errorf("gap hours misattributed to rotation for an archive-excluded read:\n%s", joined)
+		}
+	})
+}
+
+// The precedence rule: --no-archive makes EVERY session archive-blind, so
+// naming the session's own profile would point the operator at something that
+// is not the reason and whose removal would change nothing.
+func TestArchiveExclusionFor(t *testing.T) {
+	profiled := httptest.NewRequest("GET", "/api/events", nil)
+	profiled = profiled.WithContext(context.WithValue(profiled.Context(),
+		policyCtxKey{}, &ext.AccessPolicy{Profile: "analyst"}))
+	plain := httptest.NewRequest("GET", "/api/events", nil)
+
+	for _, tc := range []struct {
+		name      string
+		noArchive bool
+		profiled  bool
+		want      archiveExclusion
+	}{
+		{"neither", false, false, archivesRead},
+		{"profile only", false, true, archivesExcludedByProfile},
+		{"server only", true, false, archivesExcludedByServer},
+		{"both — server wins", true, true, archivesExcludedByServer},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := plain
+			if tc.profiled {
+				r = profiled
+			}
+			if got := archiveExclusionFor(r, &bundle{noArchive: tc.noArchive}); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/console/restricted_fetch_wiring_integration_test.go
+++ b/internal/console/restricted_fetch_wiring_integration_test.go
@@ -74,6 +74,32 @@ func TestIntegrationProfiledSessionDeclaresItsScope(t *testing.T) {
 		t.Errorf("an unprofiled session must warn about nothing, got %#v", w)
 	}
 
+	// /api/recover is the endpoint whose warning actually reaches a human
+	// today (the recover view renders response warnings; the events view did
+	// not until this change). It had no coverage at all, which meant the one
+	// working half of the feature was the untested half.
+	{
+		body := strings.NewReader(`{"schema":"app","table":"users","dry_run":true}`)
+		r := httptest.NewRequest("POST", "http://127.0.0.1:8090/api/recover", body)
+		r.Host = "127.0.0.1:8090"
+		r = r.WithContext(context.WithValue(r.Context(),
+			policyCtxKey{}, &ext.AccessPolicy{Profile: "analyst", Permissions: ext.AllPermissions()}))
+		w := httptest.NewRecorder()
+		srv.handleRecover(w, r)
+		if w.Code != 200 {
+			t.Fatalf("recover code = %d, body = %s", w.Code, w.Body.String())
+		}
+		var resp struct {
+			Warnings []string `json:"warnings"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode recover: %v\n%s", err, w.Body.String())
+		}
+		if !strings.Contains(strings.Join(resp.Warnings, "\n"), "LIVE INDEX ONLY") {
+			t.Errorf("/api/recover does not declare its scope to a profiled session: %#v", resp.Warnings)
+		}
+	}
+
 	got := strings.Join(get(t, "analyst"), "\n")
 	if !strings.Contains(got, "LIVE INDEX ONLY") {
 		t.Fatalf("the profiled response does not declare its scope — a short result still reads as an answer about the data:\n%s", got)

--- a/internal/console/restricted_fetch_wiring_integration_test.go
+++ b/internal/console/restricted_fetch_wiring_integration_test.go
@@ -1,0 +1,84 @@
+//go:build integration
+
+package console
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// The unit test proves restrictedFetchWarnings returns the right strings. This
+// proves the string reaches the WIRE: the handler is driven end to end with a
+// real profiled session, no time filter (the case that used to warn about
+// nothing at all), and the response is read as a client reads it.
+//
+// Mutating fetchRestricted to drop the exclusion, or handleEvents to call the
+// old gapWarnings, leaves the unit test passing and breaks this one.
+func TestIntegrationProfiledSessionDeclaresItsScope(t *testing.T) {
+	// A server that DOES read archives, so the only exclusion under test is
+	// the session's own profile. seedConsoleData sets NoArchive, which would
+	// make the unprofiled control fail for the server-wide reason and prove
+	// nothing about profiles.
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	testutil.InsertEvent(t, db, "bin.000001", 4, 40, "2026-06-01 12:00:00", nil,
+		"app", "users", 1 /*INSERT*/, "1", nil, nil, []byte(`{"id":1,"name":"alice"}`))
+	// The profile must EXIST in the index or the request is refused before
+	// any of this is reached — which is how the first draft of this test
+	// silently proved nothing.
+	if _, err := db.Exec(`INSERT INTO profiles (name) VALUES ('analyst')`); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	srv, err := New(Config{DB: db, DBName: dbName, Listen: "127.0.0.1:8090", Token: intToken})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	get := func(t *testing.T, profile string) []string {
+		t.Helper()
+		// No since/until on purpose: the default browse is exactly where the
+		// planner does not run, so before #1311 the response carried no
+		// warning at all while the session read half the index.
+		r := httptest.NewRequest("GET", "http://127.0.0.1:8090/api/events?schema=app&table=users", nil)
+		r.Host = "127.0.0.1:8090"
+		if profile != "" {
+			r = r.WithContext(context.WithValue(r.Context(),
+				policyCtxKey{}, &ext.AccessPolicy{Profile: profile, Permissions: ext.AllPermissions()}))
+		}
+		w := httptest.NewRecorder()
+		srv.handleEvents(w, r)
+		if w.Code != 200 {
+			t.Fatalf("events code = %d, body = %s", w.Code, w.Body.String())
+		}
+		var resp struct {
+			Count    int      `json:"count"`
+			Warnings []string `json:"warnings"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v\n%s", err, w.Body.String())
+		}
+		// Rows must still come back — this is a warning, not a refusal.
+		if resp.Count == 0 {
+			t.Fatal("the profiled read returned no rows; the fixture or the fetch is broken, and the warning assertion below would be vacuous")
+		}
+		return resp.Warnings
+	}
+
+	if w := get(t, ""); len(w) != 0 {
+		t.Errorf("an unprofiled session must warn about nothing, got %#v", w)
+	}
+
+	got := strings.Join(get(t, "analyst"), "\n")
+	if !strings.Contains(got, "LIVE INDEX ONLY") {
+		t.Fatalf("the profiled response does not declare its scope — a short result still reads as an answer about the data:\n%s", got)
+	}
+	if !strings.Contains(got, "does not mean nothing happened") {
+		t.Errorf("the response does not deny the wrong inference:\n%s", got)
+	}
+}

--- a/internal/console/session_profile.go
+++ b/internal/console/session_profile.go
@@ -221,15 +221,15 @@ func (s *Server) fetchRestricted(ctx context.Context, r *http.Request, b *bundle
 	rows, plan, err := query.FetchMerged(ctx, b.db, b.engine, query.FetchMergedOptions{
 		Opts:           opts,
 		DBName:         b.dbName,
-		NoArchive:      excl != archivesRead,
+		NoArchive:      excl.any(),
 		AllowGaps:      true,
 		ArchiveFetcher: parquetquery.Fetch,
 	})
 	return rows, plan, excl, err
 }
 
-// archiveExclusion says WHY a fetch left the Parquet archives out, or
-// archivesRead when it did not (#1311).
+// archiveExclusion records WHY a fetch left the Parquet archives out (#1311),
+// tracking the two causes SEPARATELY rather than collapsing them.
 //
 // Excluding them is correct — the archive path runs no redaction, so a
 // profiled session must not be served from it — and it fails in the safe
@@ -238,46 +238,64 @@ func (s *Server) fetchRestricted(ctx context.Context, r *http.Request, b *bundle
 // still exist; the session simply does not read them. An operator sees a short
 // or empty result and reads it as "nothing happened in that window", which is
 // the one conclusion the data does not support.
-type archiveExclusion string
+//
+// The two causes are kept apart because collapsing them to one winner made a
+// profiled session on a --no-archive console silent: the server-wide cause
+// won, and the server-wide notice is deliberately conditional on the planner
+// finding gaps, which the default browse never produces (no time range, no
+// plan). Session and console are different facts about the same read and both
+// have to survive.
+type archiveExclusion struct {
+	// server: the whole console excludes archives (--no-archive, or a startup
+	// --profile, which implies it — see consoleapp/serve.go).
+	server bool
+	// profile: THIS session carries a data profile.
+	profile bool
+}
 
-const (
-	archivesRead              archiveExclusion = ""
-	archivesExcludedByProfile archiveExclusion = "profile"
-	archivesExcludedByServer  archiveExclusion = "server"
-)
+func (e archiveExclusion) any() bool { return e.server || e.profile }
 
 // archiveExclusionFor reports why this request will not read archives.
-//
-// The server-wide cause wins when both apply: --no-archive (or a startup
-// --profile, which implies it) makes EVERY session archive-blind, so naming
-// the session's own profile would point the operator at something that is not
-// the reason and whose removal would change nothing.
 func archiveExclusionFor(r *http.Request, b *bundle) archiveExclusion {
-	switch {
-	case b.noArchive:
-		return archivesExcludedByServer
-	case sessionRestricted(r):
-		return archivesExcludedByProfile
-	default:
-		return archivesRead
-	}
+	return archiveExclusion{server: b.noArchive, profile: sessionRestricted(r)}
+}
+
+// announce reports whether the operator must be told, given whether the
+// planner found hours this read could not see.
+//
+// A session data profile is ALWAYS announced: it is invisible to the person
+// reading the screen — they did not set it, the UI does not show it, and
+// nothing else in the response hints that half the index is out of scope.
+//
+// A console-wide --no-archive alone is announced only once there is a gap to
+// point at. Putting it on every response would be a permanent banner on every
+// page of that console, and a banner that is always there is read by nobody —
+// including on the day it matters, and it would train users straight past the
+// profile notice.
+func (e archiveExclusion) announce(gaps bool) bool {
+	return e.profile || (e.server && gaps)
 }
 
 // notice is the operator-facing sentence for an exclusion. It states the scope
 // of the result and explicitly denies the wrong inference, because the wrong
 // inference is the whole failure mode: a short result under an unstated
 // restriction reads as an answer about the data.
+// The wording names the cause whose removal would actually change the result.
+// When the whole console excludes archives, saying "your data profile" would
+// point the operator at something that is not the reason and whose removal
+// would change nothing — so the console-wide sentence wins the WORDING even
+// though the profile wins the decision to speak.
 func (e archiveExclusion) notice() string {
-	switch e {
-	case archivesExcludedByProfile:
+	switch {
+	case e.server:
+		return "This console reads the LIVE INDEX ONLY (started with --no-archive, or with a profile that " +
+			"implies it), so archived (rotated) hours are not searched. A short or empty result does not " +
+			"mean nothing happened in that window."
+	case e.profile:
 		return "Your session carries a data profile, so these results come from the LIVE INDEX ONLY: " +
 			"archived (rotated) hours are not searched, because the archive path cannot apply the " +
 			"redaction your profile requires. A short or empty result does not mean nothing happened " +
 			"in that window — ask an operator without a data profile, or use the CLI, to search the archives."
-	case archivesExcludedByServer:
-		return "This console reads the LIVE INDEX ONLY (started with --no-archive, or with a profile that " +
-			"implies it), so archived (rotated) hours are not searched. A short or empty result does not " +
-			"mean nothing happened in that window."
 	}
 	return ""
 }

--- a/internal/console/session_profile.go
+++ b/internal/console/session_profile.go
@@ -216,13 +216,68 @@ func (s *Server) applySessionProfile(ctx context.Context, r *http.Request, b *bu
 // archives OFF when the request's session carries a data profile: Parquet
 // archives do not run the redaction pass, so a profiled session must read live
 // MySQL only (the same reason a startup profile forces --no-archive process-wide).
-func (s *Server) fetchRestricted(ctx context.Context, r *http.Request, b *bundle, opts query.Options) ([]query.ResultRow, *query.QueryPlan, error) {
-	noArchive := b.noArchive || sessionRestricted(r)
-	return query.FetchMerged(ctx, b.db, b.engine, query.FetchMergedOptions{
+func (s *Server) fetchRestricted(ctx context.Context, r *http.Request, b *bundle, opts query.Options) ([]query.ResultRow, *query.QueryPlan, archiveExclusion, error) {
+	excl := archiveExclusionFor(r, b)
+	rows, plan, err := query.FetchMerged(ctx, b.db, b.engine, query.FetchMergedOptions{
 		Opts:           opts,
 		DBName:         b.dbName,
-		NoArchive:      noArchive,
+		NoArchive:      excl != archivesRead,
 		AllowGaps:      true,
 		ArchiveFetcher: parquetquery.Fetch,
 	})
+	return rows, plan, excl, err
+}
+
+// archiveExclusion says WHY a fetch left the Parquet archives out, or
+// archivesRead when it did not (#1311).
+//
+// Excluding them is correct — the archive path runs no redaction, so a
+// profiled session must not be served from it — and it fails in the safe
+// direction: the session is shown less, never unredacted more. What was
+// missing is that the RESULT never said so. Hours rotated out of live MySQL
+// still exist; the session simply does not read them. An operator sees a short
+// or empty result and reads it as "nothing happened in that window", which is
+// the one conclusion the data does not support.
+type archiveExclusion string
+
+const (
+	archivesRead              archiveExclusion = ""
+	archivesExcludedByProfile archiveExclusion = "profile"
+	archivesExcludedByServer  archiveExclusion = "server"
+)
+
+// archiveExclusionFor reports why this request will not read archives.
+//
+// The server-wide cause wins when both apply: --no-archive (or a startup
+// --profile, which implies it) makes EVERY session archive-blind, so naming
+// the session's own profile would point the operator at something that is not
+// the reason and whose removal would change nothing.
+func archiveExclusionFor(r *http.Request, b *bundle) archiveExclusion {
+	switch {
+	case b.noArchive:
+		return archivesExcludedByServer
+	case sessionRestricted(r):
+		return archivesExcludedByProfile
+	default:
+		return archivesRead
+	}
+}
+
+// notice is the operator-facing sentence for an exclusion. It states the scope
+// of the result and explicitly denies the wrong inference, because the wrong
+// inference is the whole failure mode: a short result under an unstated
+// restriction reads as an answer about the data.
+func (e archiveExclusion) notice() string {
+	switch e {
+	case archivesExcludedByProfile:
+		return "Your session carries a data profile, so these results come from the LIVE INDEX ONLY: " +
+			"archived (rotated) hours are not searched, because the archive path cannot apply the " +
+			"redaction your profile requires. A short or empty result does not mean nothing happened " +
+			"in that window — ask an operator without a data profile, or use the CLI, to search the archives."
+	case archivesExcludedByServer:
+		return "This console reads the LIVE INDEX ONLY (started with --no-archive, or with a profile that " +
+			"implies it), so archived (rotated) hours are not searched. A short or empty result does not " +
+			"mean nothing happened in that window."
+	}
+	return ""
 }

--- a/internal/query/planner.go
+++ b/internal/query/planner.go
@@ -219,11 +219,25 @@ func FormatGapWarning(gaps []time.Time) string {
 	if len(gaps) == 0 {
 		return ""
 	}
-	first := gaps[0]
-	last := gaps[len(gaps)-1]
-	return fmt.Sprintf("query covers hours with no data (rotated and not archived): %s – %s",
-		first.Format("2006-01-02 15:00"),
-		last.Format("2006-01-02 15:00"))
+	first, last := GapRange(gaps)
+	return fmt.Sprintf("query covers hours with no data (rotated and not archived): %s – %s", first, last)
+}
+
+// GapRange renders the first and last gap hour for callers that need to say
+// something OTHER than FormatGapWarning's sentence about the same hours.
+//
+// It exists because that sentence names a cause — "rotated and not archived" —
+// which is only true when the reader actually opens the archives. A reader
+// that deliberately excludes them (console --no-archive, or a session data
+// profile) sees the same hours reported as gaps by design, and telling that
+// operator the data was never archived sends them to audit a rotation that is
+// working fine.
+func GapRange(gaps []time.Time) (first, last string) {
+	if len(gaps) == 0 {
+		return "", ""
+	}
+	const f = "2006-01-02 15:00"
+	return gaps[0].Format(f), gaps[len(gaps)-1].Format(f)
 }
 
 // SkipMySQL returns true when the planner determined that MySQL can be skipped

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -565,6 +565,37 @@ try {
       ackedPaint,
     };
   });
+  // Scenario 8b-bis — /api/events warnings must REACH the screen (#1311). The
+  // server computed the archive-exclusion notice correctly and the events view
+  // dropped `data.warnings` on the floor, so the flagship case -- a profiled
+  // session's default browse -- was silent in the UI while the API said the
+  // right thing. A server-side test cannot see that; this can.
+  const evWarn = await page.evaluate(() => {
+    const box = document.createElement("div");
+    box.id = "probe-warnings";
+    document.body.appendChild(box);
+    renderWarnings(box, ["LIVE INDEX ONLY probe notice"]);
+    const rendered = /LIVE INDEX ONLY probe notice/.test(box.textContent);
+    box.remove();
+    return {
+      rendered,
+      // The container the events view must build, by id. Without it
+      // renderWarnings has nowhere to write and the notice is lost.
+      hasEventsContainer: /id:\s*"ev-warnings"/.test(renderEvents.toString()),
+      // ...and it must actually be filled from the response.
+      wiredToResponse: /#ev-warnings/.test(runEventsQuery.toString())
+        && /data\.warnings/.test(runEventsQuery.toString()),
+      // previewRecover shares #recover-warnings with generateUndo; clearing it
+      // made the notice vanish the moment a filter was adjusted.
+      previewKeepsServerWarnings: /data\.warnings/.test(previewRecover.toString())
+        && !/clear\(warns\)/.test(previewRecover.toString()),
+    };
+  });
+  evWarn.rendered ? ok("warnings: renderWarnings paints a notice into a container") : bad("warnings: renderWarnings paints a notice into a container", JSON.stringify(evWarn));
+  evWarn.hasEventsContainer ? ok("warnings: the events view builds a warnings container") : bad("warnings: the events view builds a warnings container", "no #ev-warnings — an API notice has nowhere to land");
+  evWarn.wiredToResponse ? ok("warnings: the events query renders the response's own warnings") : bad("warnings: the events query renders the response's own warnings", "data.warnings is computed server-side and dropped at the browser");
+  evWarn.previewKeepsServerWarnings ? ok("warnings: Preview keeps the server's notices instead of clearing them") : bad("warnings: Preview keeps the server's notices instead of clearing them", "re-previewing wipes the scope caveat");
+
   cap.showsBackendProse ? ok("capture health: banner renders the backend's explanation (table named)") : bad("capture health: banner renders the backend's explanation (table named)", JSON.stringify(cap));
   cap.noOperatorBlame ? ok("capture health: the old blame-the-operator wording is gone") : bad("capture health: the old blame-the-operator wording is gone", "old copy still rendered");
   cap.legacyFallback ? ok("capture health: an old backend gets a fallback that promises nothing") : bad("capture health: an old backend gets a fallback that promises nothing", "fallback missing or invents advice");


### PR DESCRIPTION
Closes #1311.

A console session carrying an RBAC data profile is served with `NoArchive`, because the Parquet path runs no redaction pass. That is the right call and it fails in the safe direction — the session is shown less, never unredacted more.

**The problem is that the result never said so.** Hours rotated out of live MySQL still exist; the profiled session simply does not read them. What the operator sees is a short or empty result, and the natural reading of that is *"nothing happened in that window"* — the one conclusion the data does not support. `/api/events` and `/api/recover` are exactly where an operator forms a belief about what happened to their data.

## Three parts

**1. The notice does not depend on the planner.** `Plan` only runs with a time range, so the *default browse* — newest N events, no `since`/`until` — produced a nil plan and therefore no warning at all, while the session read half the index. That was the worst case; it is now the plainest one.

**2. Gap hours stop being blamed on rotation.** `Plan` deliberately classifies archived-only hours as gaps for an archive-excluded read, and `FormatGapWarning` explains gaps as *"rotated and not archived"*. For this reader that cause is wrong — the hours very likely **are** archived — and it sends the operator to audit a rotation that is working fine. The hours are still named (new `query.GapRange`, for callers that must say something else about the same hours), with the cause left open and the wrong inference denied in words.

**3. The two exclusions are announced asymmetrically, on purpose.**

| exclusion | when announced | why |
|---|---|---|
| session data profile | always | invisible to the person reading the screen — they did not set it and nothing else in the response hints at it |
| console `--no-archive` | only once the plan finds unreadable hours | a whole-deployment setting announced on every response is a permanent banner, and a banner that is always there is read by nobody — including on the day it matters. It would also train users straight past the profile notice. |

The server-wide cause also **wins when both apply**: `--no-archive` makes every session archive-blind, so naming the session's own profile would point the operator at something that is not the reason and whose removal would change nothing.

## What the wiring test caught

Worth recording, because the unit test passed throughout:

- `seedConsoleData` builds the server with `NoArchive: true`, so the *unprofiled control* failed for the server-wide reason and would have proved nothing about profiles.
- A profile absent from the index's `profiles` table is refused with **403 before any of this runs** — the first draft of the test asserted on a response the code never produced.

Both are why the test drives the real handler with a real profiled session and a real `profiles` row, and asserts a non-zero row count before looking at the warnings (so the assertion cannot pass vacuously).

## Testing

Unit table over every (plan, exclusion) combination including the asymmetry and the precedence rule, plus an integration test through `handleEvents` end to end.

Mutation-checked: silencing the profile notice, restoring the rotation attribution, letting the profile outrank `--no-archive`, and making the server-wide notice unconditional each break a test.
