### PR TITLE
pg: cover FOR TABLES IN SCHEMA publications in the UNLOGGED-table warning

### DIFF
--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -229,10 +229,10 @@ bintrail-pg doctor --query-dsn "$PG" --slot bintrail_shop --publication bintrail
   (**WARN** — retaining WAL and approaching the limit; doctor still exits 0) →
   `lost` (a loud **FAIL** with the re-baseline recovery path).
 - **No UNLOGGED tables** → WARN if any captured table is `UNLOGGED` (under a
-  `FOR ALL TABLES` publication; a `FOR TABLES IN SCHEMA` publication is **not**
-  covered by the check). UNLOGGED tables write no WAL, so their changes are
-  never captured — `ALTER TABLE <t> SET LOGGED` if you need them, or ignore if the
-  data is intentionally ephemeral.
+  `FOR ALL TABLES` publication, and under a `FOR TABLES IN SCHEMA` — PostgreSQL
+  15+ — publication for its member schemas). UNLOGGED tables write no WAL, so
+  their changes are never captured — `ALTER TABLE <t> SET LOGGED` if you need
+  them, or ignore if the data is intentionally ephemeral.
 - **FK cascade-child coverage** → WARN if a published table has a foreign-key
   `ON DELETE CASCADE` / `SET NULL` **child** that is *not* in the publication. A
   delete on the parent would rewrite that child, and the rewrite would not be
@@ -694,13 +694,11 @@ coerce, but verify your own round-trip.
 ## Limitations
 
 - **`UNLOGGED` tables are not captured.** They bypass the WAL by design, so logical
-  decoding never sees them. bintrail-pg now **warns** when an UNLOGGED table is in
-  capture scope (at `stream` startup and in `bintrail-pg doctor`, under a
-  `FOR ALL TABLES` publication) — but the changes are still not captured, so don't
-  rely on bintrail for UNLOGGED data. The warning does **not** cover a
-  `FOR TABLES IN SCHEMA` (PostgreSQL 15+) publication: an UNLOGGED table pulled
-  into scope by a schema-scoped publication is silently uncaptured with no
-  warning — audit those schemas by hand.
+  decoding never sees them. bintrail-pg **warns** when an UNLOGGED table is in
+  capture scope (at `stream` startup and in `bintrail-pg doctor`) — under a
+  `FOR ALL TABLES` publication and under a `FOR TABLES IN SCHEMA` (PostgreSQL
+  15+) publication's member schemas alike — but the changes are still not
+  captured, so don't rely on bintrail for UNLOGGED data.
 - **A cascade child must be in the publication.** A foreign-key `ON DELETE CASCADE`
   / `SET NULL` is captured (PostgreSQL performs it as ordinary row changes) **only
   if the child table is published**. If a published parent has an unpublished

--- a/internal/pgcapture/slot.go
+++ b/internal/pgcapture/slot.go
@@ -335,14 +335,17 @@ func QueryReplicaIdentityNotFull(ctx context.Context, conn *pgx.Conn, publicatio
 // (pg_relation_is_publishable gates on relpersistence). A query over pg_publication_
 // tables therefore can never match an UNLOGGED row — it would be dead code.
 //
-// The dangerous case is FOR ALL TABLES: the operator believes "everything" is captured,
-// but the UNLOGGED tables silently are not. We scan user base tables for relpersistence
-// = 'u' and report the ones in the client filter scope. For a FOR TABLE publication an
-// UNLOGGED table cannot be in the publication at all, and a client --tables naming an
-// unpublished table is already a fatal coverage gap in validatePublication — so there
-// is nothing this guard could uniquely surface and it returns nil. (FOR TABLES IN
-// SCHEMA, PG 15+, is not covered here — a documented limitation, not silent: the doctor
-// still lists the check.)
+// The dangerous cases are FOR ALL TABLES and FOR TABLES IN SCHEMA (PG 15+): the
+// operator believes "everything" (or "everything in that schema") is captured, but the
+// UNLOGGED tables silently are not — a schema-scoped publication accepts a schema
+// containing UNLOGGED tables, and pg_publication_tables simply omits them. We scan user
+// base tables for relpersistence = 'u' — all user schemas under FOR ALL TABLES, only the
+// published schemas (pg_publication_namespace) under a schema-scoped publication — and
+// report the ones in the client filter scope. For a FOR TABLE publication an UNLOGGED
+// table cannot be in the publication at all, and a client --tables naming an unpublished
+// table is already a fatal coverage gap in validatePublication — so there is nothing
+// this guard could uniquely surface and it returns nil. (#1211 added the schema-scoped
+// coverage.)
 func listUnloggedCaptureTables(ctx context.Context, conn *pgx.Conn, publication string, filters event.Filters) ([]string, error) {
 	var allTables bool
 	err := conn.QueryRow(ctx, `SELECT puballtables FROM pg_publication WHERE pubname = $1`, publication).Scan(&allTables)
@@ -352,8 +355,19 @@ func listUnloggedCaptureTables(ctx context.Context, conn *pgx.Conn, publication 
 	if err != nil {
 		return nil, fmt.Errorf("pgcapture: reading publication %q for the UNLOGGED check: %w", publication, err)
 	}
+
+	// nil = every user schema is in scope (FOR ALL TABLES); non-nil = only the
+	// publication's schema members are (FOR TABLES IN SCHEMA, PG 15+).
+	var schemaScope []string
 	if !allTables {
-		return nil, nil // FOR TABLE: UNLOGGED tables cannot be published (see doc above)
+		schemas, err := publicationSchemas(ctx, conn, publication)
+		if err != nil {
+			return nil, err
+		}
+		if len(schemas) == 0 {
+			return nil, nil // FOR TABLE only: UNLOGGED tables cannot be published (see doc above)
+		}
+		schemaScope = schemas
 	}
 
 	rows, err := conn.Query(ctx, `
@@ -363,7 +377,8 @@ func listUnloggedCaptureTables(ctx context.Context, conn *pgx.Conn, publication 
 		WHERE c.relkind = 'r' AND c.relpersistence = 'u'
 		  AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
 		  AND n.nspname NOT LIKE 'pg_temp%'
-		  AND n.nspname NOT LIKE 'pg_toast_temp%'`)
+		  AND n.nspname NOT LIKE 'pg_toast_temp%'
+		  AND ($1::text[] IS NULL OR n.nspname = ANY($1))`, schemaScope)
 	if err != nil {
 		return nil, fmt.Errorf("pgcapture: scanning for UNLOGGED tables: %w", err)
 	}
@@ -375,8 +390,8 @@ func listUnloggedCaptureTables(ctx context.Context, conn *pgx.Conn, publication 
 		if err := rows.Scan(&schema, &table); err != nil {
 			return nil, fmt.Errorf("pgcapture: scanning UNLOGGED tables: %w", err)
 		}
-		// Under FOR ALL TABLES the captured set is every user table narrowed by the
-		// client schema/table filter (the zero Filters accepts all), so honor it here.
+		// The captured set is the publication scope narrowed by the client
+		// schema/table filter (the zero Filters accepts all), so honor it here.
 		if filters.Matches(schema, table) {
 			unlogged = append(unlogged, schema+"."+table)
 		}
@@ -386,6 +401,51 @@ func listUnloggedCaptureTables(ctx context.Context, conn *pgx.Conn, publication 
 	}
 	sort.Strings(unlogged)
 	return unlogged, nil
+}
+
+// publicationSchemas returns the schema names a FOR TABLES IN SCHEMA publication
+// (PostgreSQL 15+) covers; empty when the publication has no schema members. On a
+// server predating pg_publication_namespace (PG 14 and older, SQLSTATE 42P01
+// undefined_table) it returns empty rather than an error: schema-scoped publications
+// cannot exist there, so there is nothing to enumerate — an advisory guard must not
+// break the preflight or the doctor on an older server. (#1211)
+func publicationSchemas(ctx context.Context, conn *pgx.Conn, publication string) ([]string, error) {
+	rows, err := conn.Query(ctx, `
+		SELECT n.nspname
+		FROM pg_publication_namespace pn
+		JOIN pg_publication p ON p.oid = pn.pnpubid
+		JOIN pg_namespace n ON n.oid = pn.pnnspid
+		WHERE p.pubname = $1`, publication)
+	if err != nil {
+		if isUndefinedTable(err) {
+			return nil, nil // pre-15 server: schema-scoped publications do not exist
+		}
+		return nil, fmt.Errorf("pgcapture: reading publication %q schema members for the UNLOGGED check: %w", publication, err)
+	}
+	defer rows.Close()
+
+	var schemas []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, fmt.Errorf("pgcapture: scanning publication %q schema members: %w", publication, err)
+		}
+		schemas = append(schemas, s)
+	}
+	if err := rows.Err(); err != nil {
+		if isUndefinedTable(err) {
+			return nil, nil // pre-15 server (pgx may defer the error to rows.Err)
+		}
+		return nil, fmt.Errorf("pgcapture: reading publication %q schema members for the UNLOGGED check: %w", publication, err)
+	}
+	return schemas, nil
+}
+
+// isUndefinedTable reports SQLSTATE 42P01 (undefined_table) — how a server answers a
+// query over a catalog relation it does not have (pg_publication_namespace before 15).
+func isUndefinedTable(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "42P01"
 }
 
 // ListUnloggedCaptureTables is the report-only form of the #555 UNLOGGED guard for

--- a/internal/pgcapture/slot_test.go
+++ b/internal/pgcapture/slot_test.go
@@ -1,8 +1,12 @@
 package pgcapture
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 func TestMissingPublishedOps(t *testing.T) {
@@ -89,4 +93,26 @@ func TestRestrictedPublicationError(t *testing.T) {
 			t.Errorf("expected apple before zebra (sorted), got %q", msg)
 		}
 	})
+}
+
+func TestIsUndefinedTable(t *testing.T) {
+	// SQLSTATE 42P01 is how a pre-15 server answers a pg_publication_namespace
+	// query — the ONE error the schema-member enumeration must swallow (#1211).
+	if !isUndefinedTable(&pgconn.PgError{Code: "42P01"}) {
+		t.Error("42P01 should be recognized as undefined_table")
+	}
+	if !isUndefinedTable(fmt.Errorf("wrapped: %w", &pgconn.PgError{Code: "42P01"})) {
+		t.Error("a wrapped 42P01 should be recognized")
+	}
+	// Any OTHER failure (permission, connection, syntax) must surface, not be
+	// silently treated as "no schema members".
+	if isUndefinedTable(&pgconn.PgError{Code: "42501"}) {
+		t.Error("insufficient_privilege must NOT be swallowed")
+	}
+	if isUndefinedTable(errors.New("connection refused")) {
+		t.Error("a non-PgError must NOT be swallowed")
+	}
+	if isUndefinedTable(nil) {
+		t.Error("nil is not an undefined-table error")
+	}
 }

--- a/internal/pgstreamrun/pgdoctor_integration_test.go
+++ b/internal/pgstreamrun/pgdoctor_integration_test.go
@@ -272,4 +272,86 @@ func TestBuildPGReport_CoverageWarnings_Integration(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("unlogged-under-schema-publication", func(t *testing.T) {
+		// #1211: a FOR TABLES IN SCHEMA publication (PG 15+) accepts a schema that
+		// contains UNLOGGED tables — pg_publication_tables silently omits them, the
+		// exact silent-loss shape #555 closed for FOR ALL TABLES. The guard must
+		// enumerate pg_publication_namespace and WARN about UNLOGGED tables in the
+		// published schemas ONLY: the same table shape in an UNPUBLISHED schema is
+		// out of capture scope and must NOT be reported — that absence is what
+		// proves the scan is schema-scoped, not the FOR ALL TABLES scan rerun.
+		var version int
+		if err := conn.QueryRow(ctx, "SELECT current_setting('server_version_num')::int").Scan(&version); err != nil {
+			t.Fatalf("read server_version_num: %v", err)
+		}
+		if version < 150000 {
+			t.Skipf("FOR TABLES IN SCHEMA requires PostgreSQL 15+; server is %d", version)
+		}
+
+		const pub = "bintrail_cov_sch_pub"
+		const schIn = "bintrail_cov_sch_in"   // published via FOR TABLES IN SCHEMA
+		const schOut = "bintrail_cov_sch_out" // NOT published
+		dropAll := func() {
+			bg := context.Background()
+			_, _ = conn.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+			_, _ = conn.Exec(bg, "DROP SCHEMA IF EXISTS "+schIn+" CASCADE")
+			_, _ = conn.Exec(bg, "DROP SCHEMA IF EXISTS "+schOut+" CASCADE")
+		}
+		dropAll()
+		t.Cleanup(dropAll)
+
+		mustExec("CREATE SCHEMA " + schIn)
+		mustExec("CREATE SCHEMA " + schOut)
+		mustExec("CREATE UNLOGGED TABLE " + schIn + ".cov_unlogged (id int PRIMARY KEY, v text)")
+		mustExec("CREATE UNLOGGED TABLE " + schOut + ".cov_unlogged (id int PRIMARY KEY, v text)")
+		mustExec("CREATE PUBLICATION " + pub + " FOR TABLES IN SCHEMA " + schIn)
+
+		// The Tables filter admits BOTH candidates, so the unpublished one being
+		// absent from the detail can only come from the schema scoping itself.
+		r := pgstreamrun.BuildPGReport(ctx, pgstreamrun.PGDoctorConfig{
+			QueryDSN: dsn, SlotName: "bintrail_cov_sch_slot", Publication: pub,
+			Tables: schIn + ".cov_unlogged," + schOut + ".cov_unlogged",
+		})
+		c := findCheck(t, r, "No UNLOGGED tables")
+		if c.Status != doctor.StatusWarn {
+			t.Errorf("No UNLOGGED tables = %s (%s), want warn", c.Status, c.Detail)
+		}
+		if !strings.Contains(c.Detail, schIn+".cov_unlogged") {
+			t.Errorf("detail should name the published schema's UNLOGGED table, got %q", c.Detail)
+		}
+		if strings.Contains(c.Detail, schOut) {
+			t.Errorf("detail must NOT name the unpublished schema %s, got %q", schOut, c.Detail)
+		}
+	})
+
+	t.Run("unlogged-check-clean-under-for-table-publication", func(t *testing.T) {
+		// A plain FOR TABLE publication has no schema members, and PostgreSQL refuses
+		// UNLOGGED members outright — the check must PASS, not WARN "could not check".
+		// On a pre-15 server this same path exercises the pg_publication_namespace
+		// degrade: the catalog does not exist there (SQLSTATE 42P01) and the guard
+		// must treat that as "no schema members", never as a probe failure — the
+		// PG 14 CI cell runs this against a server that genuinely lacks the catalog.
+		const pub = "bintrail_cov_plain_pub"
+		const tbl = "doctor_cov_plain"
+		dropAll := func() {
+			bg := context.Background()
+			_, _ = conn.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+			_, _ = conn.Exec(bg, "DROP TABLE IF EXISTS "+tbl)
+		}
+		dropAll()
+		t.Cleanup(dropAll)
+
+		mustExec("CREATE TABLE " + tbl + " (id int PRIMARY KEY)")
+		mustExec("ALTER TABLE " + tbl + " REPLICA IDENTITY FULL")
+		mustExec("CREATE PUBLICATION " + pub + " FOR TABLE " + tbl)
+
+		r := pgstreamrun.BuildPGReport(ctx, pgstreamrun.PGDoctorConfig{
+			QueryDSN: dsn, SlotName: "bintrail_cov_plain_slot", Publication: pub,
+		})
+		c := findCheck(t, r, "No UNLOGGED tables")
+		if c.Status != doctor.StatusPass {
+			t.Errorf("No UNLOGGED tables = %s (%s), want pass", c.Status, c.Detail)
+		}
+	})
 }


### PR DESCRIPTION
closes #1211

## Summary

The UNLOGGED-table coverage guard (#555) evaluated capture scope only for `FOR ALL TABLES` publications. A `FOR TABLES IN SCHEMA` (PostgreSQL 15+) publication was not covered: an UNLOGGED table pulled into scope by a schema-scoped publication was silently uncaptured with **no warning** — the exact silent-loss shape #555 closed for the `FOR ALL TABLES` case.

- `listUnloggedCaptureTables` now enumerates `pg_publication_namespace` for a non-`FOR ALL TABLES` publication and runs the same `pg_class` `relpersistence='u'` scan restricted to the published schemas. Both surfaces get the coverage through the shared probe: the stream startup preflight (`warnCaptureCoverage`) and `bintrail-pg doctor` (`addUnloggedCheck`).
- **Graceful degrade on pre-15 servers**: `pg_publication_namespace` does not exist before PostgreSQL 15, so the enumeration treats SQLSTATE `42P01` (undefined_table) as "no schema members" — schema-scoped publications cannot exist there — instead of failing the advisory probe. Any other error (permission, connection) still surfaces as the probe-failure WARN.
- Read-only catalog queries only; no change to the pgoutput-client capture posture.
- `docs/postgres.md`: the doctor-check and Limitations entries no longer carve out schema-scoped publications from the warning.

## Testing

Run locally against real PostgreSQL containers (mirroring the `integration-postgres-source` CI job setup):

- **PostgreSQL 16**: `go test -tags integration -race -run TestBuildPGReport ./internal/pgstreamrun/` — all subtests pass, including the two new ones:
  - `unlogged-under-schema-publication`: a `FOR TABLES IN SCHEMA` publication over a schema containing an UNLOGGED table → WARN names it; an identical UNLOGGED table in an **unpublished** schema is NOT reported. The `Tables` filter admits both candidates, so the absence can only come from the schema scoping itself.
  - `unlogged-check-clean-under-for-table-publication`: a plain `FOR TABLE` publication → PASS (no false "could not check" WARN).
- **PostgreSQL 14**: same run — the schema subtest skips (server < 15) and the `FOR TABLE` subtest exercises the `42P01` degrade against a server that genuinely lacks the catalog, asserting PASS (a swallowing failure would surface as the "could not check" WARN the test rejects). The PG 14 CI matrix cell keeps exercising this.
- **Mutation checks** (both caught by `unlogged-under-schema-publication` on PG 16):
  - schema enumeration made dead (schema publications treated as `FOR TABLE`) → FAIL (WARN missing);
  - schema scoping dropped (scan run unrestricted as if `FOR ALL TABLES`) → FAIL (unpublished schema reported).
- `isUndefinedTable` unit-tested without a server: only `42P01` (bare or wrapped) is swallowed; other SQLSTATEs and non-PgErrors surface.
- `go build ./...`, `go vet ./...`, `go vet -tags integration` on the touched packages, full `go test ./... -count=1`, `gofmt` clean on touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
