### PR TITLE
compose: serve Prometheus metrics by default and healthcheck the watch daemon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,13 @@ SCHEMAS=
 # needs the API.
 CONSOLE_TOKEN=
 
+# Optional — container-side bind for the watch daemon's Prometheus /metrics
+# endpoint (per-source stream metrics + bintrail_index_* gauges;
+# docs/deployment.md §7 has scrape config and alerting rules). Defaults to
+# :9090, which docker-compose.yml publishes on the host loopback as
+# 127.0.0.1:9090. Set EMPTY (uncomment the line below as-is) to disable.
+# METRICS_ADDR=
+
 # Optional — pin the bundled index MySQL root password. Leave commented to
 # get a randomly-generated one (the default). If you set it, do so BEFORE the
 # first `up` — it is baked into the datadir at init and changing it later

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,6 +216,14 @@ services:
       # off-loopback setup is refused), THEN change to "8090:8090", ideally
       # behind TLS or a TLS-terminating proxy.
       - "127.0.0.1:8090:8090"
+      # Prometheus /metrics on the host loopback (the daemon serves it because
+      # of BINTRAIL_METRICS_ADDR below). A host-run Prometheus scrapes
+      # 127.0.0.1:9090; a Prometheus CONTAINER on this compose network scrapes
+      # bintrail:9090 and does not need this mapping. /metrics has no auth —
+      # widen to "9090:9090" only behind a firewall (docs/deployment.md §7).
+      # If you disable metrics (METRICS_ADDR= empty in .env) this mapping stays
+      # but nothing listens behind it — connections are simply refused.
+      - "127.0.0.1:9090:9090"
     environment:
       # Optional: a source MySQL to start watching immediately. Leave unset
       # and add servers from the console UI instead (the zero-config path).
@@ -229,6 +237,13 @@ services:
       # The console binds all interfaces INSIDE the container; the `ports`
       # mapping above is what controls actual exposure on the host.
       BINTRAIL_CONSOLE_LISTEN: 0.0.0.0:8090
+      # Prometheus metrics for the watch daemon: stream lag/error counters for
+      # every supervised source plus the bintrail_index_* gauges (all metrics
+      # carry a "source" label). deployment.md §7 ships scrape config and
+      # alerting rules against this endpoint. On by default so the shipped
+      # stack is observable out of the box; set METRICS_ADDR= (empty) in .env
+      # to disable. The `ports` mapping above controls actual host exposure.
+      BINTRAIL_METRICS_ADDR: ${METRICS_ADDR-:9090}
       BINTRAIL_CONSOLE_TOKEN: ${CONSOLE_TOKEN:-}
       # Saved console connections persist across container recreations.
       BINTRAIL_CONSOLE_SERVERS: /var/lib/bintrail/console-servers.yaml
@@ -340,6 +355,25 @@ services:
           exec bintrail-console watch --source-dsn "$$SOURCE_DSN" --index-dsn "$$INDEX_DSN"
         fi
         exec bintrail-console watch --index-dsn "$$INDEX_DSN"
+    # Liveness probe against the console's unauthenticated GET /api/healthz
+    # (wget ships in the image). It detects a daemon whose HTTP loop is dead
+    # (deadlock, wedged event loop) and surfaces health in `docker ps` and to
+    # anything that acts on Docker health status. HONEST LIMITS: (1) plain
+    # Docker/Compose only auto-restarts on process EXIT — an `unhealthy`
+    # container is marked, not restarted (Swarm, Kubernetes, Podman
+    # --health-on-failure, or an autoheal sidecar are the pieces that act on
+    # it; running one is the operator's call); (2) a capture STALL with a live
+    # HTTP loop (e.g. source unreachable mid-gap-fill) passes this probe — for
+    # that, alert on the /metrics endpoint above (stream lag/error rules in
+    # docs/deployment.md §7) or run `bintrail status --fail-on-gap` from cron.
+    # start_period covers the doctor preflight + init + schema snapshot a
+    # SOURCE_DSN boot runs before the console binds.
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -T 5 -O /dev/null http://127.0.0.1:8090/api/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     depends_on:
       index-mysql:
         condition: service_healthy
@@ -453,9 +487,10 @@ services:
         condition: service_healthy
       # The shim only reads the index; the `bintrail` service is what creates
       # the tables and streams the boot SOURCE_DSN source into bintrail_index.
-      # Depend on it so `up -d shim` can't start against an unprovisioned index.
+      # Depend on its HEALTH (the daemon answering, not just the process
+      # started) so `up -d shim` can't start against an unprovisioned index.
       bintrail:
-        condition: service_started
+        condition: service_healthy
     restart: unless-stopped
 
   # ── Baselines (one-shot, opt-in `baseline` profile) ──────

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -312,6 +312,13 @@ After the first successful checkpoint, restart without `--start-gtid` — the po
 
 ## 7. Observability
 
+The metrics endpoint is opt-in for a standalone binary — pass
+`--metrics-addr :9090` (env `BINTRAIL_METRICS_ADDR`) to `bintrail stream` or
+`bintrail-console watch`. The [compose quickstart](docker.md#docker-compose)
+serves it out of the box on the host loopback (`127.0.0.1:9090`; a Prometheus
+container on the same compose network scrapes `bintrail:9090`), so the scrape
+config and alerting rules below apply to it unchanged.
+
 ### Prometheus scrape config
 
 ```yaml

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -172,6 +172,32 @@ Notes:
   building from a source checkout instead is a comment-toggle in the
   compose file (`build:` with `dockerfile: build/Dockerfile.bintrail-console`).
 
+### Metrics and the healthcheck
+
+The `bintrail` service serves the watch daemon's Prometheus endpoint at
+**http://127.0.0.1:9090/metrics** by default (host loopback only, same
+posture as the console): per-source stream metrics — every metric carries a
+`source` label — plus the `bintrail_index_*` gauges. The scrape config and
+alerting rules in [Deployment §7 Observability](deployment.md#7-observability)
+work against this endpoint as-is. A Prometheus running as a *container* on
+the same compose network scrapes `bintrail:9090` and needs no published
+port. Set `METRICS_ADDR=` (empty) in `.env` to disable the endpoint. It has
+no authentication — widen the port mapping beyond loopback only behind a
+firewall.
+
+The service also carries a Docker **healthcheck** probing the console's
+unauthenticated `GET /api/healthz`, so `docker compose ps` shows `(healthy)`
+for a live daemon and `(unhealthy)` for one whose HTTP loop has died. Two
+honest limits:
+
+- Plain Docker/Compose **does not restart** an unhealthy container —
+  `restart: unless-stopped` fires on process *exit* only. Swarm, Kubernetes,
+  Podman's `--health-on-failure=restart`, or an autoheal sidecar are the
+  pieces that act on health status; whether to run one is your call.
+- A wedged capture *stream* behind a live HTTP loop passes this probe.
+  Detect that with the stream-lag/error alerting rules on the metrics
+  endpoint above, or `bintrail status --fail-on-gap` from cron.
+
 ### The bundled index MySQL 8.4
 
 The bundled index is **MySQL 8.4 LTS**, pinned to an exact minor tag. The
@@ -460,6 +486,7 @@ surface, use the demo image ([demo.md](./demo.md)).
 | `INDEX_DSN` | compose (optional) | Bring-your-own index MySQL (default: the bundled container) |
 | `SCHEMAS` | compose (optional) | Comma-separated schemas to track (empty = all user schemas) |
 | `CONSOLE_TOKEN` | compose (optional) | Opt-in static API-automation token (default: none — humans sign in with the console password) |
+| `METRICS_ADDR` | compose (optional) | Container-side bind for the watch daemon's Prometheus `/metrics` (default `:9090`, published on the host loopback as `127.0.0.1:9090`; set empty to disable) |
 | `INDEX_MYSQL_ROOT_PASSWORD` | compose (optional) | Pin the bundled index root password (set *before* first boot; default: randomly generated into the `bintrail-index-secret` volume) |
 | `BINTRAIL_TAG` | compose (optional) | Image tag to run (default `latest`) |
 | `BASELINE_SOURCE_DSN` | compose `baseline` profile | Source MySQL to snapshot (default: `SOURCE_DSN`) |


### PR DESCRIPTION
closes #975

## Summary

The shipped compose stack ran `bintrail-console watch` with no metrics endpoint and no healthcheck: deployment.md §7 builds its whole observability story on `:9090`, none of which existed on the default stack, and `restart: unless-stopped` fires on process EXIT only — a wedged-but-alive daemon was invisible.

- **Metrics on by default**: `BINTRAIL_METRICS_ADDR: ${METRICS_ADDR-:9090}` on the `bintrail` service (`watch` already binds that env var to `--metrics-addr` via `bindWatchEnv`, and enabling the daemon endpoint also turns the `bintrail_index_*` scraper on for the primary stream). The port is published on the **host loopback only** (`127.0.0.1:9090`), same posture as the console; a Prometheus container on the compose network scrapes `bintrail:9090` with no published port. `METRICS_ADDR=` (empty) in `.env` disables it — the `-` (not `:-`) interpolation form is what makes empty-means-off work.
- **Healthcheck** on the `bintrail` service probing the console's unauthenticated `GET /api/healthz` with `wget` (present in the published image — verified, see Testing). `start_period: 60s` covers a `SOURCE_DSN` boot's doctor preflight + init + snapshot phases before the console binds.
- The `flashback` shim's `depends_on: bintrail` upgraded `service_started` → `service_healthy`.
- Docs: new "Metrics and the healthcheck" section + `METRICS_ADDR` env-table row in docs/docker.md, a compose note under deployment.md §7 Observability, and a `METRICS_ADDR` entry in `.env.example`.

**Honest limits, stated in the compose comments and docs** (the issue asked for a restart of a wedged daemon; half of that is not something a compose file can deliver):

1. Plain Docker/Compose **marks** an unhealthy container but does not restart it — restart-on-unhealthy is Swarm/Kubernetes/Podman `--health-on-failure`/autoheal territory, and running one of those is the operator's call (ship-vs-operate).
2. A wedged capture *stream* behind a live HTTP loop passes an HTTP probe — that failure class is what the now-enabled `/metrics` lag/error alerting rules (deployment.md §7) and `bintrail status --fail-on-gap` are for. A `status --fail-on-gap` healthcheck was considered and rejected: `gap_lost` is a *permanent* verdict, so it would restart-loop the daemon forever over an unfixable past gap, and the console image ships no `status` command anyway.

## Testing

Actually validated, not config-only:

- `docker compose config` parses cleanly; renders `BINTRAIL_METRICS_ADDR: :9090` by default and `""` under `METRICS_ADDR=` (empty); both 8090 and 9090 bind `host_ip: 127.0.0.1`; `--profile flashback config` shows the shim's `condition: service_healthy`.
- **Live smoke on the published image** (`ghcr.io/dbtrail/bintrail-console:latest` = v0.53.0, isolated project name, torn down after): stack reaches `healthy` within one probe interval (healthcheck exit 0), `curl 127.0.0.1:9090/metrics` serves from the host, `curl 127.0.0.1:8090/api/healthz` → `{"status":"ok"}`. Negative probe: the healthcheck command against a closed port exits non-zero (4), so the check can actually fail.
- Caught during the smoke: a *stale local* `latest` (v0.13.2, June) had no `wget` and sat `starting` forever — the current image ships it (both `build/Dockerfile.bintrail-console*` install it explicitly). Worth knowing if someone pins `BINTRAIL_TAG` to a pre-wget tag, though those tags predate the console split and crash-loop on this compose file anyway (documented in docs/docker.md).
- `go build ./...` green (no Go changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
