### PR TITLE
Distinguish an unreadable archive_state from no archives in the query planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a "consolidation candidate", and a comment cannot fail.
 
 ### Fixed
+- **The query planner no longer plans an unreadable `archive_state` as "no
+  archives"** (#1324). `Plan` swallowed every `archive_state` failure at
+  `Debug` and planned as if the table were empty, so two different facts were
+  indistinguishable: an index with no archive tier, and an archive tier that
+  exists but could not be read. Only `ER_NO_SUCH_TABLE` now counts as "no
+  archive tier"; every other failure — a permission denial, a corrupt table, a
+  legacy shape the fallback cannot read — is logged at `Warn` and recorded as
+  `QueryPlan.ArchiveCoverageUnavailable`. The same conflation #816 retired in
+  `status.LoadCoverage`, one layer over.
+  - The console's activity tiles keyed "complete" on that plan: with coverage
+    unread, every archived hour classified as a gap, the archived-hours caveat
+    counted zero, and an `archive_state` read failure rendered as "these
+    counts are complete." The response now says the archive records could not
+    be read and drops the completeness claim.
+  - Gap classification itself is unchanged and stays fail-closed: an hour
+    whose coverage could not be verified is still a gap, so a strict
+    (`AllowGaps=false`) `reconstruct` still refuses — but the real cause now
+    reaches the operator instead of sitting at `Debug` under a message that
+    blames rotation.
 - **The query planner no longer counts archives the read will never open**
   (#1232). Rotation is per-process, so an index capturing more than one source
   has more than one archive destination and nothing makes them archive the same

--- a/internal/console/activity_api.go
+++ b/internal/console/activity_api.go
@@ -190,6 +190,14 @@ func (s *Server) handleActivity(w http.ResponseWriter, r *http.Request) {
 		slog.Warn("console: activity coverage not evaluated", "server", serverID(r), "error", perr)
 		resp.Complete = false
 		resp.Notes = append(resp.Notes, "Coverage for this window could not be checked, so these counts may be missing archived hours.")
+	case plan != nil && plan.ArchiveCoverageUnavailable:
+		// Same stance one layer down (#1324): the planner ran but could not
+		// read archive_state, so every archived hour in the window classified
+		// as a gap and archivedHoursInWindow below would count 0. Before the
+		// plan carried this, an unreadable archive tier rendered as
+		// "complete". (Plan already logged the underlying error at Warn.)
+		resp.Complete = false
+		resp.Notes = append(resp.Notes, "The archive records for this window could not be read, so these counts may be missing archived hours.")
 	case plan != nil:
 		if n := archivedHoursInWindow(plan, since, until); n > 0 {
 			resp.Complete = false

--- a/internal/console/activity_api_test.go
+++ b/internal/console/activity_api_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
 
 	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/query"
@@ -344,6 +345,50 @@ func TestActivityArchivedWindowIsNotComplete(t *testing.T) {
 	}
 	if len(got.Notes) == 0 || !strings.Contains(got.Notes[0], "archived") {
 		t.Errorf("notes must name the archived hours, got %v", got.Notes)
+	}
+}
+
+// TestActivityUnreadableArchiveStateIsNotComplete (#1324): before the plan
+// carried ArchiveCoverageUnavailable, an unreadable archive_state made
+// query.Plan return (plan, nil) with every archived hour classified as a gap
+// — the perr branch never fired, archivedHoursInWindow counted 0, and the
+// tile said "complete" over a window nobody checked. A missing table (1146,
+// an index that never archived) keeps today's behaviour: no note, complete.
+func TestActivityUnreadableArchiveStateIsNotComplete(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		errno        uint16
+		wantComplete bool
+	}{
+		{"unreadable table", 1142, false}, // ER_TABLEACCESS_DENIED_ERROR
+		{"no archive tier", 1146, true},   // ER_NO_SUCH_TABLE
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, closeDB := newSQLMock(t)
+			defer closeDB()
+			now := time.Now().UTC()
+
+			mock.ExpectQuery(`COUNT\(\*\) AS n FROM binlog_events`).WillReturnRows(activityResult())
+			mock.ExpectQuery("PARTITION_NAME FROM information_schema.PARTITIONS").
+				WillReturnRows(sqlmock.NewRows([]string{"PARTITION_NAME"}).AddRow(now.Format("p_2006010215")))
+			mock.ExpectQuery("FROM archive_state").
+				WillReturnError(&mysql.MySQLError{Number: tc.errno, Message: "induced"})
+
+			srv := newBootServer(db)
+			// The planner is dbName-gated; a bundle without one makes Plan a no-op.
+			srv.cm.boot.dbName = "binlog_index"
+
+			code, got, body := getActivity(t, srv, "/api/activity?period=1h")
+			if code != 200 {
+				t.Fatalf("code = %d, body = %s", code, body)
+			}
+			if got.Complete != tc.wantComplete {
+				t.Fatalf("complete = %v, want %v; notes = %v", got.Complete, tc.wantComplete, got.Notes)
+			}
+			if !tc.wantComplete && (len(got.Notes) == 0 || !strings.Contains(got.Notes[0], "could not be read")) {
+				t.Errorf("notes must say the archive records were unreadable, got %v", got.Notes)
+			}
+		})
 	}
 }
 

--- a/internal/query/planner.go
+++ b/internal/query/planner.go
@@ -52,6 +52,17 @@ type QueryPlan struct {
 	// file/date scoping still opens those files; row-level time filters keep
 	// the result set correct.
 	MisfiledArchiveHours []time.Time
+
+	// ArchiveCoverageUnavailable reports that archive_state exists but could
+	// not be read, so archive coverage was NOT evaluated (#1324). Hours the
+	// archives may hold are classified as GapHours — fail-closed for data —
+	// but a caller rendering completeness or naming a cause must key on this:
+	// "complete" was never checked, and "rotated and not archived" was never
+	// established. A genuinely missing archive_state (ER_NO_SUCH_TABLE, an
+	// index that never archived) does NOT set it — there the gaps are the
+	// truth — and neither does noArchive, where skipping the read is the
+	// caller's decision rather than a failure.
+	ArchiveCoverageUnavailable bool
 }
 
 // Plan builds a QueryPlan for the given time range by inspecting live partition
@@ -109,24 +120,39 @@ func Plan(ctx context.Context, db *sql.DB, dbName string, since, until *time.Tim
 		return nil, fmt.Errorf("load partition info for planning: %w", err)
 	}
 
-	// Load archived partition names. Failure is non-fatal: archive_state may
-	// not exist in older indexes. Gap detection still works from live partitions.
+	// Load archived partition names. A missing archive_state (ER_NO_SUCH_TABLE
+	// — an index that never archived) is non-fatal and means there is no
+	// archive tier; gap detection still works from live partitions. Every
+	// OTHER failure is a different fact (#1324, the same conflation #816
+	// retired in status.LoadCoverage): archives may exist that this plan could
+	// not see, so it is recorded on the plan instead of letting "unreadable"
+	// classify as "no archives". Either way cov stays nil — fail-closed: an
+	// hour that could not be verified is a gap, never coverage.
 	//
 	// Skipped entirely when noArchive: those archives are excluded from the
 	// fetch, so reading their coverage here would only mislabel rotated hours as
 	// covered. Leaving archivedHours nil makes buildPlan classify them as gaps.
 	var cov []archiveCoverage
+	var covUnavailable bool
 	if !noArchive {
 		cov, err = loadArchiveCoverage(ctx, db, sourceIDs)
 		if err != nil {
-			slog.Debug("archive_state not available for planning", "error", err)
+			if isMissingTableErr(err) {
+				slog.Debug("archive_state not present; planning from live partitions only", "error", err)
+			} else {
+				slog.Warn("could not read archive coverage for planning; archived hours will be classified as gaps", "error", err)
+				covUnavailable = true
+			}
 			cov = nil
 		}
 	}
 
 	plan := buildPlan(liveHours, expandArchiveHours(cov), rangeStart, rangeEnd, noArchive)
-	if plan != nil && !noArchive {
-		plan.MisfiledArchiveHours = misfiledHours(cov, rangeStart, rangeEnd)
+	if plan != nil {
+		plan.ArchiveCoverageUnavailable = covUnavailable
+		if !noArchive {
+			plan.MisfiledArchiveHours = misfiledHours(cov, rangeStart, rangeEnd)
+		}
 	}
 	return plan, nil
 }
@@ -358,6 +384,16 @@ func sourceScopeClause(sourceIDs []string) (string, []any) {
 		args[i] = id
 	}
 	return " WHERE bintrail_id IN (?" + strings.Repeat(", ?", len(sourceIDs)-1) + ")", args
+}
+
+// isMissingTableErr reports whether err is MySQL's ER_NO_SUCH_TABLE (1146) —
+// the shape an index that never archived shows, as opposed to a table that
+// exists and would not read. Kept narrow to 1146 on purpose, mirroring
+// status.LoadCoverage (#816): widening it re-creates the very conflation
+// #1324 removes.
+func isMissingTableErr(err error) bool {
+	var me *mysql.MySQLError
+	return errors.As(err, &me) && me.Number == 1146
 }
 
 // loadArchiveCoverage returns per-row archive coverage from archive_state.

--- a/internal/query/planner_unavailable_integration_test.go
+++ b/internal/query/planner_unavailable_integration_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+package query_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// #1324: Plan swallowed EVERY loadArchiveCoverage failure with one slog.Debug
+// and planned as if archive_state were empty. The two causes are not the same
+// fact — "this index has no archive tier" makes the gaps true, "I could not
+// read the archive tier" makes them unverified — and collapsing them let the
+// console render "complete" over a window nobody checked, while the CLI told
+// the operator their data was never archived when the real failure sat at
+// Debug. Same conflation #816 retired in status.LoadCoverage, one layer over.
+//
+// This goes to a real database because the discrimination is on a driver
+// error code; a fixture would assert the mapping we wrote rather than the one
+// MySQL produces.
+func TestPlanDistinguishesUnreadableArchivesFromNone(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	db, dbName := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	exec := func(q string) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, q); err != nil {
+			t.Fatalf("exec %q: %v", q, err)
+		}
+	}
+
+	// An hour that is NOT a live partition (rotated out), recorded — when the
+	// table is healthy — in archive_state.
+	hour := time.Date(2020, 1, 2, 3, 0, 0, 0, time.UTC)
+	since, until := hour, hour.Add(30*time.Minute)
+	plan := func(t *testing.T) *query.QueryPlan {
+		t.Helper()
+		p, err := query.Plan(ctx, db, dbName, &since, &until, false, nil)
+		if err != nil {
+			t.Fatalf("Plan must stay non-fatal on an archive_state failure: %v", err)
+		}
+		if p == nil {
+			t.Fatal("Plan returned nil for a bounded range")
+		}
+		return p
+	}
+
+	// Healthy: the archived hour counts as covered and nothing is flagged.
+	exec(`INSERT INTO archive_state (partition_name, bintrail_id, local_path)
+	      VALUES ('p_2020010203', 'src', '/archives/bintrail_id=src/x.parquet')`)
+	p := plan(t)
+	if len(p.GapHours) != 0 || p.ArchiveCoverageUnavailable {
+		t.Errorf("healthy archive_state: gaps=%d unavailable=%v, want 0/false",
+			len(p.GapHours), p.ArchiveCoverageUnavailable)
+	}
+
+	// No archive tier at all (ER_NO_SUCH_TABLE): the gap IS the truth, so no
+	// flag. This is the case the old blanket Debug was written for, and it
+	// must not regress into a warning on every pre-archive index.
+	exec(`DROP TABLE archive_state`)
+	p = plan(t)
+	if len(p.GapHours) != 1 {
+		t.Errorf("no archive tier: %d gap hour(s), want 1", len(p.GapHours))
+	}
+	if p.ArchiveCoverageUnavailable {
+		t.Error("an index with no archive_state was flagged unavailable; 'no archive tier' is a fact, not a failure")
+	}
+
+	// Present but unreadable — a shape missing partition_name entirely, the
+	// "table exists, query fails" class (both the #1037 query and its 1054
+	// legacy fallback fail on it). THE regression: before #1324 this planned
+	// exactly like the case above.
+	exec(`CREATE TABLE archive_state (bintrail_id VARCHAR(64) NOT NULL PRIMARY KEY)`)
+	p = plan(t)
+	if !p.ArchiveCoverageUnavailable {
+		t.Fatal("an unreadable archive_state planned as 'no archives'; the console renders 'complete' off exactly this")
+	}
+	if len(p.GapHours) != 1 {
+		t.Errorf("fail-closed must hold: the unverifiable hour classified as %d gap(s), want 1", len(p.GapHours))
+	}
+
+	// A legacy pre-#1037 shape (partition_name, no min/max_event_ts) reads
+	// through the 1054 fallback: coverage works and nothing is flagged — that
+	// fallback is a supported path, not a failure.
+	exec(`DROP TABLE archive_state`)
+	exec(`CREATE TABLE archive_state (
+	        partition_name VARCHAR(64) NOT NULL,
+	        bintrail_id    VARCHAR(64) NOT NULL,
+	        PRIMARY KEY (partition_name, bintrail_id))`)
+	exec(`INSERT INTO archive_state (partition_name, bintrail_id) VALUES ('p_2020010203', 'src')`)
+	p = plan(t)
+	if len(p.GapHours) != 0 || p.ArchiveCoverageUnavailable {
+		t.Errorf("legacy archive_state shape: gaps=%d unavailable=%v, want 0/false",
+			len(p.GapHours), p.ArchiveCoverageUnavailable)
+	}
+}


### PR DESCRIPTION
closes #1324

## Summary

`Plan` swallowed every `loadArchiveCoverage` failure with one `slog.Debug` and planned as if `archive_state` were empty, so an unreadable archive tier was indistinguishable from an index that never archived. The console's activity endpoint then reported "complete" over a window nobody checked (with coverage unread, every archived hour classified as a gap, `archivedHoursInWindow` counted zero, and the `perr != nil` / "Never assume completeness we could not check" branch could never fire), and a strict `AllowGaps=false` reconstruct refused with "rotated and not archived" while the real cause sat at `Debug`.

Same discrimination #1318 applied in `status.LoadCoverage` (#816), one layer over:

- Only `ER_NO_SUCH_TABLE` (1146) counts as "no archive tier" — today's behaviour, kept: the gaps there are the truth, and no pre-archive index grows a warning. The 1054 legacy-shape fallback inside `loadArchiveCoverage` stays a supported read path, not a failure.
- Every other failure is logged at `Warn` (was `Debug`) and recorded as a new `QueryPlan.ArchiveCoverageUnavailable` field. Gap classification is unchanged and fail-closed: an hour whose coverage could not be verified is still a gap, never coverage — so strict readers still refuse, but the operator now sees why.
- The console's activity handler keys on the field: `complete` goes `false` with a note that the archive records could not be read, instead of asserting completeness.

Per the scope guard, the archive scope parameter keeps its `[]string` shape — the named-type refactor is #1327.

## Testing

- `TestPlanDistinguishesUnreadableArchivesFromNone` (`internal/query`, `//go:build integration`) ran against the real MySQL container at 127.0.0.1:13306 — verified via `-v` `--- PASS` lines, not a silent skip. It drives all four shapes through real driver errors: healthy `archive_state` (covered, unflagged), `DROP TABLE` → 1146 (gap is truth, unflagged), a shape missing `partition_name` → 1054 on both the #1037 query and its legacy fallback (flagged unavailable, hour still a gap), and a legacy pre-#1037 shape (reads through the fallback, unflagged).
- `TestActivityUnreadableArchiveStateIsNotComplete` (`internal/console`, sqlmock) pins the wiring through the handler: a 1142 on `archive_state` → `complete: false` + a note naming the unreadable archive records; a 1146 → `complete: true`, no note.
- Mutation checks — each reverted behavior made a test fail:
  - discrimination removed (every error back to the old Debug-and-nil path) → integration test fails at the unreadable case, console test fails with `complete = true … notes = []`;
  - discrimination inverted (`!= 1146`) → both "no archive tier" cases fail (flag on a missing table);
  - console branch disabled → console test fails with `complete = true`.
- Full suite: `go build ./...`, `go test ./... -count=1` (green), `go vet ./...`, `go vet -tags integration ./internal/query/... ./internal/console/...`, `gofmt -l` empty on changed files; the pre-existing `TestPlanScopesCoverageToTheArchivesTheReadOpens` integration test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
