### PR TITLE
ci: matrix the MariaDB-source job across 10.6 LTS, 10.11 LTS and 11.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,17 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.go == 'true'
     runs-on: ubuntu-22.04
 
+    # Spans the supported MariaDB range (#622): 10.6 LTS (declared minimum)
+    # through 10.11 LTS and 11.4. fail-fast: false so a regression on one
+    # version still reports the others, matching the PostgreSQL matrix. No
+    # per-version server args are needed: the `mariadb` client name, the
+    # MARIADB_ROOT_PASSWORD image env, gtid_strict_mode, log_bin_compress and
+    # the ON default of binlog_annotate_row_events all hold from 10.6 up.
+    strategy:
+      fail-fast: false
+      matrix:
+        mariadb: ["10.6", "10.11", "11.4"]
+
     env:
       BINTRAIL_TEST_DSN: "root:testroot@tcp(127.0.0.1:13306)"
       BINTRAIL_TEST_MARIADB_DSN: "root:testroot@tcp(127.0.0.1:13307)"
@@ -271,12 +282,12 @@ jobs:
           docker logs bintrail-test-mysql >&2 || true
           exit 1
 
-      - name: Start MariaDB source (bintrail-test-mariadb, 11.4)
+      - name: Start MariaDB source (bintrail-test-mariadb, ${{ matrix.mariadb }})
         run: |
           docker run -d --name bintrail-test-mariadb \
             -e MARIADB_ROOT_PASSWORD=testroot \
             -p 13307:3306 \
-            mariadb:11.4 \
+            mariadb:${{ matrix.mariadb }} \
             --log-bin=mariadb-bin --binlog-format=ROW --binlog-row-image=FULL \
             --server-id=2 --gtid-strict-mode=ON
           # Same socket-vs-TCP readiness race as the MySQL-start steps (#949):
@@ -284,7 +295,7 @@ jobs:
           # successes, instead of `docker exec ... mariadb-admin ping`.
           consecutive=0
           for i in $(seq 1 60); do
-            if docker run --rm --network host mariadb:11.4 \
+            if docker run --rm --network host mariadb:${{ matrix.mariadb }} \
                  mariadb --protocol=TCP -h 127.0.0.1 -P 13307 -u root -ptestroot -e "SELECT 1" >/dev/null 2>&1; then
               consecutive=$((consecutive + 1))
               [ "$consecutive" -ge 3 ] && { echo "MariaDB source is ready."; exit 0; }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,6 +122,12 @@ jobs:
     permissions:
       contents: read
 
+    # Same 10.6 LTS / 10.11 LTS / 11.4 matrix as ci.yml (#622).
+    strategy:
+      fail-fast: false
+      matrix:
+        mariadb: ["10.6", "10.11", "11.4"]
+
     env:
       BINTRAIL_TEST_DSN: "root:testroot@tcp(127.0.0.1:13306)"
       BINTRAIL_TEST_MARIADB_DSN: "root:testroot@tcp(127.0.0.1:13307)"
@@ -158,19 +164,19 @@ jobs:
           docker logs bintrail-test-mysql >&2 || true
           exit 1
 
-      - name: Start MariaDB source (bintrail-test-mariadb, 11.4)
+      - name: Start MariaDB source (bintrail-test-mariadb, ${{ matrix.mariadb }})
         run: |
           docker run -d --name bintrail-test-mariadb \
             -e MARIADB_ROOT_PASSWORD=testroot \
             -p 13307:3306 \
-            mariadb:11.4 \
+            mariadb:${{ matrix.mariadb }} \
             --log-bin=mariadb-bin --binlog-format=ROW --binlog-row-image=FULL \
             --server-id=2 --gtid-strict-mode=ON
           # Same socket-vs-TCP readiness race as the MySQL-start step (#949):
           # host-TCP probe with a real query, 3 consecutive successes.
           consecutive=0
           for i in $(seq 1 60); do
-            if docker run --rm --network host mariadb:11.4 \
+            if docker run --rm --network host mariadb:${{ matrix.mariadb }} \
                  mariadb --protocol=TCP -h 127.0.0.1 -P 13307 -u root -ptestroot -e "SELECT 1" >/dev/null 2>&1; then
               consecutive=$((consecutive + 1))
               [ "$consecutive" -ge 3 ] && { echo "MariaDB source is ready."; exit 0; }


### PR DESCRIPTION
closes #622

## Summary

- `integration-mariadb-source` in **ci.yml** and **release.yaml** now runs a version matrix over MariaDB **10.6 LTS**, **10.11 LTS** and **11.4** (previously 11.4 only), with `fail-fast: false` so one version's failure doesn't mask another's — same shape as the `integration-postgres-source` matrix.
- The `mariadb:11.4` image tag (server start + readiness probe) becomes `mariadb:${{ matrix.mariadb }}`; the step name carries the version.
- No test or helper changes needed: nothing in the test tree hardcodes the image tag — the parser fixture tests reference the container by its stable name (`docker cp bintrail-test-mariadb:...`), which is unchanged. No per-version server args either: the `mariadb` client name, the `MARIADB_ROOT_PASSWORD` image env, `gtid_strict_mode`, `log_bin_compress` and the ON default of `binlog_annotate_row_events` all hold from 10.6 up (noted in the job comment).

### Check-name rename (branch protection)

The required status check `integration-mariadb-source` becomes three contexts: `integration-mariadb-source (10.6)`, `integration-mariadb-source (10.11)`, `integration-mariadb-source (11.4)`. Branch protection currently requires the bare name and must be updated to the three matrix contexts (exactly what was done for `integration-postgres-source (14..17)`), or this and every later PR will wait forever on the phantom bare check.

## Testing

Ran the exact CI invocation locally against both NEW versions — same env (`BINTRAIL_TEST_DSN` → MySQL index on 13306, `BINTRAIL_TEST_MARIADB_DSN` → 13307, `BINTRAIL_REQUIRE_MARIADB=1`), same server args as the workflow step, same `-run 'MariaDB|Mariadb|mariadb|Flavor|FourColumns'` selector with `-tags=integration -race -p 1 -count=1 -v`:

- **MariaDB 10.6.28**: **63 passed, 0 failed, 0 skipped** (verified via `-v` PASS lines, not just exit 0). Includes the #518 GTID gap-detection suite (`TestDetectMariaDBGTIDGap_*`, 12 tests incl. `_livePurge` and `_crossServerFailover` against the live server) and the #520 compressed-event decode tests (`TestParseFile_realBinlog_mariadbLogBinCompress`, `TestHandleRows_mariadbCompressedRowTypes`).
- **MariaDB 10.11.18**: **63 passed, 0 failed, 0 skipped**, same selector and env.
- 11.4 is the previously green CI version (unchanged args).
- Workflow YAML validated with `python3 -c "import yaml, ..."` and `actionlint` (only pre-existing SC2034 `i`-unused warnings in the readiness loops, present on main; nothing new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
