### PR TITLE
mcp: align the recover/query tool filters with the CLI and pin the parity

### DIFF
--- a/cmd/bintrail-mcp/main.go
+++ b/cmd/bintrail-mcp/main.go
@@ -330,6 +330,6 @@ func queryResultNotice(ceilingApplied bool, requestedLimit, ceiling, n, limit in
 	return mcptools.QueryResultNotice(ceilingApplied, requestedLimit, ceiling, n, limit)
 }
 
-func buildQueryOptions(schema, table, pk, eventType, gtid, since, until, changedCol string, columnEq []string, flagVal string, limit, defaultLimit int) (query.Options, error) {
-	return mcptools.BuildQueryOptions(schema, table, pk, eventType, gtid, since, until, changedCol, columnEq, flagVal, limit, defaultLimit)
+func buildQueryOptions(p mcptools.FilterParams, defaultLimit int) (query.Options, error) {
+	return mcptools.BuildQueryOptions(p, defaultLimit)
 }

--- a/cmd/bintrail-mcp/main_test.go
+++ b/cmd/bintrail-mcp/main_test.go
@@ -24,7 +24,7 @@ const defaultLimit = 100
 // ─── buildQueryOptions ───────────────────────────────────────────────────────
 
 func TestBuildQueryOptions_empty(t *testing.T) {
-	opts, err := buildQueryOptions("", "", "", "", "", "", "", "", nil, "", 0, defaultLimit)
+	opts, err := buildQueryOptions(mcptools.FilterParams{}, defaultLimit)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -43,11 +43,11 @@ func TestBuildQueryOptions_empty(t *testing.T) {
 }
 
 func TestBuildQueryOptions_allFields(t *testing.T) {
-	opts, err := buildQueryOptions(
-		"mydb", "orders", "12345", "INSERT",
-		"abc:1", "2026-02-19 14:00:00", "2026-02-19 15:00:00", "status", nil, "",
-		50, defaultLimit,
-	)
+	opts, err := buildQueryOptions(mcptools.FilterParams{
+		Schema: "mydb", Table: "orders", PK: "12345", EventType: "INSERT",
+		GTID: "abc:1", Since: "2026-02-19 14:00:00", Until: "2026-02-19 15:00:00",
+		ChangedColumn: "status", Limit: 50,
+	}, defaultLimit)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestBuildQueryOptions_allFields(t *testing.T) {
 }
 
 func TestBuildQueryOptions_pkWithoutSchemaTable(t *testing.T) {
-	_, err := buildQueryOptions("", "", "12345", "", "", "", "", "", nil, "", 0, defaultLimit)
+	_, err := buildQueryOptions(mcptools.FilterParams{PK: "12345"}, defaultLimit)
 	if err == nil {
 		t.Error("expected error when pk is set without schema/table")
 	}
@@ -91,14 +91,14 @@ func TestBuildQueryOptions_pkWithoutSchemaTable(t *testing.T) {
 }
 
 func TestBuildQueryOptions_pkWithSchemaOnly(t *testing.T) {
-	_, err := buildQueryOptions("mydb", "", "12345", "", "", "", "", "", nil, "", 0, defaultLimit)
+	_, err := buildQueryOptions(mcptools.FilterParams{Schema: "mydb", PK: "12345"}, defaultLimit)
 	if err == nil {
 		t.Error("expected error when pk is set with schema but no table")
 	}
 }
 
 func TestBuildQueryOptions_changedColumnWithoutSchemaTable(t *testing.T) {
-	_, err := buildQueryOptions("", "", "", "", "", "", "", "status", nil, "", 0, defaultLimit)
+	_, err := buildQueryOptions(mcptools.FilterParams{ChangedColumn: "status"}, defaultLimit)
 	if err == nil {
 		t.Error("expected error when changed_column is set without schema/table")
 	}
@@ -108,14 +108,14 @@ func TestBuildQueryOptions_changedColumnWithoutSchemaTable(t *testing.T) {
 }
 
 func TestBuildQueryOptions_invalidEventType(t *testing.T) {
-	_, err := buildQueryOptions("mydb", "orders", "", "UPSERT", "", "", "", "", nil, "", 0, defaultLimit)
+	_, err := buildQueryOptions(mcptools.FilterParams{Schema: "mydb", Table: "orders", EventType: "UPSERT"}, defaultLimit)
 	if err == nil {
 		t.Error("expected error for invalid event_type")
 	}
 }
 
 func TestBuildQueryOptions_invalidSince(t *testing.T) {
-	_, err := buildQueryOptions("", "", "", "", "", "not-a-date", "", "", nil, "", 0, defaultLimit)
+	_, err := buildQueryOptions(mcptools.FilterParams{Since: "not-a-date"}, defaultLimit)
 	if err == nil {
 		t.Error("expected error for invalid since")
 	}
@@ -125,7 +125,7 @@ func TestBuildQueryOptions_invalidSince(t *testing.T) {
 }
 
 func TestBuildQueryOptions_invalidUntil(t *testing.T) {
-	_, err := buildQueryOptions("", "", "", "", "", "", "not-a-date", "", nil, "", 0, defaultLimit)
+	_, err := buildQueryOptions(mcptools.FilterParams{Until: "not-a-date"}, defaultLimit)
 	if err == nil {
 		t.Error("expected error for invalid until")
 	}
@@ -135,7 +135,7 @@ func TestBuildQueryOptions_invalidUntil(t *testing.T) {
 }
 
 func TestBuildQueryOptions_limitZeroUsesDefault(t *testing.T) {
-	opts, err := buildQueryOptions("", "", "", "", "", "", "", "", nil, "", 0, defaultLimit)
+	opts, err := buildQueryOptions(mcptools.FilterParams{}, defaultLimit)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestBuildQueryOptions_limitZeroUsesDefault(t *testing.T) {
 }
 
 func TestBuildQueryOptions_negativeLimitUsesDefault(t *testing.T) {
-	opts, err := buildQueryOptions("", "", "", "", "", "", "", "", nil, "", -5, defaultLimit)
+	opts, err := buildQueryOptions(mcptools.FilterParams{Limit: -5}, defaultLimit)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -155,8 +155,8 @@ func TestBuildQueryOptions_negativeLimitUsesDefault(t *testing.T) {
 }
 
 func TestBuildQueryOptions_columnEqPassedThrough(t *testing.T) {
-	opts, err := buildQueryOptions("mydb", "orders", "", "", "", "", "", "",
-		[]string{"status=active", "deleted_at=NULL"}, "", 0, defaultLimit)
+	opts, err := buildQueryOptions(mcptools.FilterParams{Schema: "mydb", Table: "orders",
+		ColumnEq: []string{"status=active", "deleted_at=NULL"}}, defaultLimit)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -172,8 +172,7 @@ func TestBuildQueryOptions_columnEqPassedThrough(t *testing.T) {
 }
 
 func TestBuildQueryOptions_columnEqRequiresSchemaTable(t *testing.T) {
-	_, err := buildQueryOptions("", "", "", "", "", "", "", "",
-		[]string{"status=active"}, "", 0, defaultLimit)
+	_, err := buildQueryOptions(mcptools.FilterParams{ColumnEq: []string{"status=active"}}, defaultLimit)
 	if err == nil {
 		t.Fatal("expected error when column_eq is set without schema/table")
 	}
@@ -183,8 +182,8 @@ func TestBuildQueryOptions_columnEqRequiresSchemaTable(t *testing.T) {
 }
 
 func TestBuildQueryOptions_columnEqMalformedEntry(t *testing.T) {
-	_, err := buildQueryOptions("mydb", "orders", "", "", "", "", "", "",
-		[]string{"no-equals"}, "", 0, defaultLimit)
+	_, err := buildQueryOptions(mcptools.FilterParams{Schema: "mydb", Table: "orders",
+		ColumnEq: []string{"no-equals"}}, defaultLimit)
 	if err == nil {
 		t.Fatal("expected error for malformed column_eq entry")
 	}
@@ -194,7 +193,7 @@ func TestBuildQueryOptions_columnEqMalformedEntry(t *testing.T) {
 }
 
 func TestBuildQueryOptions_flagPassedThrough(t *testing.T) {
-	opts, err := buildQueryOptions("", "", "", "", "", "", "", "", nil, "billing", 0, defaultLimit)
+	opts, err := buildQueryOptions(mcptools.FilterParams{Flag: "billing"}, defaultLimit)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -230,11 +230,21 @@ The `query` and `recover` tools share the CLI's filters and validation. Beyond
 the basics (`schema`, `table`, `pk`, `event_type`, `gtid`, `since`, `until`),
 both accept:
 
-- `changed_column` — events that touched a given column
+- `pks` — multiple primary key values (each pipe-delimited for composite
+  keys); requires `schema` and `table`, mutually exclusive with `pk`
+- `limit_per_pk` — cap events per `pk_values` to the latest N (0 = unlimited);
+  requires `pk` or `pks`
 - `column_eq` — repeatable `column=value` equality filters
 - `flag` — table/column flag filter
 - `profile` — RBAC table-deny + column-redaction
 - `no_archive` — disable Parquet archive auto-routing (see below)
+
+`query` also takes `changed_column` — events that touched a given column.
+`recover` does not: a changed-column filter selects row *versions*, and
+reversing a filtered subset of a row's history can produce a state that never
+existed — the same reason the `bintrail recover` CLI has no `--changed-column`
+flag (a `recover` call passing `changed_column` is rejected by the tool's
+input schema).
 
 `query` also takes `query_hash` — the 64-character statement digest of an event
 you already have, returning every event that statement produced across every

--- a/internal/mcptools/filterparams_test.go
+++ b/internal/mcptools/filterparams_test.go
@@ -1,0 +1,73 @@
+package mcptools
+
+import (
+	"strings"
+	"testing"
+)
+
+// Validation of the pks / limit_per_pk parameters added by #962. The
+// cross-field rules mirror `bintrail recover`/`bintrail query` (see
+// runRecover/runQuery in internal/cli): pks needs schema+table, pk and pks
+// are mutually exclusive, limit_per_pk needs a PK scope and rejects
+// negatives, and the pk list is trimmed + deduplicated with empty entries
+// refused loudly.
+
+func TestBuildQueryOptions_pksRequireSchemaTable(t *testing.T) {
+	_, err := BuildQueryOptions(FilterParams{PKs: []string{"1"}}, DefaultQueryLimit)
+	if err == nil || !strings.Contains(err.Error(), "schema") {
+		t.Fatalf("expected schema/table error for pks without scope, got: %v", err)
+	}
+}
+
+func TestBuildQueryOptions_pkAndPKsMutuallyExclusive(t *testing.T) {
+	_, err := BuildQueryOptions(FilterParams{
+		Schema: "app", Table: "orders", PK: "1", PKs: []string{"2"},
+	}, DefaultQueryLimit)
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("expected mutual-exclusion error, got: %v", err)
+	}
+}
+
+func TestBuildQueryOptions_limitPerPKNegative(t *testing.T) {
+	_, err := BuildQueryOptions(FilterParams{
+		Schema: "app", Table: "orders", PK: "1", LimitPerPK: -1,
+	}, DefaultQueryLimit)
+	if err == nil || !strings.Contains(err.Error(), "limit_per_pk") {
+		t.Fatalf("expected limit_per_pk error, got: %v", err)
+	}
+}
+
+func TestBuildQueryOptions_limitPerPKRequiresPKScope(t *testing.T) {
+	_, err := BuildQueryOptions(FilterParams{
+		Schema: "app", Table: "orders", LimitPerPK: 2,
+	}, DefaultQueryLimit)
+	if err == nil || !strings.Contains(err.Error(), "requires pk or pks") {
+		t.Fatalf("expected pk-scope error, got: %v", err)
+	}
+}
+
+func TestBuildQueryOptions_pksEmptyEntryRefused(t *testing.T) {
+	_, err := BuildQueryOptions(FilterParams{
+		Schema: "app", Table: "orders", PKs: []string{"1", "  "},
+	}, DefaultQueryLimit)
+	if err == nil || !strings.Contains(err.Error(), "empty or whitespace-only") {
+		t.Fatalf("expected empty-entry refusal, got: %v", err)
+	}
+}
+
+func TestBuildQueryOptions_pksTrimmedDedupedAndPlumbed(t *testing.T) {
+	opts, err := BuildQueryOptions(FilterParams{
+		Schema: "app", Table: "orders",
+		PKs:        []string{" 1 ", "2", "1"},
+		LimitPerPK: 3,
+	}, DefaultQueryLimit)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.Join(opts.PKValuesIn, ","); got != "1,2" {
+		t.Errorf("PKValuesIn = %q, want \"1,2\" (trimmed, deduped, order kept)", got)
+	}
+	if opts.LimitPerPK != 3 {
+		t.Errorf("LimitPerPK = %d, want 3", opts.LimitPerPK)
+	}
+}

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -455,6 +455,8 @@ type QueryArgs struct {
 	Schema        string   `json:"schema,omitempty" jsonschema:"Filter by database schema name"`
 	Table         string   `json:"table,omitempty" jsonschema:"Filter by table name"`
 	PK            string   `json:"pk,omitempty" jsonschema:"Filter by primary key value (pipe-delimited for composite keys e.g. 123 or 123|2)"`
+	PKs           []string `json:"pks,omitempty" jsonschema:"Filter by multiple primary key values (each pipe-delimited for composite keys); requires schema and table; mutually exclusive with pk"`
+	LimitPerPK    int      `json:"limit_per_pk,omitempty" jsonschema:"Cap returned events per pk_values to the latest N (0 = unlimited); requires pk or pks"`
 	EventType     string   `json:"event_type,omitempty" jsonschema:"Filter by event type: INSERT UPDATE or DELETE"`
 	GTID          string   `json:"gtid,omitempty" jsonschema:"Filter by GTID (e.g. uuid:42)"`
 	Since         string   `json:"since,omitempty" jsonschema:"Filter events at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
@@ -470,21 +472,38 @@ type QueryArgs struct {
 }
 
 // RecoverArgs are the recover tool's parameters.
+//
+// Deliberately NOT here, matching the CLI recover surface (see
+// TestRecoverToolParams_matchCLIRecoverFlags):
+//
+//   - changed_column: a changed-column filter names row VERSIONS, and
+//     reversing a filtered subset of a row's history can produce a state that
+//     never existed — which is why CLI recover has never accepted
+//     --changed-column (it is query-only). The MCP recover tool exposed it
+//     anyway until #962. It is REMOVED rather than kept-and-rejected: the
+//     inferred input schema sets additionalProperties:false, so a client that
+//     still sends changed_column gets a loud schema-validation error naming
+//     the property instead of a silently ignored filter (the dangerous
+//     outcome would be a reversal covering more events than the client
+//     believes it scoped).
+//   - query_hash: same shape-vs-instance reasoning — see
+//     TestRecoverArgs_hasNoQueryHashParam.
 type RecoverArgs struct {
-	IndexDSN      string   `json:"index_dsn,omitempty" jsonschema:"MySQL DSN for the index database. Overrides BINTRAIL_INDEX_DSN env var. Rejected on servers that route connections themselves (the console /mcp endpoint)."`
-	Schema        string   `json:"schema,omitempty" jsonschema:"Filter by database schema name"`
-	Table         string   `json:"table,omitempty" jsonschema:"Filter by table name"`
-	PK            string   `json:"pk,omitempty" jsonschema:"Filter by primary key value (pipe-delimited for composite keys)"`
-	EventType     string   `json:"event_type,omitempty" jsonschema:"Filter by event type: INSERT UPDATE or DELETE"`
-	GTID          string   `json:"gtid,omitempty" jsonschema:"Filter by GTID (e.g. uuid:42)"`
-	Since         string   `json:"since,omitempty" jsonschema:"Filter events at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
-	Until         string   `json:"until,omitempty" jsonschema:"Filter events at or before this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
-	ChangedColumn string   `json:"changed_column,omitempty" jsonschema:"Filter UPDATE events that modified this column"`
-	ColumnEq      []string `json:"column_eq,omitempty" jsonschema:"Filter events where a column in row_after or row_before equals the given value. Each entry is column=value. Repeat for AND. Literal NULL matches JSON null."`
-	Flag          string   `json:"flag,omitempty" jsonschema:"Filter events from tables or columns carrying this flag"`
-	Limit         int      `json:"limit,omitempty" jsonschema:"Maximum number of events to reverse (default: 1000)"`
-	Profile       string   `json:"profile,omitempty" jsonschema:"Apply RBAC access rules for this profile (table-level deny and column-level redaction)"`
-	NoArchive     bool     `json:"no_archive,omitempty" jsonschema:"Disable auto-routing to Parquet archives (MySQL-only results)"`
+	IndexDSN   string   `json:"index_dsn,omitempty" jsonschema:"MySQL DSN for the index database. Overrides BINTRAIL_INDEX_DSN env var. Rejected on servers that route connections themselves (the console /mcp endpoint)."`
+	Schema     string   `json:"schema,omitempty" jsonschema:"Filter by database schema name"`
+	Table      string   `json:"table,omitempty" jsonschema:"Filter by table name"`
+	PK         string   `json:"pk,omitempty" jsonschema:"Filter by primary key value (pipe-delimited for composite keys)"`
+	PKs        []string `json:"pks,omitempty" jsonschema:"Filter by multiple primary key values (each pipe-delimited for composite keys); requires schema and table; mutually exclusive with pk"`
+	LimitPerPK int      `json:"limit_per_pk,omitempty" jsonschema:"Cap reversed events per pk_values to the latest N (0 = unlimited); requires pk or pks"`
+	EventType  string   `json:"event_type,omitempty" jsonschema:"Filter by event type: INSERT UPDATE or DELETE"`
+	GTID       string   `json:"gtid,omitempty" jsonschema:"Filter by GTID (e.g. uuid:42)"`
+	Since      string   `json:"since,omitempty" jsonschema:"Filter events at or after this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
+	Until      string   `json:"until,omitempty" jsonschema:"Filter events at or before this time (YYYY-MM-DD HH:MM:SS or RFC 3339)"`
+	ColumnEq   []string `json:"column_eq,omitempty" jsonschema:"Filter events where a column in row_after or row_before equals the given value. Each entry is column=value. Repeat for AND. Literal NULL matches JSON null."`
+	Flag       string   `json:"flag,omitempty" jsonschema:"Filter events from tables or columns carrying this flag"`
+	Limit      int      `json:"limit,omitempty" jsonschema:"Maximum number of events to reverse (default: 1000)"`
+	Profile    string   `json:"profile,omitempty" jsonschema:"Apply RBAC access rules for this profile (table-level deny and column-level redaction)"`
+	NoArchive  bool     `json:"no_archive,omitempty" jsonschema:"Disable auto-routing to Parquet archives (MySQL-only results)"`
 }
 
 // StatusArgs are the status tool's parameters.
@@ -550,8 +569,21 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 			}
 		}
 
-		opts, err := BuildQueryOptions(args.Schema, args.Table, args.PK, args.EventType,
-			args.GTID, args.Since, args.Until, args.ChangedColumn, args.ColumnEq, args.Flag, args.Limit, DefaultQueryLimit)
+		opts, err := BuildQueryOptions(FilterParams{
+			Schema:        args.Schema,
+			Table:         args.Table,
+			PK:            args.PK,
+			PKs:           args.PKs,
+			LimitPerPK:    args.LimitPerPK,
+			EventType:     args.EventType,
+			GTID:          args.GTID,
+			Since:         args.Since,
+			Until:         args.Until,
+			ChangedColumn: args.ChangedColumn,
+			ColumnEq:      args.ColumnEq,
+			Flag:          args.Flag,
+			Limit:         args.Limit,
+		}, DefaultQueryLimit)
 		if err != nil {
 			return ErrorResult(err), nil, nil
 		}
@@ -661,7 +693,12 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 				results = append(results, ar...)
 			}
 			if len(archSources) > 0 {
-				results, divergedEvents = query.MergeResultsReport(results, opts.Limit, opts.Order)
+				// MergeAndTrimReport, not MergeResultsReport: each source
+				// applied its own per-PK cap independently (SQL window /
+				// DuckDB QUALIFY), so the union can still exceed limit_per_pk
+				// per PK — the same post-merge re-trim the CLI query path
+				// does, carrying the #1325 divergence count through.
+				results, divergedEvents = query.MergeAndTrimReport(results, opts.Limit, opts.LimitPerPK, opts.Order)
 			}
 			t.stripStatementText(results)
 			n, err = query.Format(results, format, &buf)
@@ -720,8 +757,22 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 			}
 		}
 
-		opts, err := BuildQueryOptions(args.Schema, args.Table, args.PK, args.EventType,
-			args.GTID, args.Since, args.Until, args.ChangedColumn, args.ColumnEq, args.Flag, args.Limit, DefaultRecoverLimit)
+		// No ChangedColumn here on purpose — see the RecoverArgs doc comment:
+		// the field does not exist on the recover surface, matching CLI recover.
+		opts, err := BuildQueryOptions(FilterParams{
+			Schema:     args.Schema,
+			Table:      args.Table,
+			PK:         args.PK,
+			PKs:        args.PKs,
+			LimitPerPK: args.LimitPerPK,
+			EventType:  args.EventType,
+			GTID:       args.GTID,
+			Since:      args.Since,
+			Until:      args.Until,
+			ColumnEq:   args.ColumnEq,
+			Flag:       args.Flag,
+			Limit:      args.Limit,
+		}, DefaultRecoverLimit)
 		if err != nil {
 			return ErrorResult(err), nil, nil
 		}
@@ -825,7 +876,11 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 				}
 				rows = append(rows, ar...)
 			}
-			rows, divergedEvents = query.MergeResultsReport(rows, opts.Limit, opts.Order)
+			// MergeAndTrimReport, not MergeResultsReport: each source applied
+			// its own per-PK cap independently, so the union can still exceed
+			// limit_per_pk per PK — mirror the CLI recover merge
+			// (FetchMerged), carrying the #1325 divergence count through.
+			rows, divergedEvents = query.MergeAndTrimReport(rows, opts.Limit, opts.LimitPerPK, opts.Order)
 		} else {
 			rows, err = engine.Fetch(ctx, opts)
 			if err != nil {
@@ -1279,52 +1334,119 @@ func ArchiveSkipNotice(discoveryFailed bool, skipped []string) string {
 	return b.String()
 }
 
+// FilterParams are the shared filter parameters the query and recover tools
+// hand to BuildQueryOptions. Both tools map their (deliberately separate) arg
+// structs into this one builder so the cross-field validation stays in one
+// place. ChangedColumn is query-only: the recover handler has no field to
+// plumb into it (see the RecoverArgs doc comment), and QueryHash is
+// deliberately absent — the query tool layers it on AFTER the builder so the
+// recover tool can never gain it through here.
+type FilterParams struct {
+	Schema        string
+	Table         string
+	PK            string
+	PKs           []string
+	LimitPerPK    int
+	EventType     string
+	GTID          string
+	Since         string
+	Until         string
+	ChangedColumn string
+	ColumnEq      []string
+	Flag          string
+	Limit         int
+}
+
+// cleanPKs mirrors the CLI's pks hygiene (internal/cli cleanPKList): trim
+// whitespace, reject empty entries loudly, and drop duplicates while keeping
+// the first occurrence's order. MCP clients send a JSON array so there is no
+// comma-splitting concern, but a whitespace-only entry is still a client bug
+// worth naming rather than a silently narrower filter.
+func cleanPKs(pks []string) ([]string, error) {
+	if len(pks) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{}, len(pks))
+	out := make([]string, 0, len(pks))
+	for _, pk := range pks {
+		trimmed := strings.TrimSpace(pk)
+		if trimmed == "" {
+			return nil, fmt.Errorf("pks: empty or whitespace-only PK value")
+		}
+		if _, dup := seen[trimmed]; dup {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out, nil
+}
+
 // BuildQueryOptions converts the shared tool filter parameters into a
 // query.Options, validating cross-field requirements and applying the default
 // limit to a non-positive request.
-func BuildQueryOptions(schema, table, pk, eventType, gtid, since, until, changedCol string, columnEq []string, flagVal string, limit, defaultLimit int) (query.Options, error) {
-	if pk != "" && (schema == "" || table == "") {
+func BuildQueryOptions(p FilterParams, defaultLimit int) (query.Options, error) {
+	if p.PK != "" && (p.Schema == "" || p.Table == "") {
 		return query.Options{}, fmt.Errorf("pk requires both schema and table")
 	}
-	if changedCol != "" && (schema == "" || table == "") {
+	if len(p.PKs) > 0 && (p.Schema == "" || p.Table == "") {
+		return query.Options{}, fmt.Errorf("pks requires both schema and table")
+	}
+	if p.PK != "" && len(p.PKs) > 0 {
+		return query.Options{}, fmt.Errorf("pk and pks are mutually exclusive; use one or the other")
+	}
+	pks, err := cleanPKs(p.PKs)
+	if err != nil {
+		return query.Options{}, err
+	}
+	if p.LimitPerPK < 0 {
+		return query.Options{}, fmt.Errorf("limit_per_pk must be >= 0")
+	}
+	if p.LimitPerPK > 0 && p.PK == "" && len(pks) == 0 {
+		return query.Options{}, fmt.Errorf("limit_per_pk requires pk or pks")
+	}
+	if p.ChangedColumn != "" && (p.Schema == "" || p.Table == "") {
 		return query.Options{}, fmt.Errorf("changed_column requires both schema and table")
 	}
-	if len(columnEq) > 0 && (schema == "" || table == "") {
+	if len(p.ColumnEq) > 0 && (p.Schema == "" || p.Table == "") {
 		return query.Options{}, fmt.Errorf("column_eq requires both schema and table")
 	}
 
-	et, err := cliutil.ParseEventType(eventType)
+	et, err := cliutil.ParseEventType(p.EventType)
 	if err != nil {
 		return query.Options{}, err
 	}
-	sinceT, err := cliutil.ParseTime(since)
+	sinceT, err := cliutil.ParseTime(p.Since)
 	if err != nil {
 		return query.Options{}, fmt.Errorf("invalid since: %w", err)
 	}
-	untilT, err := cliutil.ParseTime(until)
+	untilT, err := cliutil.ParseTime(p.Until)
 	if err != nil {
 		return query.Options{}, fmt.Errorf("invalid until: %w", err)
 	}
-	parsedEq, err := query.ParseColumnEqs(columnEq)
+	parsedEq, err := query.ParseColumnEqs(p.ColumnEq)
 	if err != nil {
 		return query.Options{}, err
 	}
 
+	limit := p.Limit
 	if limit <= 0 {
 		limit = defaultLimit
 	}
 
 	return query.Options{
-		Schema:        schema,
-		Table:         table,
-		PKValues:      pk,
+		Schema:        p.Schema,
+		Table:         p.Table,
+		PKValues:      p.PK,
+		PKValuesIn:    pks,
+		LimitPerPK:    p.LimitPerPK,
 		EventType:     et,
-		GTID:          gtid,
+		GTID:          p.GTID,
 		Since:         sinceT,
 		Until:         untilT,
-		ChangedColumn: changedCol,
+		ChangedColumn: p.ChangedColumn,
 		ColumnEq:      parsedEq,
-		Flag:          flagVal,
+		Flag:          p.Flag,
 		Limit:         limit,
 	}, nil
 }

--- a/internal/mcptools/paramsync_test.go
+++ b/internal/mcptools/paramsync_test.go
@@ -1,0 +1,155 @@
+package mcptools
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/cli"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// ─── CLI ↔ MCP filter parity (#962) ─────────────────────────────────────────
+//
+// QueryArgs/RecoverArgs are parallel copies of the CLI query/recover filter
+// surfaces, and before #962 they had drifted silently: MCP recover exposed
+// changed_column (which CLI recover deliberately refuses — a changed-column
+// filter names row VERSIONS, and reversing a filtered subset of a row's
+// history can produce a state that never existed) and lacked --pks and
+// --limit-per-pk. Nothing failed, because the two surfaces were only prose-
+// synchronized.
+//
+// These tests make the drift structural: every CLI flag must either map to an
+// MCP param (kebab-case → snake_case) or be recorded below with the reason it
+// is CLI-only, and every MCP param must map back to a CLI flag. Adding a
+// filter to one surface without the other — or without an explicit, documented
+// exception — fails the build.
+
+// recoverCLIOnly are `bintrail recover` flags that deliberately have no MCP
+// recover param. Every entry must still exist as a CLI flag (a stale entry
+// fails the test) and must NOT have an MCP counterpart.
+var recoverCLIOnly = map[string]string{
+	"output":                 "CLI file plumbing; the MCP tool always returns the script text in the result",
+	"dry-run":                "CLI stdout plumbing; the MCP tool is always dry-run (it returns the script, never applies it)",
+	"format":                 "CLI text/json envelope rendering; the MCP result is always the script text",
+	"max-script-bytes":       "script-budget override for operator-run large recoveries; the MCP surface keeps the serving process's budget (see the ScriptBudgetError rewrite in MakeRecoverTool)",
+	"allow-gaps":             "proceed-despite-gaps escape hatch; MCP recover REFUSES on archive trouble and offers no_archive instead (#1285)",
+	"suppress-triggers":      "apply-side codegen (PG session_replication_role) for scripts an operator will run",
+	"restore-auto-increment": "apply-side codegen (MySQL AUTO_INCREMENT checklist) for scripts an operator will run",
+	"ultrafast":              "DuckDB resource tuning; the long-lived MCP daemons keep the safe default (#510/#511)",
+	"duckdb-threads":         "DuckDB resource tuning; the long-lived MCP daemons keep the safe default (#510/#511)",
+	"duckdb-memory-limit":    "DuckDB resource tuning; the long-lived MCP daemons keep the safe default (#510/#511)",
+}
+
+// queryCLIOnly is the same ledger for `bintrail query` vs the MCP query tool.
+var queryCLIOnly = map[string]string{
+	"order":               "sort-direction of the returned page (#1511); the MCP tool keeps the pre-#1511 ascending default",
+	"archive-dir":         "explicit archive source override; the MCP surface uses env config + archive_state auto-discovery",
+	"archive-s3":          "explicit archive source override; the MCP surface uses env config + archive_state auto-discovery",
+	"bintrail-id":         "companion to the explicit archive source flags above",
+	"include-snapshot":    "baseline Parquet scan mode; on MCP that capability is the reconstruct tool",
+	"baseline":            "companion to include-snapshot",
+	"ultrafast":           "DuckDB resource tuning; the long-lived MCP daemons keep the safe default (#510/#511)",
+	"duckdb-threads":      "DuckDB resource tuning; the long-lived MCP daemons keep the safe default (#510/#511)",
+	"duckdb-memory-limit": "DuckDB resource tuning; the long-lived MCP daemons keep the safe default (#510/#511)",
+}
+
+// cliFlagNames returns the local flag names registered on the named CLI
+// read-plane command, via the same registration path the real binaries use
+// (cli.AddReadCommands), so the test pins the production flag set rather than
+// a copy of it.
+func cliFlagNames(t *testing.T, name string) map[string]bool {
+	t.Helper()
+	root := &cobra.Command{Use: "bintrail"}
+	cli.AddReadCommands(root)
+	cmd, _, err := root.Find([]string{name})
+	if err != nil || cmd == nil || cmd.Name() != name {
+		t.Fatalf("CLI command %q not found via cli.AddReadCommands: %v", name, err)
+	}
+	names := map[string]bool{}
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Name == "help" {
+			return
+		}
+		names[f.Name] = true
+	})
+	if len(names) == 0 {
+		t.Fatalf("CLI command %q registered no flags — the enumeration is broken", name)
+	}
+	return names
+}
+
+// mcpParamNames reflects the json parameter names out of a tool args struct —
+// the exact names the inferred input schema advertises to MCP clients.
+func mcpParamNames(t *testing.T, args any) map[string]bool {
+	t.Helper()
+	rt := reflect.TypeOf(args)
+	names := map[string]bool{}
+	for i := range rt.NumField() {
+		tag := rt.Field(i).Tag.Get("json")
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" || name == "-" {
+			t.Fatalf("%s.%s has no json name; every tool param must name its wire form", rt.Name(), rt.Field(i).Name)
+		}
+		names[name] = true
+	}
+	return names
+}
+
+func assertParamParity(t *testing.T, cliCmd string, args any, cliOnly map[string]string) {
+	t.Helper()
+	flags := cliFlagNames(t, cliCmd)
+	params := mcpParamNames(t, args)
+
+	// The exception ledger must stay live: a stale entry means the CLI flag is
+	// gone (delete the entry) or an MCP param appeared anyway (the reason no
+	// longer holds — resolve it explicitly, don't let both coexist).
+	for name := range cliOnly {
+		if !flags[name] {
+			t.Errorf("cliOnly exception %q is not a `bintrail %s` flag anymore; delete the stale exception", name, cliCmd)
+		}
+		if params[strings.ReplaceAll(name, "-", "_")] {
+			t.Errorf("cliOnly exception %q also exists as an MCP param; it is not CLI-only — remove one side or the exception", name)
+		}
+	}
+
+	for name := range flags {
+		if _, excepted := cliOnly[name]; excepted {
+			continue
+		}
+		if want := strings.ReplaceAll(name, "-", "_"); !params[want] {
+			t.Errorf("`bintrail %s` flag --%s has no %q param on the MCP %s tool: add the param, or record it in the cliOnly ledger with the reason it must not exist on MCP",
+				cliCmd, name, want, cliCmd)
+		}
+	}
+	for name := range params {
+		if kebab := strings.ReplaceAll(name, "_", "-"); !flags[kebab] {
+			t.Errorf("MCP %s tool param %q has no --%s flag on `bintrail %s`: the surfaces drifted — if the CLI omits the flag DELIBERATELY (changed-column on recover is the precedent), the MCP tool must omit the param too",
+				cliCmd, name, kebab, cliCmd)
+		}
+	}
+}
+
+func TestRecoverToolParams_matchCLIRecoverFlags(t *testing.T) {
+	assertParamParity(t, "recover", RecoverArgs{}, recoverCLIOnly)
+}
+
+func TestQueryToolParams_matchCLIQueryFlags(t *testing.T) {
+	assertParamParity(t, "query", QueryArgs{}, queryCLIOnly)
+}
+
+// TestRecoverSurfaces_neverChangedColumn names the design decision the parity
+// tests enforce implicitly: NEITHER recover surface filters by changed column.
+// A changed-column filter selects row versions; reversing a filtered subset of
+// a row's history is unsafe (the reverse-image WHERE clauses assume the
+// intervening, un-reverted versions). If either side ever grows it, this fails
+// and forces the decision to be made explicitly on both.
+func TestRecoverSurfaces_neverChangedColumn(t *testing.T) {
+	if cliFlagNames(t, "recover")["changed-column"] {
+		t.Error("`bintrail recover` grew --changed-column; decide the reversal-safety question explicitly before mirroring it to MCP")
+	}
+	if mcpParamNames(t, RecoverArgs{})["changed_column"] {
+		t.Error("RecoverArgs exposes changed_column; CLI recover deliberately refuses it (#962)")
+	}
+}

--- a/internal/mcptools/pks_integration_test.go
+++ b/internal/mcptools/pks_integration_test.go
@@ -1,0 +1,80 @@
+//go:build integration
+
+package mcptools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestRecoverTool_pksAndLimitPerPK is the wiring proof for the #962 params:
+// the unit tests pin BuildQueryOptions, but only a real fetch shows the
+// options reach the SQL (an unplumbed PKValuesIn returns the whole table and
+// the reversal script covers events nobody named — the exact failure mode
+// the recover tool exists to avoid).
+func TestRecoverTool_pksAndLimitPerPK(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	// pk 1 has TWO updates (limit_per_pk=1 must keep only the newer),
+	// pk 2 has one, pk 9 is outside the pks filter entirely.
+	testutil.InsertEvent(t, db, "bin.000001", 100, 200, "2026-06-01 12:00:00", nil,
+		"app", "orders", 2, "1", nil,
+		[]byte(`{"id":1,"status":"old1"}`), []byte(`{"id":1,"status":"mid1"}`))
+	testutil.InsertEvent(t, db, "bin.000001", 200, 300, "2026-06-01 12:00:01", nil,
+		"app", "orders", 2, "1", nil,
+		[]byte(`{"id":1,"status":"mid1"}`), []byte(`{"id":1,"status":"new1"}`))
+	testutil.InsertEvent(t, db, "bin.000001", 300, 400, "2026-06-01 12:00:02", nil,
+		"app", "orders", 2, "2", nil,
+		[]byte(`{"id":2,"status":"old2"}`), []byte(`{"id":2,"status":"new2"}`))
+	testutil.InsertEvent(t, db, "bin.000001", 400, 500, "2026-06-01 12:00:03", nil,
+		"app", "orders", 2, "9", nil,
+		[]byte(`{"id":9,"status":"old9"}`), []byte(`{"id":9,"status":"new9"}`))
+
+	cfg := Config{
+		Resolve: func(context.Context, string) (*Target, error) {
+			return &Target{DB: db, NoArchive: true}, nil
+		},
+	}
+	res, _, err := MakeRecoverTool(cfg)(context.Background(), &mcp.CallToolRequest{}, RecoverArgs{
+		Schema: "app", Table: "orders",
+		PKs:        []string{"1", "2"},
+		LimitPerPK: 1,
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("recover refused: %s", resultText(res))
+	}
+	script := resultText(res)
+
+	// Latest event per selected pk is reversed: pk 1 rolls back to mid1
+	// (NOT old1 — that would mean limit_per_pk was ignored and the older
+	// event was reversed too), pk 2 to old2.
+	if !strings.Contains(script, "mid1") {
+		t.Errorf("script does not reverse pk 1's latest event (missing mid1):\n%s", script)
+	}
+	if strings.Contains(script, "old1") {
+		t.Errorf("script reverses pk 1's OLDER event despite limit_per_pk=1 (found old1):\n%s", script)
+	}
+	if !strings.Contains(script, "old2") {
+		t.Errorf("script does not reverse pk 2's event (missing old2):\n%s", script)
+	}
+	if strings.Contains(script, "old9") || strings.Contains(script, "new9") {
+		t.Errorf("script touches pk 9, which the pks filter never named:\n%s", script)
+	}
+	if !strings.Contains(script, "2 reversal statement(s) generated") {
+		t.Errorf("expected exactly 2 reversal statements, got:\n%s", script)
+	}
+}

--- a/internal/mcptools/queryhash_test.go
+++ b/internal/mcptools/queryhash_test.go
@@ -85,8 +85,8 @@ func TestQueryTool_queryHashRefusedWhenStatementTextIsWithheld(t *testing.T) {
 // scoped to one would undo every execution of that shape in the window — none
 // of which the operator named.
 //
-// The realistic regression is not the shared BuildQueryOptions (its positional
-// signature makes leakage hard) but someone adding QueryHash to RecoverArgs
+// The realistic regression is not the shared BuildQueryOptions (FilterParams
+// deliberately has no QueryHash field) but someone adding QueryHash to RecoverArgs
 // "for symmetry" with QueryArgs. The blast radius of that mistake is generated
 // reversal SQL, so it gets its own assertion rather than a comment.
 func TestRecoverArgs_hasNoQueryHashParam(t *testing.T) {


### PR DESCRIPTION
closes #962

## Summary

The MCP `recover` tool's filter params were a parallel copy of the CLI recover surface and had drifted in both directions. This aligns them and makes future drift fail the build.

- **`changed_column` removed from the `recover` tool.** `bintrail recover` deliberately refuses `--changed-column`: a changed-column filter names row *versions*, and reversing a filtered subset of a row's history can produce a state that never existed. Removed rather than kept-and-rejected — the inferred input schema sets `additionalProperties: false`, so a client still sending `changed_column` gets a loud schema-validation error naming the property instead of a silently ignored filter (the dangerous outcome would be a reversal covering more events than the client believes it scoped). This is a **breaking change for MCP clients** that passed `changed_column` to `recover`; per the issue, that filter never should have existed on a reversal surface, and it fails loudly, not silently. `query` keeps `changed_column` unchanged.
- **`pks` and `limit_per_pk` added to both `recover` and `query`** (the CLI query surface also has `--pks`/`--limit-per-pk`), with the CLI's cross-field validation: `pks` requires `schema`+`table`, `pk`/`pks` mutually exclusive, `limit_per_pk` requires a PK scope and rejects negatives, entries trimmed + deduped with empty ones refused. The live+archive merge paths switch `MergeResults` → `MergeAndTrim` so the per-PK cap holds across the union (each source caps independently), mirroring the CLI merge.
- **`BuildQueryOptions` now takes a `FilterParams` struct** (was 12 positional args). `ChangedColumn` is plumbed only by the query handler — `RecoverArgs` no longer has the field — and `QueryHash` stays out of the builder entirely (unchanged, layered on after it by `query` only).
- **Sync test (`paramsync_test.go`)** pins the parity structurally: it enumerates the real CLI flag sets via `cli.AddReadCommands` (the production registration path, not a copy), maps kebab→snake, and compares against the tool arg structs' json params in both directions. Deliberate divergences live in an explicit per-flag CLI-only exception ledger with the reason each flag must not exist on MCP (`--output`/`--dry-run`/`--format`, `--max-script-bytes`, `--allow-gaps`, apply-side codegen flags, `--order`, explicit archive-source flags, DuckDB tuning); a stale ledger entry also fails. `TestRecoverSurfaces_neverChangedColumn` names the design decision explicitly on both surfaces.
- docs/mcp-server.md: the shared-filter list no longer claims both tools accept `changed_column`; documents `pks`/`limit_per_pk` and the recover rationale.

## Testing

- `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, `gofmt -l` clean on touched files.
- `go test ./... -count=1` — full unit suite green.
- `go test -tags integration -count=1 -v ./cmd/bintrail-mcp/... ./internal/mcptools/... ./internal/console/` against the MySQL test container — green, and the DB-backed tests verifiably ran (non-zero durations, no SKIP).
- New `TestRecoverTool_pksAndLimitPerPK` integration test proves the params reach the generated SQL end-to-end: `pks: ["1","2"], limit_per_pk: 1` reverses exactly the latest event per named PK and never touches an unnamed PK.
- Mutation-checked the guards: (1) reintroducing `changed_column` on `RecoverArgs` fails the parity test and the explicit never-changed-column test; (2) renaming/removing the `pks` wire param fails the parity test in both directions; (3) deleting the `PKs: args.PKs` plumbing in the recover handler (schema intact, wiring gone) fails the integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
