### PR TITLE
status: report a coverage/archives read failure instead of deleting the section

### DIFF
--- a/internal/status/collect_status_error_integration_test.go
+++ b/internal/status/collect_status_error_integration_test.go
@@ -1,0 +1,145 @@
+//go:build integration
+
+package status_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/status"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// #1323: CollectStatus swallowed a LoadCoverage or LoadArchiveStats failure
+// with a slog.Warn, leaving the field nil — the whole section then vanished
+// from both renderings, and a consumer read the absence as an affirmative
+// fact ("no archives exist", "nothing to restore from"). The same class #816
+// closed one layer down, at the frame above.
+//
+// This goes to a real database because the discrimination is on driver error
+// codes (a missing table must NOT alarm; anything else must), and because the
+// wiring under test is CollectStatus itself — the unit render tests set the
+// fields by hand and would pass with the swallow restored.
+func TestCollectStatus_readFailuresSurfaceNotVanish(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	db, dbName := testutil.CreateTestDB(t)
+	if err := indexer.CreateIndexTables(ctx, db, 4, false, nil); err != nil {
+		t.Fatalf("CreateIndexTables: %v", err)
+	}
+	exec := func(q string) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, q); err != nil {
+			t.Fatalf("exec %q: %v", q, err)
+		}
+	}
+	collect := func() *status.StatusData {
+		t.Helper()
+		d, err := status.CollectStatus(ctx, db, dbName)
+		if err != nil {
+			t.Fatalf("CollectStatus must stay non-fatal — status is a report, not a gate: %v", err)
+		}
+		return d
+	}
+
+	// Healthy index: both sections load, neither error field is set.
+	d := collect()
+	if d.Coverage == nil || d.CoverageErr != nil {
+		t.Fatalf("healthy index: coverage=%v err=%v", d.Coverage, d.CoverageErr)
+	}
+	if d.ArchivesErr != nil {
+		t.Fatalf("healthy index: ArchivesErr = %v", d.ArchivesErr)
+	}
+
+	// No archive tier at all (ER_NO_SUCH_TABLE): the absent section IS the
+	// truth — no error, no tombstone. This is every pre-archive index, and it
+	// must not start crying wolf (#816's stance, applied to LoadArchiveStats).
+	exec(`DROP TABLE archive_state`)
+	d = collect()
+	if d.ArchivesErr != nil {
+		t.Errorf("an index with no archive_state was flagged unreadable; 'no archive tier' is a fact, not a failure: %v", d.ArchivesErr)
+	}
+	if d.Archives != nil {
+		t.Errorf("no archive_state but Archives = %+v", d.Archives)
+	}
+
+	// Present but unreadable — a legacy shape missing row_count (1054), the
+	// same "table exists, query fails" class the #816 test uses. THE bug: this
+	// used to be indistinguishable from the case above.
+	exec(`CREATE TABLE archive_state (
+	        partition_name VARCHAR(64) NOT NULL,
+	        bintrail_id    VARCHAR(64) NOT NULL,
+	        PRIMARY KEY (partition_name, bintrail_id))`)
+	d = collect()
+	if d.ArchivesErr == nil {
+		t.Fatal("an unreadable archive_state left ArchivesErr nil; the section will silently vanish")
+	}
+	if d.Archives != nil {
+		t.Errorf("unreadable archive_state but Archives = %+v", d.Archives)
+	}
+	var text bytes.Buffer
+	d.Write(&text)
+	if !strings.Contains(text.String(), "=== Archives ===") || !strings.Contains(text.String(), "NOT READ") {
+		t.Errorf("the text report has no Archives tombstone:\n%s", text.String())
+	}
+	var js bytes.Buffer
+	if err := d.WriteJSON(&js); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	type sectionKeys struct {
+		Archives      *json.RawMessage `json:"archives"`
+		ArchivesError *struct {
+			Error string `json:"error"`
+		} `json:"archives_error"`
+		Coverage      *json.RawMessage `json:"coverage"`
+		CoverageError *struct {
+			Error string `json:"error"`
+		} `json:"coverage_error"`
+	}
+	var parsed sectionKeys
+	if err := json.Unmarshal(js.Bytes(), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, js.String())
+	}
+	if parsed.ArchivesError == nil || parsed.ArchivesError.Error == "" {
+		t.Errorf("JSON lacks archives_error; a consumer reads the absent archives key as 'no archives exist':\n%s", js.String())
+	}
+
+	// LoadCoverage failing outright — here binlog_events gone (the aggregate
+	// scan is the statement in this package most likely to die at scale; any
+	// error there must land in CoverageErr, there is no benign sub-case).
+	// index_state and the partition listing still load, so CollectStatus
+	// itself succeeds and the failure has to be carried, not returned.
+	exec(`DROP TABLE binlog_events`)
+	d = collect()
+	if d.CoverageErr == nil {
+		t.Fatal("a failed LoadCoverage left CoverageErr nil; the coverage section will silently vanish")
+	}
+	if d.Coverage != nil {
+		t.Errorf("failed LoadCoverage but Coverage = %+v", d.Coverage)
+	}
+	text.Reset()
+	d.Write(&text)
+	if !strings.Contains(text.String(), "=== Restore Coverage ===") || !strings.Contains(text.String(), "NOT READ") {
+		t.Errorf("the text report has no coverage tombstone:\n%s", text.String())
+	}
+	js.Reset()
+	if err := d.WriteJSON(&js); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	parsed = sectionKeys{} // Unmarshal leaves absent keys untouched; a stale Coverage would mask its omission
+	if err := json.Unmarshal(js.Bytes(), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, js.String())
+	}
+	if parsed.Coverage != nil {
+		t.Errorf("a read error must not fabricate a coverage object:\n%s", js.String())
+	}
+	if parsed.CoverageError == nil || !strings.Contains(parsed.CoverageError.Error, "binlog_events") {
+		t.Errorf("JSON lacks coverage_error with the underlying cause:\n%s", js.String())
+	}
+}

--- a/internal/status/section_error_render_test.go
+++ b/internal/status/section_error_render_test.go
@@ -1,0 +1,113 @@
+package status
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// ─── coverage / archives read failures (#1323) ──────────────────────────────────
+//
+// A FAILURE to load a section (err set, data nil) must render AS a failure in
+// both formats — never as the section's silent absence, which a consumer reads
+// as an affirmative fact ("no archives exist", "nothing to restore from").
+// These are pure functions over StatusData, so they live in a plain unit test
+// (the coverage_render_test.go stance); the CollectStatus wiring that SETS the
+// fields is pinned by the integration test.
+
+func TestStatusData_coverageReadError_text(t *testing.T) {
+	var buf bytes.Buffer
+	(&StatusData{CoverageErr: errors.New("query binlog_events coverage: Error 3024: max_execution_time exceeded")}).Write(&buf)
+	out := buf.String()
+	for _, want := range []string{"=== Restore Coverage ===", "NOT READ", "UNKNOWN, not empty", "max_execution_time"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("a coverage read error must surface %q in the text report\n--- output ---\n%s", want, out)
+		}
+	}
+
+	// No error, no coverage (never collected) → no tombstone.
+	var empty bytes.Buffer
+	(&StatusData{}).Write(&empty)
+	if strings.Contains(empty.String(), "NOT READ") || strings.Contains(empty.String(), "=== Restore Coverage ===") {
+		t.Errorf("no read error must mean no coverage tombstone:\n%s", empty.String())
+	}
+}
+
+func TestStatusData_archivesReadError_text(t *testing.T) {
+	var buf bytes.Buffer
+	(&StatusData{ArchivesErr: errors.New("Error 1142: SELECT command denied on archive_state")}).Write(&buf)
+	out := buf.String()
+	for _, want := range []string{"=== Archives ===", "NOT READ", "read failure", "1142"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("an archive_state read error must surface %q in the text report\n--- output ---\n%s", want, out)
+		}
+	}
+
+	// No error, no archives (no archive tier) → no section, no tombstone.
+	var empty bytes.Buffer
+	(&StatusData{}).Write(&empty)
+	if strings.Contains(empty.String(), "=== Archives ===") {
+		t.Errorf("an index with no archive tier must not render an Archives block:\n%s", empty.String())
+	}
+}
+
+func TestStatusData_sectionReadErrors_json(t *testing.T) {
+	decode := func(t *testing.T, d *StatusData) (raw string, parsed struct {
+		Archives      *json.RawMessage `json:"archives"`
+		ArchivesError *struct {
+			Error string `json:"error"`
+		} `json:"archives_error"`
+		Coverage      *json.RawMessage `json:"coverage"`
+		CoverageError *struct {
+			Error string `json:"error"`
+		} `json:"coverage_error"`
+	}) {
+		t.Helper()
+		var buf bytes.Buffer
+		if err := d.WriteJSON(&buf); err != nil {
+			t.Fatalf("WriteJSON: %v", err)
+		}
+		if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+			t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+		}
+		return buf.String(), parsed
+	}
+
+	t.Run("coverage read error", func(t *testing.T) {
+		raw, got := decode(t, &StatusData{CoverageErr: errors.New("read timeout")})
+		if got.Coverage != nil {
+			t.Errorf("a read error must not fabricate a coverage object (its zero fields would read as a real empty index):\n%s", raw)
+		}
+		if got.CoverageError == nil {
+			t.Fatalf("coverage_error missing — the read failure was silently omitted:\n%s", raw)
+		}
+		if !strings.Contains(got.CoverageError.Error, "read timeout") {
+			t.Errorf("coverage_error.error must carry the underlying cause, got %q", got.CoverageError.Error)
+		}
+	})
+
+	t.Run("archives read error", func(t *testing.T) {
+		raw, got := decode(t, &StatusData{ArchivesErr: errors.New("Error 1054: Unknown column 'row_count'")})
+		if got.Archives != nil {
+			t.Errorf("a read error must not fabricate an archives object:\n%s", raw)
+		}
+		if got.ArchivesError == nil {
+			t.Fatalf("archives_error missing — the read failure was silently omitted:\n%s", raw)
+		}
+		if !strings.Contains(got.ArchivesError.Error, "1054") {
+			t.Errorf("archives_error.error must carry the underlying cause, got %q", got.ArchivesError.Error)
+		}
+	})
+
+	t.Run("healthy report omits both keys", func(t *testing.T) {
+		raw, got := decode(t, &StatusData{Archives: &ArchiveStats{TotalFiles: 1}, Coverage: &CoverageInfo{TotalEvents: 3}})
+		if got.ArchivesError != nil || got.CoverageError != nil {
+			t.Errorf("a healthy report must omit the section-error keys (a monitor's schema depends on absence):\n%s", raw)
+		}
+		if got.Archives == nil || got.Coverage == nil {
+			t.Errorf("healthy data lost its sections:\n%s", raw)
+		}
+	})
+}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -640,6 +640,23 @@ type StatusData struct {
 	// not silent). json:"-" — StatusData is rendered via the manual jsonSummary mapping,
 	// never marshalled directly; the tag is insurance against a future direct marshal.
 	StreamErr error `json:"-"`
+	// ArchivesErr records a failure to READ archive_state for the Archives
+	// section (StreamErr's sibling, #1323) — as distinct from an index with no
+	// archive tier at all (Archives==nil, ArchivesErr==nil: ER_NO_SUCH_TABLE,
+	// which the absent section describes correctly). When set, the output must
+	// render the section as unreadable rather than omit it: a consumer reading
+	// "no archives section" concludes "no archives exist" while the Parquet may
+	// be sitting in the bucket.
+	ArchivesErr error `json:"-"`
+	// CoverageErr records a LoadCoverage failure (#1323) — the likeliest
+	// at-scale one being the full binlog_events scan hitting max_execution_time
+	// or a lost connection. #816 taught LoadCoverage to report an unreadable
+	// archive tier INSIDE its result; this is the frame above, where the whole
+	// result is lost: without it the report prints no restore window, no error,
+	// and exits 0 — a read failure rendering as an affirmative fact about the
+	// data. When set, Coverage is nil and the output must carry a tombstone in
+	// both renderings.
+	CoverageErr error `json:"-"`
 }
 
 // BaselineInfo holds metadata about a discovered baseline Parquet file.
@@ -695,13 +712,28 @@ func CollectStatus(ctx context.Context, db *sql.DB, dbName string) (*StatusData,
 	}
 
 	if archives, err := LoadArchiveStats(ctx, db); err != nil {
-		slog.Warn("could not load archive stats", "error", err)
+		// Same discrimination LoadCoverage applies to the same table (#816,
+		// #1323): a missing archive_state is an index with no archive tier —
+		// a fact the absent section describes correctly, and flagging it would
+		// put a scary banner on every pre-archive index. Anything else means
+		// archives may exist that we could not see, and the report must say so
+		// instead of rendering the failure as "no archives".
+		if isMissingTableErr(err) {
+			slog.Debug("archive_state not present; no archive tier to report", "error", err)
+		} else {
+			slog.Warn("could not load archive stats; the Archives section will report itself unreadable", "error", err)
+			d.ArchivesErr = err
+		}
 	} else {
 		d.Archives = archives
 	}
 
 	if coverage, err := LoadCoverage(ctx, db); err != nil {
-		slog.Warn("could not load coverage info", "error", err)
+		slog.Warn("could not load coverage info; the coverage section will report itself unreadable", "error", err)
+		// Record the failure so the output renders a coverage tombstone instead
+		// of silently omitting the section — a monitor keyed on
+		// coverage.archives_unavailable must see coverage_error, not nothing.
+		d.CoverageErr = err
 	} else {
 		d.Coverage = coverage
 	}
@@ -739,6 +771,12 @@ func (d *StatusData) Write(w io.Writer) {
 	if d.Stream == nil && d.StreamErr != nil {
 		writeStreamUnavailable(w, d.StreamErr)
 	}
+	if d.Archives == nil && d.ArchivesErr != nil {
+		writeArchivesUnavailable(w, d.ArchivesErr)
+	}
+	if d.Coverage == nil && d.CoverageErr != nil {
+		writeCoverageUnavailable(w, d.CoverageErr)
+	}
 	writeBaselines(w, d.Baselines)
 }
 
@@ -754,9 +792,38 @@ func writeStreamUnavailable(w io.Writer, err error) {
 	fmt.Fprintln(w)
 }
 
+// writeArchivesUnavailable renders a visible Archives block when archive_state
+// could not be READ (ArchivesErr set, Archives nil) — writeStreamUnavailable's
+// sibling (#1323). Distinct from a missing table (no block): "no archive tier"
+// is a fact the absent section describes correctly, while a read failure
+// rendered the same way tells the operator archives do not exist when they may
+// simply be unreadable right now.
+func writeArchivesUnavailable(w io.Writer, err error) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "=== Archives ===")
+	fmt.Fprintf(w, "  ⚠ NOT READ — archive_state could not be queried: %v\n", err)
+	fmt.Fprintln(w, "  This is a read failure, not \"no archives\": archived data may exist that")
+	fmt.Fprintln(w, "  is not shown here. Re-run status to retry.")
+	fmt.Fprintln(w)
+}
+
+// writeCoverageUnavailable renders a visible Restore Coverage block when
+// LoadCoverage itself failed (CoverageErr set, Coverage nil) — the frame above
+// the #816 in-section flag (#1323). Without it the report prints no restore
+// window at all and an operator mid-incident reads the silence as "nothing to
+// restore from".
+func writeCoverageUnavailable(w io.Writer, err error) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "=== Restore Coverage ===")
+	fmt.Fprintf(w, "  ⚠ NOT READ — coverage could not be computed: %v\n", err)
+	fmt.Fprintln(w, "  The restore window is UNKNOWN, not empty: indexed events and archived")
+	fmt.Fprintln(w, "  hours may exist that are not shown here. Re-run status to retry.")
+	fmt.Fprintln(w)
+}
+
 // WriteJSON writes the status data as JSON to w.
 func (d *StatusData) WriteJSON(w io.Writer) error {
-	return writeStatusJSONFull(w, d.Files, d.Parts, d.Archives, d.Coverage, d.Servers, d.Stream, d.Baselines, d.BaselinesUnavailable, d.StreamErr)
+	return writeStatusJSONFull(w, d.Files, d.Parts, d.Archives, d.Coverage, d.Servers, d.Stream, d.Baselines, d.BaselinesUnavailable, d.StreamErr, d.ArchivesErr, d.CoverageErr)
 }
 
 // WriteStatus writes a multi-section status report (Servers, Stream, Indexed Files, Partitions, Archives, Coverage, Summary) to w.
@@ -1177,10 +1244,10 @@ func Truncate(s string, n int) string {
 
 // WriteStatusJSON writes the status data as a JSON object to w.
 func WriteStatusJSON(w io.Writer, files []IndexStateRow, parts []PartitionStat, archives *ArchiveStats, coverage *CoverageInfo, servers []ServerInfo, stream *StreamStateInfo) error {
-	return writeStatusJSONFull(w, files, parts, archives, coverage, servers, stream, nil, false, nil)
+	return writeStatusJSONFull(w, files, parts, archives, coverage, servers, stream, nil, false, nil, nil, nil)
 }
 
-func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionStat, archives *ArchiveStats, coverage *CoverageInfo, servers []ServerInfo, stream *StreamStateInfo, baselines []BaselineInfo, baselinesUnavailable bool, streamErr error) error {
+func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionStat, archives *ArchiveStats, coverage *CoverageInfo, servers []ServerInfo, stream *StreamStateInfo, baselines []BaselineInfo, baselinesUnavailable bool, streamErr, archivesErr, coverageErr error) error {
 	type jsonFile struct {
 		BinlogFile    string  `json:"binlog_file"`
 		Status        string  `json:"status"`
@@ -1358,6 +1425,15 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		Freshness  jsonFreshness  `json:"freshness"`
 		Error      string         `json:"error"`
 	}
+	// jsonSectionError marks a section whose data could not be READ (#1323) —
+	// stream_error's shape for sections with no verdict sub-structure. Emitted
+	// under a distinct key, never as a fake archives/coverage object whose
+	// non-omitempty zero fields would read as real empty data. Absence of the
+	// data key alone is NOT the signal: absent-and-no-error means the fact
+	// "there is nothing here", absent-with-this means "could not look".
+	type jsonSectionError struct {
+		Error string `json:"error"`
+	}
 	type jsonSummary struct {
 		Servers     []jsonServer     `json:"servers,omitempty"`
 		Stream      *jsonStream      `json:"stream,omitempty"`
@@ -1366,8 +1442,15 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 		Parts       []jsonPartition  `json:"partitions"`
 		Total       int64            `json:"total_events_estimate"`
 		Archives    *jsonArchives    `json:"archives,omitempty"`
-		Coverage    *jsonCoverage    `json:"coverage,omitempty"`
-		Baselines   []jsonBaseline   `json:"baselines,omitempty"`
+		// ArchivesError / CoverageError (#1323): the read failed, so the
+		// corresponding data key is absent for a BAD reason. Note the scope
+		// difference from coverage.archives_error (#816): that one says
+		// coverage was computed but its archive extension was not; these say
+		// the whole section is missing because its read failed.
+		ArchivesError *jsonSectionError `json:"archives_error,omitempty"`
+		Coverage      *jsonCoverage     `json:"coverage,omitempty"`
+		CoverageError *jsonSectionError `json:"coverage_error,omitempty"`
+		Baselines     []jsonBaseline    `json:"baselines,omitempty"`
 		// BaselineStaleness is the worst per-table-newest verdict — the same
 		// headline the text banner keys on (#1193).
 		BaselineStaleness string `json:"baseline_staleness,omitempty"`
@@ -1516,6 +1599,15 @@ func writeStatusJSONFull(w io.Writer, files []IndexStateRow, parts []PartitionSt
 			S3Files:        archives.S3Files,
 			S3Buckets:      archives.S3Buckets,
 		}
+	} else if archives == nil && archivesErr != nil {
+		// archive_state could not be READ — surface it so an absent archives
+		// key is not misread as "no archives exist" (#1323).
+		out.ArchivesError = &jsonSectionError{Error: archivesErr.Error()}
+	}
+	if coverage == nil && coverageErr != nil {
+		// LoadCoverage failed — a monitor keyed on coverage.archives_unavailable
+		// must find this loud sibling instead of no coverage key at all (#1323).
+		out.CoverageError = &jsonSectionError{Error: coverageErr.Error()}
 	}
 	if coverage != nil {
 		jc := &jsonCoverage{


### PR DESCRIPTION
closes #1323

## Summary

#1318 taught `LoadCoverage` to distinguish an unreadable archive tier from an absent one — and one call frame up, `CollectStatus` deleted that work on the more likely failure: a `LoadCoverage` error (the `binlog_events` full scan is the statement in this package most likely to hit `max_execution_time` or a lost connection) was swallowed with a `slog.Warn`, so the report printed **no restore window, no error, and exited 0**. A monitor keyed on the new `coverage.archives_unavailable` saw nothing rather than `true`. Seven lines above, `LoadArchiveStats` swallowed the identical failure on the identical `archive_state` table: no `=== Archives ===` section, no `archives` JSON key — an absence a consumer reads as "no archives exist".

The fix mirrors the file's own `StreamErr` pattern ("a swallowed error must not read as 'no stream'"):

- `StatusData` gains `ArchivesErr` / `CoverageErr` (`json:"-"`, set by `CollectStatus`, still non-fatal — status is a report, not a gate).
- `LoadArchiveStats` failures get the same discrimination `LoadCoverage` applies to the same table: `ER_NO_SUCH_TABLE` = an index with no archive tier, a fact the absent section describes correctly (no flag — a pre-archive index must not start crying wolf); anything else is recorded. Every `LoadCoverage` error is recorded — there is no benign sub-case, because an index missing `binlog_events` already fails `CollectStatus` at the required `LoadIndexState` step.
- **Text**: `⚠ NOT READ` tombstone blocks for `=== Archives ===` and `=== Restore Coverage ===`, saying explicitly that the absence is a read failure, not a fact about the data ("archived data may exist that is not shown here" / "the restore window is UNKNOWN, not empty").
- **JSON**: top-level `archives_error` / `coverage_error` objects (`{"error": "..."}` — `stream_error`'s shape) under distinct keys, never a fake `archives`/`coverage` object whose non-omitempty zero fields would read as real empty data. Both `omitempty`: healthy reports are byte-identical on the wire.

`--fail-on-gap` / `--fail-on-lag` exit semantics are untouched, and `WriteStatus` / `WriteStatusJSON` keep their signatures (only the unexported `writeStatusJSONFull` grew parameters).

## Testing

- `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, `gofmt -l` on changed files (clean), full `go test ./... -count=1` green.
- **Unit** (`internal/status/section_error_render_test.go`, no build tag so it cannot skip silently): text tombstones carry the section header, `NOT READ`, the honesty qualifier, and the underlying cause; JSON carries `coverage_error`/`archives_error` with the cause, fabricates no `coverage`/`archives` object, and omits both keys on a healthy report. Verified RAN with `-v -run`: `TestStatusData_coverageReadError_text`, `TestStatusData_archivesReadError_text`, `TestStatusData_sectionReadErrors_json` all `--- PASS`.
- **Integration** (`internal/status/collect_status_error_integration_test.go`, real MySQL at 127.0.0.1:13306, because the discrimination is on driver error codes and the wiring under test is `CollectStatus` itself): healthy index sets neither error; `DROP TABLE archive_state` (1146) sets **no** error (anti-cry-wolf); a legacy `archive_state` missing `row_count` (1054) sets `ArchivesErr` and both renderings carry the tombstone; `DROP TABLE binlog_events` fails `LoadCoverage`, sets `CoverageErr`, and both renderings carry the tombstone while `CollectStatus` stays non-fatal. Verified RAN, not skipped: `=== RUN TestCollectStatus_readFailuresSurfaceNotVanish` → `--- PASS (0.35s)`. The pre-existing #816 integration test still passes.
- **Mutation checks** (each applied, test observed failing, then reverted):
  1. Remove `d.CoverageErr = err` (restore the swallow) → integration fails: "a failed LoadCoverage left CoverageErr nil".
  2. Remove `d.ArchivesErr = err` → integration fails: "an unreadable archive_state left ArchivesErr nil".
  3. Make the missing-table branch record the error too → integration fails: "an index with no archive_state was flagged unreadable".
  4. Remove the text tombstone calls in `Write` → both text unit tests fail.
  5. Remove the JSON emission branches → the JSON unit test fails on both keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
