### PR TITLE
archive: store start_pos/end_pos unsigned so >2^63 positions archive, and read both schema generations in one scan

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -20,18 +20,27 @@ import (
 // MySQL table order (pk_hash is a stored generated column and is omitted).
 // Exported for reuse by the buffer package when writing Parquet files.
 //
-// event_id / start_pos / end_pos are BIGINT UNSIGNED in MySQL but are scanned as
-// sql.NullInt64 here (ArchivePartition) and never exceed int64 in practice —
-// AUTO_INCREMENT and binlog byte offsets stay well under 2^63 — so the signed
-// Int64 column they map to via MysqlToParquetNode is lossless. connection_id is
-// the one column that genuinely needs the unsigned widening below: it is INT
-// UNSIGNED (a CONNECTION_ID() can exceed int32's 2147483647) and is written via
-// FormatUint by the buffer path, so a signed Int(32) column would reject it.
+// event_id / start_pos / end_pos are BIGINT UNSIGNED in MySQL. event_id is
+// AUTO_INCREMENT (counts from 1, never near 2^63), so its signed Int64 column
+// is lossless. start_pos/end_pos are NOT bounded the same way: pre-#1180
+// builds stored the MariaDB underflow shape (StartPos = 2^64 - EventSize,
+// #986/#1117) in real indexes, so a legitimate stored position exceeds 2^63.
+// They are therefore scanned through sql.Null[uint64] (the #1202/#1217
+// pattern from internal/query) and mapped to UNSIGNED Uint(64) parquet columns
+// (#1218) — widening only the scan against the old signed Int(64) columns
+// would have written a silently wrapped negative to disk. Archives written
+// before #1218 keep signed Int(64) positions forever; parquetquery reads the
+// two generations together in one union_by_name scan (DuckDB promotes the
+// mixed column to HUGEINT) and widens its scan targets to match — see its
+// scanRows. connection_id needs the same treatment one size down: it is INT
+// UNSIGNED (a CONNECTION_ID() can exceed int32's 2147483647) and is written
+// via FormatUint by the buffer path, so a signed Int(32) column would reject
+// it.
 var BinlogEventColumns = []baseline.Column{
 	{Name: "event_id", MySQLType: "bigint", ParquetType: baseline.MysqlToParquetNode("bigint")},
 	{Name: "binlog_file", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
-	{Name: "start_pos", MySQLType: "bigint", ParquetType: baseline.MysqlToParquetNode("bigint")},
-	{Name: "end_pos", MySQLType: "bigint", ParquetType: baseline.MysqlToParquetNode("bigint")},
+	{Name: "start_pos", MySQLType: "bigint", Unsigned: true, ParquetType: baseline.MysqlToParquetNode2("bigint", true)},
+	{Name: "end_pos", MySQLType: "bigint", Unsigned: true, ParquetType: baseline.MysqlToParquetNode2("bigint", true)},
 	{Name: "event_timestamp", MySQLType: "datetime", ParquetType: baseline.MysqlToParquetNode("datetime")},
 	{Name: "gtid", MySQLType: "varchar", ParquetType: baseline.MysqlToParquetNode("varchar")},
 	{Name: "connection_id", MySQLType: "int", Unsigned: true, ParquetType: baseline.MysqlToParquetNode2("int", true)},
@@ -127,11 +136,18 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 		// production observation that "NOT NULL" cannot be trusted in
 		// drifted/external-pipeline-fed indexes. event_id stays a bare
 		// uint64 since AUTO_INCREMENT cannot return NULL.
+		// start_pos/end_pos scan through sql.Null[uint64], not sql.NullInt64:
+		// a stored position above 2^63 (the #986/#1117 MariaDB underflow
+		// shape written by pre-#1180 builds) failed the int64 Scan and the
+		// partition could never archive — so rotation could never drop it
+		// (#1218). The mysql driver hands back uint64 (TEXT protocol) or
+		// []byte above 2^63 (BINARY protocol); convertAssign takes both
+		// losslessly into uint64, same as internal/query's scanRows.
 		var (
 			eventID        uint64
 			binlogFile     sql.NullString
-			startPos       sql.NullInt64
-			endPos         sql.NullInt64
+			startPos       sql.Null[uint64]
+			endPos         sql.Null[uint64]
 			eventTimestamp sql.NullTime
 			gtid           sql.NullString
 			connID         sql.NullInt64
@@ -182,8 +198,8 @@ func ArchivePartition(ctx context.Context, db *sql.DB, dbName, partition, output
 		values := []string{
 			strconv.FormatUint(eventID, 10),
 			binlogFile.String,
-			strconv.FormatInt(startPos.Int64, 10),
-			strconv.FormatInt(endPos.Int64, 10),
+			strconv.FormatUint(startPos.V, 10),
+			strconv.FormatUint(endPos.V, 10),
 			eventTimestampStr,
 			gtid.String,
 			connIDStr,

--- a/internal/archive/archive_integration_test.go
+++ b/internal/archive/archive_integration_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/parquet-go/parquet-go"
 
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/parquetquery"
+	"github.com/dbtrail/dbtrail/internal/query"
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
 
@@ -264,4 +267,144 @@ func TestArchivePartition_commitTsRoundTrip(t *testing.T) {
 	if !row[0][idx].IsNull() {
 		t.Errorf("row 1 commit_ts_us must be a real Parquet NULL, got %v", row[0][idx])
 	}
+}
+
+// ─── #1218: start_pos/end_pos above 2^63 through the rotate + restore paths ──
+
+// oldSignedPositionColumnsTest reproduces the pre-#1218 archive schema:
+// identical to BinlogEventColumns except start_pos/end_pos are the SIGNED
+// Int(64) nodes the old MysqlToParquetNode("bigint") mapping produced. Every
+// archive written before the fix carries this schema on disk forever.
+func oldSignedPositionColumnsTest() []baseline.Column {
+	cols := make([]baseline.Column, len(BinlogEventColumns))
+	copy(cols, BinlogEventColumns)
+	for i, c := range cols {
+		if c.Name == "start_pos" || c.Name == "end_pos" {
+			c.Unsigned = false
+			c.ParquetType = baseline.MysqlToParquetNode("bigint")
+			cols[i] = c
+		}
+	}
+	return cols
+}
+
+// writePositionArchive writes one archive parquet file with the given schema
+// and one INSERT row per (eventID, startPos, endPos, pk) tuple.
+func writePositionArchive(t *testing.T, path string, cols []baseline.Column, rows [][4]string) {
+	t.Helper()
+	w, err := baseline.NewWriter(path, cols, baseline.WriterConfig{Compression: "none"})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	for _, r := range rows {
+		values := []string{r[0], "mariadb-bin.000001", r[1], r[2], "2026-02-19 14:00:00", "", "", "mydb", "orders", "1", r[3], "", "", `{"id":` + r[3] + `}`, "0", "", ""}
+		nulls := []bool{false, false, false, false, false, true, true, false, false, false, false, true, true, false, false, true, true}
+		if err := w.WriteRow(values, nulls); err != nil {
+			t.Fatalf("WriteRow: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+// TestArchivePartition_positionsAbove2to63 is the #1218 rotate-path pin: a
+// partition holding the #986/#1117 MariaDB underflow shape (start_pos =
+// 2^64 - EventSize, stored by pre-#1180 builds and still present in real
+// indexes) used to fail ArchivePartition's int64 Scan — "scan row: ... value
+// out of range" — so the partition never archived and rotation could never
+// drop it. The full loop must now hold: MySQL → ArchivePartition → Parquet →
+// parquetquery.Fetch, with the positions EXACT at the far end.
+func TestArchivePartition_positionsAbove2to63(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	const (
+		bigStart = uint64(18446744073709551516) // 2^64 - 100
+		bigEnd   = uint64(18446744073709551615) // max BIGINT UNSIGNED
+	)
+	ts := "2026-02-19 14:00:00"
+	testutil.InsertEvent(t, db, "mariadb-bin.000001", bigStart, bigEnd, ts, nil,
+		"mydb", "orders", 1, "1", nil, nil, []byte(`{"id":1}`))
+	testutil.InsertEvent(t, db, "mariadb-bin.000001", 100, 200, ts, nil,
+		"mydb", "orders", 1, "2", nil, nil, []byte(`{"id":2}`))
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "events.parquet")
+	stats, err := ArchivePartition(context.Background(), db, dbName, "p_future", outPath, "none")
+	if err != nil {
+		t.Fatalf("ArchivePartition over >2^63 positions failed (the #1218 bug): %v", err)
+	}
+	if stats.Rows != 2 {
+		t.Fatalf("rowCount = %d, want 2", stats.Rows)
+	}
+
+	rows, err := parquetquery.Fetch(context.Background(),
+		query.Options{Schema: "mydb", Table: "orders", Limit: 10}, dir)
+	if err != nil {
+		t.Fatalf("Fetch over the archived file: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	byPK := map[string]query.ResultRow{}
+	for _, r := range rows {
+		byPK[r.PKValues] = r
+	}
+	if r := byPK["1"]; r.StartPos != bigStart || r.EndPos != bigEnd {
+		t.Errorf("pk 1 positions = [%d, %d], want [%d, %d] (exact, no wrap)",
+			r.StartPos, r.EndPos, bigStart, bigEnd)
+	}
+	if r := byPK["2"]; r.StartPos != 100 || r.EndPos != 200 {
+		t.Errorf("pk 2 positions = [%d, %d], want [100, 200]", r.StartPos, r.EndPos)
+	}
+}
+
+// TestRestorePartition_mixedSignedUnsignedPositionArchives pins restore-index's
+// read side across both archive generations: an OLD file (signed Int64
+// positions, pre-#1218) and a NEW file (unsigned Uint64, one position above
+// 2^63) must both load back into binlog_events with exact values —
+// RestorePartition scans per file, so each schema is exercised on its own.
+func TestRestorePartition_mixedSignedUnsignedPositionArchives(t *testing.T) {
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	const (
+		bigStart = uint64(18446744073709551516)
+		bigEnd   = uint64(18446744073709551615)
+	)
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "old-signed.parquet")
+	newPath := filepath.Join(dir, "new-unsigned.parquet")
+	writePositionArchive(t, oldPath, oldSignedPositionColumnsTest(), [][4]string{
+		{"1", "100", "200", "1"},
+	})
+	writePositionArchive(t, newPath, BinlogEventColumns, [][4]string{
+		{"2", "18446744073709551516", "18446744073709551615", "2"},
+	})
+
+	for _, p := range []string{oldPath, newPath} {
+		n, err := RestorePartition(context.Background(), db, p, 0)
+		if err != nil {
+			t.Fatalf("RestorePartition(%s): %v", filepath.Base(p), err)
+		}
+		if n != 1 {
+			t.Fatalf("RestorePartition(%s) loaded %d rows, want 1", filepath.Base(p), n)
+		}
+	}
+
+	check := func(pk string, wantStart, wantEnd uint64) {
+		t.Helper()
+		var start, end uint64
+		if err := db.QueryRow(
+			`SELECT start_pos, end_pos FROM binlog_events WHERE pk_values = ?`, pk).
+			Scan(&start, &end); err != nil {
+			t.Fatalf("read back pk %s: %v", pk, err)
+		}
+		if start != wantStart || end != wantEnd {
+			t.Errorf("pk %s positions = [%d, %d], want [%d, %d]", pk, start, end, wantStart, wantEnd)
+		}
+	}
+	check("1", 100, 200)
+	check("2", bigStart, bigEnd)
 }

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -252,6 +252,71 @@ func TestWriteRowConnectionIDUnsignedDuckDBScan(t *testing.T) {
 	}
 }
 
+// TestWriteRowStartEndPosUnsignedDuckDBScan pins the #1218 write half:
+// start_pos/end_pos are BIGINT UNSIGNED and pre-#1180 builds stored the
+// MariaDB underflow shape (StartPos = 2^64 - EventSize, #986/#1117) in real
+// indexes, so a legitimate stored position exceeds 2^63. Against the old
+// signed Int(64) columns such a value could not be written at all (ParseInt
+// fails loud in convertValue) — which is what kept the partition unarchivable.
+// This drives the production BinlogEventColumns through WriteRow with max
+// uint64 and the underflow shape, then reads back via DuckDB parquet_scan
+// (the real consumer): both must round-trip EXACTLY as unsigned values.
+func TestWriteRowStartEndPosUnsignedDuckDBScan(t *testing.T) {
+	const (
+		bigStart = uint64(18446744073709551516) // 2^64 - 100, the underflow shape
+		bigEnd   = uint64(18446744073709551615) // max BIGINT UNSIGNED
+	)
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "pos.parquet")
+	w, err := baseline.NewWriter(outPath, BinlogEventColumns,
+		baseline.WriterConfig{Compression: "none", RowGroupSize: 100})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	values := make([]string, 15)
+	nulls := make([]bool, 15)
+	for i := range nulls {
+		nulls[i] = true
+	}
+	values[0], nulls[0] = "1", false                    // event_id
+	values[2], nulls[2] = "18446744073709551516", false // start_pos
+	values[3], nulls[3] = "18446744073709551615", false // end_pos
+	values[4], nulls[4] = "2026-02-19 10:00:00", false
+
+	if err := w.WriteRow(values, nulls); err != nil {
+		t.Fatalf("WriteRow(start_pos>2^63): got error, want round-trip: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	safePath := strings.ReplaceAll(outPath, "'", "''")
+	var start, end any
+	if err := db.QueryRowContext(context.Background(),
+		"SELECT start_pos, end_pos FROM parquet_scan('"+safePath+"')").Scan(&start, &end); err != nil {
+		t.Fatalf("scan positions: %v", err)
+	}
+	// BIGINT UNSIGNED → Uint(64) parquet → DuckDB UBIGINT → Go uint64.
+	gotStart, ok := start.(uint64)
+	if !ok {
+		t.Fatalf("start_pos scanned as %T (%v), want uint64", start, start)
+	}
+	gotEnd, ok := end.(uint64)
+	if !ok {
+		t.Fatalf("end_pos scanned as %T (%v), want uint64", end, end)
+	}
+	if gotStart != bigStart || gotEnd != bigEnd {
+		t.Errorf("positions = [%d, %d], want [%d, %d] (exact, no wrap)", gotStart, gotEnd, bigStart, bigEnd)
+	}
+}
+
 // parquetColumnIndex looks up the position of a column in the file's leaf
 // schema. parquet-go's NewReader returns rows whose values are ordered by
 // the schema's leaf walk (alphabetical for our flat schemas), not by the

--- a/internal/buffer/parquet_test.go
+++ b/internal/buffer/parquet_test.go
@@ -13,6 +13,8 @@ import (
 	_ "github.com/duckdb/duckdb-go/v2" // DuckDB driver — exercises the real read path
 	"github.com/parquet-go/parquet-go"
 
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/parquetquery"
 	"github.com/dbtrail/dbtrail/internal/parser"
 	"github.com/dbtrail/dbtrail/internal/query"
 )
@@ -232,5 +234,50 @@ func TestWriteParquet_nullableFields(t *testing.T) {
 	}
 	if pf.NumRows() != 1 {
 		t.Errorf("NumRows = %d, want 1", pf.NumRows())
+	}
+}
+
+// TestWriteParquet_positionsAbove2to63 pins the buffer's write half of #1218:
+// rowToParquet always rendered StartPos/EndPos via FormatUint, so before the
+// archive schema widened those columns to unsigned, a buffered event carrying
+// the #986/#1117 underflow shape (>2^63) aborted WriteParquet at conversion.
+// Now it must round-trip exactly through the real consumer, parquetquery.Fetch.
+func TestWriteParquet_positionsAbove2to63(t *testing.T) {
+	const (
+		bigStart = uint64(18446744073709551516) // 2^64 - 100
+		bigEnd   = uint64(18446744073709551615) // max BIGINT UNSIGNED
+	)
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "buffer.parquet")
+
+	rows := []query.ResultRow{{
+		EventID:        1,
+		BinlogFile:     "mariadb-bin.000001",
+		StartPos:       bigStart,
+		EndPos:         bigEnd,
+		EventTimestamp: time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC),
+		SchemaName:     "mydb",
+		TableName:      "orders",
+		EventType:      event.EventInsert,
+		PKValues:       "1",
+	}}
+	n, err := WriteParquet(rows, outPath, "none")
+	if err != nil {
+		t.Fatalf("WriteParquet(positions>2^63): %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("count = %d, want 1", n)
+	}
+
+	got, err := parquetquery.Fetch(context.Background(), query.Options{Limit: 10}, dir)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("rows = %d, want 1", len(got))
+	}
+	if got[0].StartPos != bigStart || got[0].EndPos != bigEnd {
+		t.Errorf("positions = [%d, %d], want [%d, %d] (exact, no wrap)",
+			got[0].StartPos, got[0].EndPos, bigStart, bigEnd)
 	}
 }

--- a/internal/parquetquery/parquetquery.go
+++ b/internal/parquetquery/parquetquery.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
+	"math/big"
 	"os"
 	"runtime"
 	"slices"
@@ -990,6 +992,20 @@ func limitPerPKClause(opts query.Options) (string, []any) {
 		" ORDER BY event_timestamp DESC, event_id DESC) <= ?", []any{opts.LimitPerPK}
 }
 
+// posArg renders a binlog position for use as a DuckDB bind argument. The
+// duckdb driver rejects a uint64 whose high bit is set ("uint64 values with
+// high bit set are not supported"), and a >2^63 position is exactly the
+// #986/#1117 underflow shape this filter must be able to anchor on (#1218) —
+// so positions above int64 bind as *big.Int (HUGEINT), which DuckDB compares
+// exactly against BIGINT, UBIGINT, and HUGEINT position columns alike. The
+// common below-2^63 case keeps the plain uint64 fast path.
+func posArg(pos uint64) any {
+	if pos > math.MaxInt64 {
+		return new(big.Int).SetUint64(pos)
+	}
+	return pos
+}
+
 // buildFilters extracts WHERE clause fragments and bind args from query options.
 func buildFilters(opts query.Options, cols map[string]bool) ([]string, []any) {
 	var where []string
@@ -1036,7 +1052,7 @@ func buildFilters(opts query.Options, cols map[string]bool) ([]string, []any) {
 		where = append(where, "(length(binlog_file) > length(?)"+
 			" OR (length(binlog_file) = length(?) AND binlog_file > ?)"+
 			" OR (binlog_file = ? AND start_pos >= ?))")
-		args = append(args, opts.SincePos.File, opts.SincePos.File, opts.SincePos.File, opts.SincePos.File, opts.SincePos.Pos)
+		args = append(args, opts.SincePos.File, opts.SincePos.File, opts.SincePos.File, opts.SincePos.File, posArg(opts.SincePos.Pos))
 	} else if opts.Since != nil {
 		where = append(where, "event_timestamp >= ?")
 		args = append(args, *opts.Since)
@@ -1054,7 +1070,7 @@ func buildFilters(opts query.Options, cols map[string]bool) ([]string, []any) {
 		where = append(where, "(length(binlog_file) < length(?)"+
 			" OR (length(binlog_file) = length(?) AND binlog_file < ?)"+
 			" OR (binlog_file = ? AND end_pos <= ?))")
-		args = append(args, opts.UntilPos.File, opts.UntilPos.File, opts.UntilPos.File, opts.UntilPos.File, opts.UntilPos.Pos)
+		args = append(args, opts.UntilPos.File, opts.UntilPos.File, opts.UntilPos.File, opts.UntilPos.File, posArg(opts.UntilPos.Pos))
 	}
 	if opts.AfterEvent != nil {
 		// Keyset cut on the composite sort key, mirroring internal/query's
@@ -1317,11 +1333,22 @@ func scanRows(rows *sql.Rows) ([]query.ResultRow, error) {
 		// every column its Scan saw as NULL, so the consumer side must
 		// handle the same set. See dbtrail/bintrail#318. event_id stays
 		// a bare int64 since AUTO_INCREMENT cannot be NULL.
+		// start_pos/end_pos scan through sql.Null[uint64], not sql.NullInt64
+		// (#1218): a >2^63 position (the #986/#1117 MariaDB underflow shape
+		// written by pre-#1180 builds) does not fit the int64 path. The
+		// driver hands back three shapes, one per archive generation mix —
+		// int64 from a signed pre-#1218 file, uint64 from a current unsigned
+		// file, and *big.Int when one union_by_name scan covers BOTH
+		// generations (DuckDB promotes BIGINT ∪ UBIGINT to HUGEINT).
+		// convertAssign takes all three losslessly into uint64 (*big.Int via
+		// its exact decimal-string fallback); the int64 destination was the
+		// one that failed, on two of the three. Pinned against real files by
+		// TestFetch_mixedSignedUnsignedPositionArchives and siblings.
 		var (
 			eventID        int64
 			binlogFile     sql.NullString
-			startPos       sql.NullInt64
-			endPos         sql.NullInt64
+			startPos       sql.Null[uint64]
+			endPos         sql.Null[uint64]
 			eventTimestamp sql.NullTime
 			gtid           sql.NullString
 			connID         sql.NullInt64
@@ -1349,8 +1376,8 @@ func scanRows(rows *sql.Rows) ([]query.ResultRow, error) {
 		r := query.ResultRow{
 			EventID:        uint64(eventID),
 			BinlogFile:     binlogFile.String,
-			StartPos:       uint64(startPos.Int64),
-			EndPos:         uint64(endPos.Int64),
+			StartPos:       startPos.V,
+			EndPos:         endPos.V,
 			EventTimestamp: eventTimestamp.Time,
 			SchemaName:     schemaName.String,
 			TableName:      tableName.String,

--- a/internal/parquetquery/position_uint64_test.go
+++ b/internal/parquetquery/position_uint64_test.go
@@ -1,0 +1,218 @@
+package parquetquery
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dbtrail/dbtrail/internal/archive"
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/query"
+)
+
+// ─── #1218 start_pos/end_pos above 2^63 through Fetch ────────────────────────
+//
+// start_pos/end_pos are BIGINT UNSIGNED in MySQL. Pre-#1180 builds wrote the
+// MariaDB underflow shape (StartPos = 2^64 - EventSize) into real indexes, so
+// a legitimate stored position can exceed 2^63. The archive schema stored them
+// as SIGNED Int(64) parquet columns until #1218; the fixed schema is Uint(64).
+// Both generations of file exist on disk simultaneously, and one multi-file
+// DuckDB scan must read them together. These tests are the empirical proof of
+// the mixed-schema design: an old signed file and a new unsigned file carrying
+// a >2^63 position are scanned in ONE parquet_scan(union_by_name=true) and
+// every position comes back EXACT — no float promotion, no wrap, no scan error.
+
+const (
+	// The #986/#1117 MariaDB underflow shape: 2^64 - EventSize.
+	bigStartPos = uint64(18446744073709551516) // 2^64 - 100
+	bigEndPos   = uint64(18446744073709551615) // 2^64 - 1 (max BIGINT UNSIGNED)
+)
+
+// oldSignedPositionColumns reproduces the pre-#1218 archive schema exactly:
+// identical to archive.BinlogEventColumns except start_pos/end_pos are the
+// SIGNED Int(64) nodes MysqlToParquetNode("bigint") used to produce. Every
+// archive written before the fix carries this schema on disk forever, so the
+// fixture writer is pinned here rather than deleted with the production code.
+func oldSignedPositionColumns() []baseline.Column {
+	cols := make([]baseline.Column, len(archive.BinlogEventColumns))
+	copy(cols, archive.BinlogEventColumns)
+	for i, c := range cols {
+		if c.Name == "start_pos" || c.Name == "end_pos" {
+			c.Unsigned = false
+			c.ParquetType = baseline.MysqlToParquetNode("bigint")
+			cols[i] = c
+		}
+	}
+	return cols
+}
+
+// writeArchiveFileInto writes one parquet file with the given column schema at
+// dir/name (writeArchiveFixture's sibling for multi-file directories).
+func writeArchiveFileInto(t *testing.T, dir, name string, cols []baseline.Column, rows [][2][]string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	w, err := baseline.NewWriter(path, cols, baseline.WriterConfig{Compression: "none"})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	for _, r := range rows {
+		values, nullFlags := r[0], r[1]
+		nulls := make([]bool, len(nullFlags))
+		for i, f := range nullFlags {
+			nulls[i] = f == "1"
+		}
+		if err := w.WriteRow(values, nulls); err != nil {
+			t.Fatalf("WriteRow: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	return path
+}
+
+// positionRow builds one 17-value fixture row (commit_ts_us omitted → NULL)
+// with the given event_id, timestamp and positions.
+func positionRow(id, ts, startPos, endPos, pk string) [2][]string {
+	return [2][]string{
+		{id, "mariadb-bin.000001", startPos, endPos, ts, "", "", "mydb", "orders", "1", pk, "", "", `{"id":` + pk + `}`, "0", "", ""},
+		{"0", "0", "0", "0", "0", "1", "1", "0", "0", "0", "0", "1", "1", "0", "0", "1", "1"},
+	}
+}
+
+// TestFetch_mixedSignedUnsignedPositionArchives is the design-deciding test for
+// #1218's read side: a directory holding an OLD archive (signed Int64
+// positions, written pre-fix) next to a NEW archive (unsigned Uint64 positions,
+// one of them above 2^63) is read through Fetch's real local-glob path — one
+// parquet_scan over both files with union_by_name=true. Both files' positions
+// must come back exactly.
+func TestFetch_mixedSignedUnsignedPositionArchives(t *testing.T) {
+	if os.Getenv("CGO_ENABLED") == "0" {
+		t.Skip("DuckDB requires CGO")
+	}
+	dir := t.TempDir()
+	writeArchiveFileInto(t, dir, "old-signed.parquet", oldSignedPositionColumns(), [][2][]string{
+		positionRow("1", "2026-02-19 14:00:00", "100", "200", "1"),
+	})
+	writeArchiveFileInto(t, dir, "new-unsigned.parquet", archive.BinlogEventColumns, [][2][]string{
+		positionRow("2", "2026-02-19 15:00:00", "18446744073709551516", "18446744073709551615", "2"),
+	})
+
+	rows, err := Fetch(context.Background(), query.Options{Schema: "mydb", Table: "orders", Limit: 10}, dir)
+	if err != nil {
+		t.Fatalf("Fetch over mixed signed/unsigned position archives: %v", err)
+	}
+	assertMixedPositionRows(t, rows)
+}
+
+// TestQueryFileList_mixedSignedUnsignedPositionArchives drives the same mixed
+// pair through queryFileList — the multi-file scan behind the S3-direct
+// (--ultrafast) path, whose SQL comes from buildQueryFromFiles rather than
+// buildQueryForFile. Local paths, per queryFileList's contract: only the
+// transport differs from s3://.
+func TestQueryFileList_mixedSignedUnsignedPositionArchives(t *testing.T) {
+	if os.Getenv("CGO_ENABLED") == "0" {
+		t.Skip("DuckDB requires CGO")
+	}
+	dir := t.TempDir()
+	oldFile := writeArchiveFileInto(t, dir, "old-signed.parquet", oldSignedPositionColumns(), [][2][]string{
+		positionRow("1", "2026-02-19 14:00:00", "100", "200", "1"),
+	})
+	newFile := writeArchiveFileInto(t, dir, "new-unsigned.parquet", archive.BinlogEventColumns, [][2][]string{
+		positionRow("2", "2026-02-19 15:00:00", "18446744073709551516", "18446744073709551615", "2"),
+	})
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	rows, err := queryFileList(context.Background(), db, []string{oldFile, newFile},
+		query.Options{Schema: "mydb", Table: "orders", Limit: 10})
+	if err != nil {
+		t.Fatalf("queryFileList over mixed signed/unsigned position archives: %v", err)
+	}
+	assertMixedPositionRows(t, rows)
+}
+
+func assertMixedPositionRows(t *testing.T, rows []query.ResultRow) {
+	t.Helper()
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	byPK := map[string]query.ResultRow{}
+	for _, r := range rows {
+		byPK[r.PKValues] = r
+	}
+	oldRow, ok := byPK["1"]
+	if !ok {
+		t.Fatalf("old-signed file's row missing; got %v", byPK)
+	}
+	if oldRow.StartPos != 100 || oldRow.EndPos != 200 {
+		t.Errorf("old file positions = [%d, %d], want [100, 200]", oldRow.StartPos, oldRow.EndPos)
+	}
+	newRow, ok := byPK["2"]
+	if !ok {
+		t.Fatalf("new-unsigned file's row missing; got %v", byPK)
+	}
+	if newRow.StartPos != bigStartPos || newRow.EndPos != bigEndPos {
+		t.Errorf("new file positions = [%d, %d], want [%d, %d] (exact, no wrap/float promotion)",
+			newRow.StartPos, newRow.EndPos, bigStartPos, bigEndPos)
+	}
+}
+
+// TestFetch_oldSignedPositionArchiveAlone pins the single-file read of a
+// pre-#1218 archive: no union promotion is in play (the whole scan is signed
+// BIGINT), and the widened scan targets must still accept it.
+func TestFetch_oldSignedPositionArchiveAlone(t *testing.T) {
+	if os.Getenv("CGO_ENABLED") == "0" {
+		t.Skip("DuckDB requires CGO")
+	}
+	dir := t.TempDir()
+	writeArchiveFileInto(t, dir, "old-signed.parquet", oldSignedPositionColumns(), [][2][]string{
+		positionRow("1", "2026-02-19 14:00:00", "100", "200", "1"),
+	})
+
+	rows, err := Fetch(context.Background(), query.Options{Schema: "mydb", Table: "orders", Limit: 10}, dir)
+	if err != nil {
+		t.Fatalf("Fetch over an old signed-position archive: %v", err)
+	}
+	if len(rows) != 1 || rows[0].StartPos != 100 || rows[0].EndPos != 200 {
+		t.Fatalf("rows = %+v, want one row with positions [100, 200]", rows)
+	}
+}
+
+// TestFetch_untilPosAbove2to63 pins the position PREDICATE over a >2^63 anchor:
+// buildFilters binds UntilPos.Pos as a uint64 and compares it against the
+// (possibly type-promoted) end_pos column, so the cut must land exactly even
+// when both sides exceed int64.
+func TestFetch_untilPosAbove2to63(t *testing.T) {
+	if os.Getenv("CGO_ENABLED") == "0" {
+		t.Skip("DuckDB requires CGO")
+	}
+	dir := t.TempDir()
+	writeArchiveFileInto(t, dir, "new-unsigned.parquet", archive.BinlogEventColumns, [][2][]string{
+		positionRow("1", "2026-02-19 14:00:00", "100", "200", "1"),                                   // ≤ anchor (included)
+		positionRow("2", "2026-02-19 15:00:00", "18446744073709551516", "18446744073709551615", "2"), // > anchor (excluded)
+		positionRow("3", "2026-02-19 15:30:00", "18446744073709551000", "18446744073709551516", "3"), // end == anchor (included)
+	})
+
+	rows, err := Fetch(context.Background(), query.Options{
+		Schema: "mydb", Table: "orders",
+		UntilPos: &query.BinlogPos{File: "mariadb-bin.000001", Pos: bigStartPos},
+		Limit:    10,
+	}, dir)
+	if err != nil {
+		t.Fatalf("Fetch with a >2^63 UntilPos anchor: %v", err)
+	}
+	got := map[string]bool{}
+	for _, r := range rows {
+		got[r.PKValues] = true
+	}
+	if len(rows) != 2 || !got["1"] || !got["3"] {
+		t.Fatalf("expected exactly pks {1,3} at-or-before the >2^63 anchor, got %v", got)
+	}
+}


### PR DESCRIPTION
closes #1218

## Summary

`start_pos`/`end_pos` are BIGINT UNSIGNED, and pre-#1180 builds stored the MariaDB underflow shape (`StartPos = 2^64 - EventSize`, #986/#1117) in real indexes. `ArchivePartition` scanned them through `sql.NullInt64`, so any partition holding such a row failed with `scan row: ... value out of range` — the partition never archived, and rotation could never drop it. PR #1217 deliberately left this half unfixed: widening only the scan would have written a silently wrapped negative into the signed `Int(64)` parquet columns.

This fixes every side at once:

- **Write**: `BinlogEventColumns` now maps `start_pos`/`end_pos` through `MysqlToParquetNode2("bigint", true)` → `Uint(64)`; `ArchivePartition` scans them via `sql.Null[uint64]` (the #1202/#1217 pattern from `internal/query`) and renders with `FormatUint`. The stale `archive.go:24` "never exceed int64 in practice" comment is replaced with the real invariants.
- **Read — the mixed-schema compat design**: archives written before this change carry signed `Int(64)` positions forever, so `parquetquery`'s multi-file scans cover both generations. Decided empirically, test-first (`TestFetch_mixedSignedUnsignedPositionArchives`, real DuckDB over real files): one `parquet_scan(union_by_name=true)` over an old signed file plus a new unsigned file promotes the column to **HUGEINT**, which the duckdb driver returns as `*big.Int` — the old `sql.NullInt64` targets failed exactly there. `scanRows` widens to `sql.Null[uint64]`, which takes all three driver shapes losslessly into uint64: `int64` (old-only scan), `uint64` (new-only), `*big.Int` (mixed, via `convertAssign`'s exact decimal-string fallback). The test asserts byte-exact positions on both sides — no float promotion, no wrap. A `CAST(... AS UBIGINT)` projection was prototyped and then dropped: with the widened scan targets it changed no observable behavior (mutating it away failed no test), while reverting the scan widening fails the mixed-dir test with the `*big.Int` scan error.
- **Predicates**: the duckdb driver rejects binding a `uint64` with the high bit set, so `SincePos`/`UntilPos` anchors above 2^63 bind as `*big.Int` (HUGEINT) via the new `posArg`; below 2^63 keeps the plain `uint64` fast path. Pinned by `TestFetch_untilPosAbove2to63`.
- **Every other reader/writer audited**: `RestorePartition` (restore-index) needed no code change — it scans into `any` by introspected column name and go-sql-driver accepts `uint64` args — but the mixed-generation load into MySQL is now pinned by an integration test. `buffer.WriteParquet` already rendered `FormatUint` (it aborted loudly on >2^63 against the signed column; now it round-trips, pinned). `internal/views` projects the columns by name only (untyped view SQL, unaffected). `ResolveSnapshotCut` scans a bare `uint64` (already safe). The live-MySQL side was already fixed by #1217.

## Testing

- New `internal/parquetquery/position_uint64_test.go` (real DuckDB): mixed signed+unsigned directory through `Fetch` (local-glob path) and through `queryFileList` (the S3-direct/`--ultrafast` builder), old-signed file alone, and a >2^63 `UntilPos` anchor. Written FIRST against the unfixed code (failed as the issue describes) and used to decide the compat design.
- New `internal/archive` tests: unit `TestWriteRowStartEndPosUnsignedDuckDBScan` (WriteRow → DuckDB scan, exact uint64); integration `TestArchivePartition_positionsAbove2to63` (real MySQL → `ArchivePartition` → `parquetquery.Fetch`, the exact failure loop from the issue) and `TestRestorePartition_mixedSignedUnsignedPositionArchives` (both generations loaded back into MySQL exactly).
- New `internal/buffer` test: `TestWriteParquet_positionsAbove2to63` round-trips through `parquetquery.Fetch`.
- Mutation checks, each restored after: (a) schema back to signed → write round-trip tests fail at `ParseInt`; (b) `scanRows` back to `sql.NullInt64` → mixed-dir and >2^63 tests fail with the `*big.Int`/`uint64`→int64 scan errors; (c) `posArg` neutered → `TestFetch_untilPosAbove2to63` fails with `uint64 values with high bit set are not supported`.
- `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, `gofmt` clean on touched files, full `go test ./... -count=1` green, and `go test -tags integration` for archive/parquetquery/buffer against the MySQL container: 137 PASS, 0 SKIP, 0 FAIL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
