### PR TITLE
console: hide archive-only schemas from a profiled session's dropdown

### DIFF
--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -612,7 +612,8 @@ func (s *Server) handleSchemas(w http.ResponseWriter, r *http.Request) {
 	}
 	schema := r.URL.Query().Get("schema")
 	if schema == "" {
-		names, snapshotOnly, err := b.distinctSchemas(r.Context())
+		restricted := sessionRestricted(r)
+		names, snapshotOnly, err := b.distinctSchemas(r.Context(), restricted)
 		if err != nil {
 			writeJSONError(w, http.StatusInternalServerError, err.Error())
 			return
@@ -620,10 +621,11 @@ func (s *Server) handleSchemas(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, schemasResponse{
 			Schemas:      names,
 			SnapshotOnly: snapshotOnly,
-			// Suppressed under noArchive: there the snapshot half is skipped by
-			// design (archives unreachable), so a broken resolver changes nothing
-			// about this listing and the flag would only read as noise.
-			SnapshotUnavailable: b.resolverUnavailable && !b.noArchive,
+			// Suppressed under noArchive and under a profiled session: there the
+			// snapshot half is skipped by design (archives unreachable), so a
+			// broken resolver changes nothing about this listing and the flag
+			// would only read as noise.
+			SnapshotUnavailable: b.resolverUnavailable && !b.noArchive && !restricted,
 		})
 		return
 	}
@@ -655,9 +657,10 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 // from the source is absent from the latest snapshot, yet its archived events
 // are still recoverable and must stay listed.
 //
-// The snapshot half is gated on archives being reachable (see below), so this
-// is strictly additive: a server that cannot read archives keeps the exact
-// pre-#1065 listing.
+// The snapshot half is gated on archives being reachable BY THIS REQUEST (see
+// below), so this is strictly additive: a server that cannot read archives —
+// and a session whose data profile excludes them — keeps the exact pre-#1065
+// listing.
 //
 // One residual gap, out of scope — this endpoint answers "which schemas does
 // this index know of", NOT "which schemas have retrievable data in a given
@@ -671,7 +674,13 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 //
 // The resolver is loaded once when the bundle opens (manager.go, server.go), so
 // a snapshot taken after the console started is not picked up until restart.
-func (b *bundle) distinctSchemas(ctx context.Context) (schemas, snapshotOnly []string, err error) {
+//
+// restricted carries sessionRestricted(r): a session with a data profile is
+// served archive-excluded (the Parquet path runs no redaction — see
+// fetchRestricted), so for that session the snapshot half is exactly as
+// unreachable as it is under --no-archive, and listing it would offer targets
+// the session's every query provably answers zero rows for (#1326).
+func (b *bundle) distinctSchemas(ctx context.Context, restricted bool) (schemas, snapshotOnly []string, err error) {
 	rows, err := b.db.QueryContext(ctx, "SELECT DISTINCT schema_name FROM binlog_events ORDER BY schema_name")
 	if err != nil {
 		return nil, nil, err
@@ -681,13 +690,14 @@ func (b *bundle) distinctSchemas(ctx context.Context) (schemas, snapshotOnly []s
 	if err != nil {
 		return nil, nil, err
 	}
-	if b.noArchive {
-		// Archives are never consulted for this server (--no-archive, or ANY
-		// active RBAC profile — see newBundleDerived), so a schema that survives
-		// only in the snapshot is unreachable BY CONSTRUCTION: the union's whole
-		// justification is that the archives still answer. Advertising it would
-		// offer the operator a target this server provably cannot return a row
-		// for. Live-only here is byte-identical to the pre-#1065 behaviour.
+	if b.noArchive || restricted {
+		// Archives are never consulted for this read (--no-archive or a startup
+		// RBAC profile — see newBundleDerived — or THIS session's data profile),
+		// so a schema that survives only in the snapshot is unreachable BY
+		// CONSTRUCTION: the union's whole justification is that the archives
+		// still answer. Advertising it would offer the operator a target this
+		// read provably cannot return a row for. Live-only here is
+		// byte-identical to the pre-#1065 behaviour.
 		return live, nil, nil
 	}
 	schemas, snapshotOnly = mergeSchemaNames(live, b.resolver)

--- a/internal/console/api_test.go
+++ b/internal/console/api_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 
+	"github.com/dbtrail/dbtrail/ext"
 	"github.com/dbtrail/dbtrail/internal/metadata"
 	"github.com/dbtrail/dbtrail/internal/parser"
 	"github.com/dbtrail/dbtrail/internal/query"
@@ -423,7 +424,7 @@ func TestDistinctSchemasUnionsSnapshot(t *testing.T) {
 		"app.customers": {Schema: "app", Table: "customers"},
 		"shop.items":    {Schema: "shop", Table: "items"},
 	})}
-	got, snapOnly, err := b.distinctSchemas(context.Background())
+	got, snapOnly, err := b.distinctSchemas(context.Background(), false)
 	if err != nil {
 		t.Fatalf("distinctSchemas: %v", err)
 	}
@@ -487,7 +488,7 @@ func TestDistinctSchemasNoArchiveKeepsLiveOnly(t *testing.T) {
 	b := &bundle{db: db, noArchive: true, resolver: metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
 		"archived.orders": {Schema: "archived", Table: "orders"},
 	})}
-	got, snapOnly, err := b.distinctSchemas(context.Background())
+	got, snapOnly, err := b.distinctSchemas(context.Background(), false)
 	if err != nil {
 		t.Fatalf("distinctSchemas: %v", err)
 	}
@@ -496,6 +497,36 @@ func TestDistinctSchemasNoArchiveKeepsLiveOnly(t *testing.T) {
 	}
 	if len(snapOnly) != 0 {
 		t.Errorf("--no-archive snapshot-only = %v, want none (snapshot half skipped)", snapOnly)
+	}
+}
+
+// TestDistinctSchemasRestrictedSessionKeepsLiveOnly pins the #1326 gate: a
+// session carrying a data profile is served archive-excluded (the Parquet path
+// runs no redaction), so even on a server that DOES read archives the snapshot
+// half must be skipped for it — otherwise the dropdown offers archive-only
+// schemas the session's every query answers zero rows for.
+func TestDistinctSchemasRestrictedSessionKeepsLiveOnly(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("SELECT DISTINCT schema_name FROM binlog_events").
+		WillReturnRows(sqlmock.NewRows([]string{"schema_name"}).AddRow("live"))
+
+	// noArchive is FALSE: the server reads archives, only the session doesn't.
+	b := &bundle{db: db, resolver: metadata.NewResolverFromTables(1, map[string]*metadata.TableMeta{
+		"archived.orders": {Schema: "archived", Table: "orders"},
+	})}
+	got, snapOnly, err := b.distinctSchemas(context.Background(), true)
+	if err != nil {
+		t.Fatalf("distinctSchemas: %v", err)
+	}
+	if want := []string{"live"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("restricted-session schemas = %v, want %v (snapshot-only schema is unreachable for this session)", got, want)
+	}
+	if len(snapOnly) != 0 {
+		t.Errorf("restricted-session snapshot-only = %v, want none (snapshot half skipped)", snapOnly)
 	}
 }
 
@@ -546,15 +577,18 @@ func TestHandleSchemasProvenance(t *testing.T) {
 // (#1071): when the resolver failed to load for a reason other than
 // ErrNoSnapshots, the response says the snapshot half was skipped instead of
 // answering an empty list indistinguishable from the #1065 bug. Under
-// --no-archive that half is skipped by design, so the flag stays off there.
+// --no-archive — and for a profiled session (#1326) — that half is skipped by
+// design, so the flag stays off there.
 func TestHandleSchemasSnapshotUnavailable(t *testing.T) {
 	for _, c := range []struct {
 		name      string
 		noArchive bool
+		profiled  bool
 		want      bool
 	}{
-		{"archives reachable flags the skip", false, true},
-		{"no-archive suppresses the flag", true, false},
+		{"archives reachable flags the skip", false, false, true},
+		{"no-archive suppresses the flag", true, false, false},
+		{"profiled session suppresses the flag", false, true, false},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			db, mock, err := sqlmock.New()
@@ -568,8 +602,13 @@ func TestHandleSchemasSnapshotUnavailable(t *testing.T) {
 			s := newBootServer(db)
 			s.cm.boot.noArchive = c.noArchive
 			s.cm.boot.resolverUnavailable = true // loadResolver's Warn path: nil resolver, real failure
+			req := httptest.NewRequest("GET", "/api/schemas", nil)
+			if c.profiled {
+				req = req.WithContext(context.WithValue(req.Context(),
+					policyCtxKey{}, &ext.AccessPolicy{Profile: "analyst", Permissions: ext.AllPermissions()}))
+			}
 			rec := httptest.NewRecorder()
-			s.handleSchemas(rec, httptest.NewRequest("GET", "/api/schemas", nil))
+			s.handleSchemas(rec, req)
 			if rec.Code != 200 {
 				t.Fatalf("code = %d, want 200 (body %s)", rec.Code, rec.Body.String())
 			}

--- a/internal/console/schemas_profile_integration_test.go
+++ b/internal/console/schemas_profile_integration_test.go
@@ -1,0 +1,89 @@
+//go:build integration
+
+package console
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// The unit tests prove distinctSchemas skips the snapshot half when told the
+// session is restricted. This proves the HANDLER tells it: GET /api/schemas is
+// driven end to end against a real index, once unprofiled and once with a real
+// profiled session, and the two listings must differ on exactly the
+// archive-only schema (#1326).
+//
+// Mutating handleSchemas to pass false, or distinctSchemas to ignore the
+// parameter, leaves the unit tests passing and breaks this one.
+func TestIntegrationProfiledSessionSchemaDropdownIsLiveOnly(t *testing.T) {
+	// A server that DOES read archives (NoArchive unset), so the only exclusion
+	// under test is the session's own profile — with NoArchive:true the control
+	// case would drop the archive-only schema for the server-wide reason and
+	// prove nothing about profiles.
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	// One live schema...
+	testutil.InsertEvent(t, db, "bin.000001", 4, 40, "2026-06-01 12:00:00", nil,
+		"app", "users", 1 /*INSERT*/, "1", nil, nil, []byte(`{"id":1,"name":"alice"}`))
+	// ...and a snapshot that also knows a schema with NO live events — the
+	// archive-only shape from the issue: it survives in Parquet and the latest
+	// snapshot, but a profiled (archive-excluded) read can never reach it.
+	// Inserted BEFORE New: the resolver is loaded once when the bundle opens.
+	testutil.InsertSnapshot(t, db, 1, "2026-06-01 11:00:00", "app", "users", "id", 1, "PRI", "int", "NO")
+	testutil.InsertSnapshot(t, db, 1, "2026-06-01 11:00:00", "legacy_billing", "invoices", "id", 1, "PRI", "int", "NO")
+	// The profile exists in the index, matching a real deployment: the schemas
+	// endpoint doesn't resolve it, but the session's data reads do, and a
+	// nonexistent profile would be refused 403 there.
+	if _, err := db.Exec(`INSERT INTO profiles (name) VALUES ('analyst')`); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	srv, err := New(Config{DB: db, DBName: dbName, Listen: "127.0.0.1:8090", Token: intToken})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	get := func(t *testing.T, profile string) schemasResponse {
+		t.Helper()
+		r := httptest.NewRequest("GET", "http://127.0.0.1:8090/api/schemas", nil)
+		r.Host = "127.0.0.1:8090"
+		if profile != "" {
+			r = r.WithContext(context.WithValue(r.Context(),
+				policyCtxKey{}, &ext.AccessPolicy{Profile: profile, Permissions: ext.AllPermissions()}))
+		}
+		w := httptest.NewRecorder()
+		srv.handleSchemas(w, r)
+		if w.Code != 200 {
+			t.Fatalf("schemas code = %d, body = %s", w.Code, w.Body.String())
+		}
+		var sr schemasResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &sr); err != nil {
+			t.Fatalf("decode: %v\n%s", err, w.Body.String())
+		}
+		return sr
+	}
+
+	// Control first, and non-vacuously: the unprofiled listing must OFFER the
+	// archive-only schema, or the profiled assertion below tests a fixture in
+	// which there was nothing to withhold.
+	unprofiled := get(t, "")
+	if want := []string{"app", "legacy_billing"}; !reflect.DeepEqual(unprofiled.Schemas, want) {
+		t.Fatalf("unprofiled schemas = %v, want %v (the archive-backed union)", unprofiled.Schemas, want)
+	}
+	if want := []string{"legacy_billing"}; !reflect.DeepEqual(unprofiled.SnapshotOnly, want) {
+		t.Fatalf("unprofiled snapshot_only = %v, want %v", unprofiled.SnapshotOnly, want)
+	}
+
+	profiled := get(t, "analyst")
+	if want := []string{"app"}; !reflect.DeepEqual(profiled.Schemas, want) {
+		t.Errorf("profiled schemas = %v, want %v — the dropdown offers a schema this session's every query answers zero rows for", profiled.Schemas, want)
+	}
+	if len(profiled.SnapshotOnly) != 0 {
+		t.Errorf("profiled snapshot_only = %v, want none (snapshot half skipped)", profiled.SnapshotOnly)
+	}
+}


### PR DESCRIPTION
closes #1326

## Summary

A session carrying an RBAC data profile is served archive-excluded (the Parquet path runs no redaction — see `fetchRestricted`, #1321), but `/api/schemas` built its listing as the union of live-observed + snapshot-listed schemas gated only on `b.noArchive`. On a console that DOES read archives — exactly the deployment where per-session profiles are the live path — the dropdown offered snapshot-only schemas the session's every query provably answers zero rows for. #1321 made the resulting empty result explicable, but the dropdown kept promising a target the session cannot reach, and the two surfaces contradicted each other.

This gates the snapshot half of the union on `sessionRestricted(r)` as well as `b.noArchive` (the issue's own proposed fix): `handleSchemas` passes the session predicate into `distinctSchemas`, which now skips the snapshot half for a profiled session exactly as it does under `--no-archive`. The `snapshot_unavailable` flag is suppressed under the same predicate, for the same reason it was already suppressed under `--no-archive`: when the snapshot half is skipped by design, a broken resolver changes nothing about the listing and the flag would only read as noise.

Unprofiled sessions and `--no-archive` consoles are byte-identical to before.

## Testing

- `TestDistinctSchemasRestrictedSessionKeepsLiveOnly` (unit, sqlmock): a bundle whose SERVER reads archives (`noArchive` false) with a snapshot-only schema loaded — `restricted=true` must return live-only, no `snapshot_only` entries.
- `TestHandleSchemasSnapshotUnavailable` gains a `profiled session suppresses the flag` case (real handler, request carrying a policy context).
- `TestIntegrationProfiledSessionSchemaDropdownIsLiveOnly` (integration, real MySQL): drives the real `handleSchemas` end to end. The server has `NoArchive` UNSET so the only exclusion under test is the session's profile; the profile exists in the `profiles` table as it would in a real deployment. The unprofiled control asserts the archive-only schema IS offered (`schemas` = `[app, legacy_billing]`, `snapshot_only` = `[legacy_billing]`) — without that the profiled assertion would test a fixture with nothing to withhold — and the profiled session must see `[app]` only.
- Mutation-checked: reverting the gate to `b.noArchive` alone fails both `TestDistinctSchemasRestrictedSessionKeepsLiveOnly` and the integration test.
- `go build ./...`, `go vet ./...` (also `-tags integration`), full `go test ./... -count=1`, and the integration run against the local MySQL container all green; `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
