### PR TITLE
merge: surface index/archive divergence in console and MCP response warnings

### DIFF
--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -296,7 +296,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	// row is not a paging escape hatch for pulling the index into a browser.
 	pageLimit := opts.Limit
 	opts.Limit = pageLimit + 1
-	rows, plan, excl, err := s.fetchRestricted(r.Context(), r, b, opts)
+	rows, plan, excl, diverged, err := s.fetchRestricted(r.Context(), r, b, opts)
 	if err != nil {
 		writeFetchError(w, err)
 		return
@@ -306,11 +306,14 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		rows = rows[:pageLimit]
 	}
 	resp := eventsResponse{
-		Events:   toEventDTOs(rows),
-		Count:    len(rows),
-		Limit:    pageLimit,
-		HasMore:  hasMore,
-		Warnings: restrictedFetchWarnings(plan, excl),
+		Events:  toEventDTOs(rows),
+		Count:   len(rows),
+		Limit:   pageLimit,
+		HasMore: hasMore,
+		// The divergence finding (#1325) rides the same warnings list: the
+		// merge's slog.Warn dies in the daemon log, and this operator is in a
+		// browser.
+		Warnings: appendDivergenceWarning(restrictedFetchWarnings(plan, excl), diverged),
 	}
 	// The cursor comes from the last row of the page the client is about to
 	// see, in the direction it is reading. Built server-side from a served row
@@ -390,12 +393,16 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 	// Coverage gaps come back in plan.GapHours and are surfaced as warnings
 	// below — the recover UI renders them, so an incomplete-coverage undo is
 	// flagged to the operator rather than silently presented as complete.
-	rows, plan, excl, err := s.fetchRestricted(r.Context(), r, b, opts)
+	rows, plan, excl, diverged, err := s.fetchRestricted(r.Context(), r, b, opts)
 	if err != nil {
 		writeFetchError(w, err)
 		return
 	}
-	warnings := restrictedFetchWarnings(plan, excl)
+	// The divergence finding (#1325) is sharpest here: the kept copy's row
+	// images become the SET/WHERE clauses of the generated reversal SQL, so a
+	// silent coin-flip between two disagreeing before-images must reach the
+	// operator reviewing the script.
+	warnings := appendDivergenceWarning(restrictedFetchWarnings(plan, excl), diverged)
 
 	// The fetch above ran Order=DESC so the limit kept the newest suffix of
 	// the window (#981). Detect truncation on the FETCHED row count — before

--- a/internal/console/coverage_warnings.go
+++ b/internal/console/coverage_warnings.go
@@ -1,6 +1,10 @@
 package console
 
-import "github.com/dbtrail/dbtrail/internal/query"
+import (
+	"fmt"
+
+	"github.com/dbtrail/dbtrail/internal/query"
+)
 
 // coverageWarnings extends gapWarnings with the two allow_gaps blind spots
 // (#1281) — conditions where partial state would otherwise render with no
@@ -34,6 +38,28 @@ func coverageWarnings(plan *query.QueryPlan, skippedSources []string, allowGaps 
 	}
 	if allowGaps && plan == nil {
 		w = append(w, "coverage could not be verified (query planner unavailable): gaps in the captured history may be undetected")
+	}
+	return w
+}
+
+// divergenceWarning renders the merge-layer divergence finding (#1325) for the
+// events and recover responses: two copies of one event_id — live index vs an
+// archived partition — disagreed, and one was silently chosen. The merge layer
+// already slog.Warns with per-event detail; this is the response-level echo for
+// an operator who is in a browser, not in the daemon log. It matters most on
+// the recover path, where the chosen copy's row images become the generated
+// reversal SQL. The wording claims no winner: which copy is kept is a
+// positional convention of the caller, not a contract of the merge (see the
+// comment inside query.MergeResultsReport).
+func divergenceWarning(n int) string {
+	return fmt.Sprintf("%d duplicate event(s) disagreed between the live index and an archive copy; the first copy fetched (normally the live index) was used. An archived partition should be a byte-for-byte copy of the index rows — a mismatch means the index row changed after archiving, or two index generations wrote under the same bintrail_id. Details are in the server log.", n)
+}
+
+// appendDivergenceWarning appends divergenceWarning when the merge reported
+// any diverging duplicates, else returns w unchanged.
+func appendDivergenceWarning(w []string, diverged int) []string {
+	if diverged > 0 {
+		w = append(w, divergenceWarning(diverged))
 	}
 	return w
 }

--- a/internal/console/coverage_warnings_test.go
+++ b/internal/console/coverage_warnings_test.go
@@ -43,3 +43,28 @@ func TestCoverageWarnings(t *testing.T) {
 		}
 	})
 }
+
+// #1325: the merge divergence finding must render once, count-first, and the
+// zero case must append nothing (cry-wolf rule — the normal
+// archived-but-not-dropped overlap produces agreeing duplicates, count 0).
+func TestAppendDivergenceWarning(t *testing.T) {
+	if w := appendDivergenceWarning(nil, 0); len(w) != 0 {
+		t.Errorf("count 0 must append nothing, got %#v", w)
+	}
+	base := []string{"existing"}
+	w := appendDivergenceWarning(base, 3)
+	if len(w) != 2 || w[0] != "existing" {
+		t.Fatalf("expected existing warning + one divergence entry, got %#v", w)
+	}
+	for _, want := range []string{"3 duplicate event(s) disagreed", "archive copy", "byte-for-byte"} {
+		if !strings.Contains(w[1], want) {
+			t.Errorf("warning lacks %q: %s", want, w[1])
+		}
+	}
+	// The console DTO boundary deliberately omits row internals
+	// (connection_id/query_text); the warning must not smuggle any in — it
+	// carries a COUNT, and per-event detail stays in the server log.
+	if strings.Contains(w[1], "connection_id") || strings.Contains(w[1], "query_text") {
+		t.Errorf("warning must not name row internals: %s", w[1])
+	}
+}

--- a/internal/console/divergence_warning_integration_test.go
+++ b/internal/console/divergence_warning_integration_test.go
@@ -1,0 +1,133 @@
+//go:build integration
+
+package console
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/buffer"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// The unit tests prove MergeResultsReport counts a diverging duplicate and
+// appendDivergenceWarning renders it. This proves the count reaches the WIRE
+// (#1325): the real handlers are driven end to end against a live index plus
+// a registered Parquet archive holding (a) the live row's event_id with a
+// DISAGREEING row image and (b) one archive-only event. (b) is the non-vacuous
+// precondition: Count must include it, proving the archive was actually read
+// and merged — without it, a silently-unread archive would let the warning
+// assertions pass or fail for the wrong reason (the #1321 lesson).
+//
+// Mutating fetchRestricted to drop the diverged count, or either handler to
+// skip appendDivergenceWarning, turns this red while the unit tests stay green.
+func TestIntegrationMergeDivergenceReachesResponseWarnings(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	testutil.InsertEvent(t, db, "bin.000001", 4, 40, "2026-06-01 12:00:00", nil,
+		"app", "users", 1 /*INSERT*/, "1", nil, nil, []byte(`{"id":1,"name":"alice"}`))
+	var eventID uint64
+	if err := db.QueryRow(`SELECT event_id FROM binlog_events LIMIT 1`).Scan(&eventID); err != nil {
+		t.Fatalf("read event_id: %v", err)
+	}
+
+	srv, err := New(Config{DB: db, DBName: dbName, Listen: "127.0.0.1:8090", Token: intToken})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	getEvents := func(t *testing.T) (int, []string) {
+		t.Helper()
+		r := httptest.NewRequest("GET", "http://127.0.0.1:8090/api/events?schema=app&table=users", nil)
+		r.Host = "127.0.0.1:8090"
+		w := httptest.NewRecorder()
+		srv.handleEvents(w, r)
+		if w.Code != 200 {
+			t.Fatalf("events code = %d, body = %s", w.Code, w.Body.String())
+		}
+		var resp struct {
+			Count    int      `json:"count"`
+			Warnings []string `json:"warnings"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v\n%s", err, w.Body.String())
+		}
+		return resp.Count, resp.Warnings
+	}
+
+	// Cry-wolf control: no archive registered → nothing merged, no warning.
+	if _, warnings := getEvents(t); strings.Contains(strings.Join(warnings, "\n"), "disagreed") {
+		t.Errorf("no archive → no divergence warning, got %#v", warnings)
+	}
+
+	// A valid archive: the live event's id with a mutated row image, plus an
+	// archive-only sibling.
+	ts := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	diverging := query.ResultRow{
+		EventID: eventID, BinlogFile: "bin.000001", StartPos: 4, EndPos: 40,
+		EventTimestamp: ts, SchemaName: "app", TableName: "users",
+		EventType: 1, PKValues: "1",
+		RowAfter: map[string]any{"id": 1, "name": "MUTATED"},
+	}
+	archiveOnly := query.ResultRow{
+		EventID: eventID + 1000, BinlogFile: "bin.000001", StartPos: 41, EndPos: 80,
+		EventTimestamp: ts.Add(time.Minute), SchemaName: "app", TableName: "users",
+		EventType: 1, PKValues: "2",
+		RowAfter: map[string]any{"id": 2, "name": "bob-from-archive"},
+	}
+	base := filepath.Join(t.TempDir(), "bintrail_id=div-test")
+	hourDir := filepath.Join(base, "date=2026-06-01", "hour=12")
+	if err := os.MkdirAll(hourDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pq := filepath.Join(hourDir, "events.parquet")
+	if _, err := buffer.WriteParquet([]query.ResultRow{diverging, archiveOnly}, pq, "none"); err != nil {
+		t.Fatalf("WriteParquet: %v", err)
+	}
+	testutil.MustExec(t, db, `INSERT INTO archive_state
+		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key, s3_uploaded_at)
+		VALUES ('p_2026060112', 'div-test', ?, 2, NULL, NULL, NULL)`, pq)
+
+	// Events browser: the divergence must land in the response warnings.
+	count, warnings := getEvents(t)
+	if count != 2 {
+		t.Fatalf("count = %d, want 2 (live row + archive-only row) — the archive was not merged, so the warning assertion below would be vacuous; warnings: %#v", count, warnings)
+	}
+	got := strings.Join(warnings, "\n")
+	if !strings.Contains(got, "1 duplicate event(s) disagreed between the live index and an archive copy") {
+		t.Errorf("events response does not carry the divergence warning: %#v", warnings)
+	}
+
+	// Recover: the same finding is sharpest here — the kept copy's row images
+	// become the reversal SQL the operator is reviewing.
+	{
+		body := strings.NewReader(`{"schema":"app","table":"users"}`)
+		r := httptest.NewRequest("POST", "http://127.0.0.1:8090/api/recover", body)
+		r.Host = "127.0.0.1:8090"
+		w := httptest.NewRecorder()
+		srv.handleRecover(w, r)
+		if w.Code != 200 {
+			t.Fatalf("recover code = %d, body = %s", w.Code, w.Body.String())
+		}
+		var resp struct {
+			SQL      string   `json:"sql"`
+			RowCount int      `json:"row_count"`
+			Warnings []string `json:"warnings"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode recover: %v\n%s", err, w.Body.String())
+		}
+		if resp.RowCount != 2 || resp.SQL == "" {
+			t.Fatalf("recover did not process the merged rows (row_count=%d, sql empty=%v) — the warning assertion below would be vacuous", resp.RowCount, resp.SQL == "")
+		}
+		if !strings.Contains(strings.Join(resp.Warnings, "\n"), "disagreed between the live index and an archive copy") {
+			t.Errorf("recover response does not carry the divergence warning: %#v", resp.Warnings)
+		}
+	}
+}

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -431,7 +431,7 @@ func (s *Server) handleReconstruct(w http.ResponseWriter, r *http.Request) {
 		AllowGaps:      allowGaps,
 		ArchiveFetcher: parquetquery.Fetch,
 	}
-	rows, plan, skippedSources, err := query.FetchMergedFull(ctx, b.db, b.engine, fmOpts)
+	rows, plan, skippedSources, diverged, err := query.FetchMergedFull(ctx, b.db, b.engine, fmOpts)
 	if err != nil {
 		var gapErr *query.GapError
 		if errors.As(err, &gapErr) {
@@ -479,10 +479,13 @@ func (s *Server) handleReconstruct(w http.ResponseWriter, r *http.Request) {
 		At:           atTime.Format(consoleTSFormat),
 		BaselineTime: snapshotTime.Format(consoleTSFormat),
 		EventCount:   len(rows),
-		// Surface a stale-baseline fallback (#466) and a rendering-GUC stamp
-		// mismatch (#921) alongside coverage-gap warnings: the server already
-		// logs these; this puts them in front of the operator.
-		Warnings: appendRenderGUCsWarning(appendStaleWarning(coverageWarnings(plan, skippedSources, allowGaps), stale), bmeta),
+		// Surface a stale-baseline fallback (#466), a rendering-GUC stamp
+		// mismatch (#921) and a merge divergence (#1325) alongside
+		// coverage-gap warnings: the server already logs these; this puts
+		// them in front of the operator.
+		Warnings: appendDivergenceWarning(
+			appendRenderGUCsWarning(appendStaleWarning(coverageWarnings(plan, skippedSources, allowGaps), stale), bmeta),
+			diverged),
 	}
 
 	// 3. Fold baseline + deltas. baselineRow may be nil. "existed" = the row was

--- a/internal/console/session_profile.go
+++ b/internal/console/session_profile.go
@@ -216,16 +216,25 @@ func (s *Server) applySessionProfile(ctx context.Context, r *http.Request, b *bu
 // archives OFF when the request's session carries a data profile: Parquet
 // archives do not run the redaction pass, so a profiled session must read live
 // MySQL only (the same reason a startup profile forces --no-archive process-wide).
-func (s *Server) fetchRestricted(ctx context.Context, r *http.Request, b *bundle, opts query.Options) ([]query.ResultRow, *query.QueryPlan, archiveExclusion, error) {
+//
+// diverged is the count of duplicate event_ids whose live-index and archive
+// copies DISAGREED during the merge (#1325); the handlers put it in the
+// response warnings, since a console operator never sees the server log where
+// the merge already warns. The skipped-sources list FetchMergedFull also
+// returns stays deliberately unused here: for these browsing endpoints a
+// partially-failing archive source remains a log-only condition (the
+// documented trade-off on Server.fetch), and adopting it is a separate
+// decision from surfacing divergence.
+func (s *Server) fetchRestricted(ctx context.Context, r *http.Request, b *bundle, opts query.Options) ([]query.ResultRow, *query.QueryPlan, archiveExclusion, int, error) {
 	excl := archiveExclusionFor(r, b)
-	rows, plan, err := query.FetchMerged(ctx, b.db, b.engine, query.FetchMergedOptions{
+	rows, plan, _, diverged, err := query.FetchMergedFull(ctx, b.db, b.engine, query.FetchMergedOptions{
 		Opts:           opts,
 		DBName:         b.dbName,
 		NoArchive:      excl.any(),
 		AllowGaps:      true,
 		ArchiveFetcher: parquetquery.Fetch,
 	})
-	return rows, plan, excl, err
+	return rows, plan, excl, diverged, err
 }
 
 // archiveExclusion records WHY a fetch left the Parquet archives out (#1311),

--- a/internal/mcptools/divergence_integration_test.go
+++ b/internal/mcptools/divergence_integration_test.go
@@ -1,0 +1,125 @@
+//go:build integration
+
+package mcptools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/dbtrail/dbtrail/internal/buffer"
+	"github.com/dbtrail/dbtrail/internal/indexer"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestIntegrationMergeDivergenceWarning drives the REAL query and recover
+// tools against a live index plus a registered Parquet archive that holds
+// (a) the same event_id as the live row with a DISAGREEING row image and
+// (b) one archive-only event. (b) is the non-vacuous precondition: its data
+// must appear in the result, proving the archive was actually read and merged
+// — without it, a silently-unread archive would make the warning assertion
+// pass or fail for the wrong reason (the #1321 lesson).
+//
+// Mutating MakeQueryTool to call MergeResults instead of MergeResultsReport,
+// dropping the EventDivergenceNotice append, or dropping the recover tool's
+// SQL-comment warning turns this red while every unit test stays green.
+func TestIntegrationMergeDivergenceWarning(t *testing.T) {
+	testutil.SkipIfNoMySQL(t)
+	db, _ := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+	if err := indexer.EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	testutil.InsertEvent(t, db, "bin.000001", 4, 40, "2026-06-01 12:00:00", nil,
+		"app", "users", 1 /*INSERT*/, "1", nil, nil, []byte(`{"id":1,"name":"alice"}`))
+	var eventID uint64
+	if err := db.QueryRow(`SELECT event_id FROM binlog_events LIMIT 1`).Scan(&eventID); err != nil {
+		t.Fatalf("read event_id: %v", err)
+	}
+
+	cfg := Config{
+		Resolve: func(context.Context, string) (*Target, error) {
+			return &Target{DB: db}, nil
+		},
+	}
+
+	// Cry-wolf control: with no archive registered there is nothing to merge
+	// and no divergence warning may render.
+	q0, _, err := MakeQueryTool(cfg)(context.Background(), &mcp.CallToolRequest{}, QueryArgs{Schema: "app", Table: "users"})
+	if err != nil {
+		t.Fatalf("query handler (no archive): %v", err)
+	}
+	if txt := resultText(q0); strings.Contains(txt, "event_divergence") {
+		t.Errorf("no archive → no divergence warning, got: %s", txt)
+	}
+
+	// A valid archive: the live event's id with a mutated row image, plus an
+	// archive-only sibling.
+	ts := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	diverging := query.ResultRow{
+		EventID: eventID, BinlogFile: "bin.000001", StartPos: 4, EndPos: 40,
+		EventTimestamp: ts, SchemaName: "app", TableName: "users",
+		EventType: 1, PKValues: "1",
+		RowAfter: map[string]any{"id": 1, "name": "MUTATED"},
+	}
+	archiveOnly := query.ResultRow{
+		EventID: eventID + 1000, BinlogFile: "bin.000001", StartPos: 41, EndPos: 80,
+		EventTimestamp: ts.Add(time.Minute), SchemaName: "app", TableName: "users",
+		EventType: 1, PKValues: "2",
+		RowAfter: map[string]any{"id": 2, "name": "bob-from-archive"},
+	}
+	base := filepath.Join(t.TempDir(), "bintrail_id=div-test")
+	hourDir := filepath.Join(base, "date=2026-06-01", "hour=12")
+	if err := os.MkdirAll(hourDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pq := filepath.Join(hourDir, "events.parquet")
+	if _, err := buffer.WriteParquet([]query.ResultRow{diverging, archiveOnly}, pq, "none"); err != nil {
+		t.Fatalf("WriteParquet: %v", err)
+	}
+	testutil.MustExec(t, db, `INSERT INTO archive_state
+		(partition_name, bintrail_id, local_path, row_count, s3_bucket, s3_key, s3_uploaded_at)
+		VALUES ('p_2026060112', 'div-test', ?, 2, NULL, NULL, NULL)`, pq)
+
+	// Query tool: the merged result must carry the archive-only row
+	// (precondition) AND the divergence warning.
+	qres, _, err := MakeQueryTool(cfg)(context.Background(), &mcp.CallToolRequest{}, QueryArgs{Schema: "app", Table: "users"})
+	if err != nil {
+		t.Fatalf("query handler: %v", err)
+	}
+	if qres.IsError {
+		t.Fatalf("query tool errored: %s", resultText(qres))
+	}
+	txt := resultText(qres)
+	if !strings.Contains(txt, "bob-from-archive") {
+		t.Fatalf("archive-only row missing — the archive was not merged, so the warning assertion below would be vacuous: %s", txt)
+	}
+	if !strings.Contains(txt, "event_divergence: 1 duplicate event(s) disagreed") {
+		t.Errorf("query result must warn about the diverging duplicate, got: %s", txt)
+	}
+
+	// Recover tool: divergence is a WARNING, not a refusal — both copies
+	// exist and the live index's is used, so the script is not incomplete.
+	// But the reviewing operator must see the finding inside the script text.
+	rres, _, err := MakeRecoverTool(cfg)(context.Background(), &mcp.CallToolRequest{}, RecoverArgs{Schema: "app", Table: "users"})
+	if err != nil {
+		t.Fatalf("recover handler: %v", err)
+	}
+	if rres.IsError {
+		t.Fatalf("recover must still generate on divergence (warning, not refusal), got: %s", resultText(rres))
+	}
+	rtxt := resultText(rres)
+	if !strings.Contains(rtxt, "DELETE FROM") {
+		t.Fatalf("no reversal statements generated — the divergence assertion below would be vacuous: %s", rtxt)
+	}
+	if !strings.Contains(rtxt, "-- Warning: event_divergence: 1 duplicate event(s) disagreed") {
+		t.Errorf("recover script must carry the divergence warning as a SQL comment, got: %s", rtxt)
+	}
+}

--- a/internal/mcptools/divergence_test.go
+++ b/internal/mcptools/divergence_test.go
@@ -1,0 +1,32 @@
+package mcptools
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEventDivergenceNotice pins the #1325 query-tool warning surface: zero
+// divergences render NOTHING (agreeing duplicates are the normal
+// archived-but-not-dropped overlap — warning on them is the cry-wolf failure
+// the merge comparison was designed around), a positive count renders one
+// tagged line, and no flag-shaped token reaches the client text (an MCP
+// client cannot pass a CLI flag).
+func TestEventDivergenceNotice(t *testing.T) {
+	if got := EventDivergenceNotice(0); got != "" {
+		t.Errorf("no divergence must render nothing, got %q", got)
+	}
+
+	got := EventDivergenceNotice(3)
+	for _, want := range []string{
+		"Warning: event_divergence: 3 duplicate event(s) disagreed",
+		"byte-for-byte copy of the index rows",
+		"server log",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in %q", want, got)
+		}
+	}
+	if strings.Contains(got, "--") {
+		t.Errorf("notice must carry no flag-shaped tokens, got %q", got)
+	}
+}

--- a/internal/mcptools/mcptools.go
+++ b/internal/mcptools/mcptools.go
@@ -629,6 +629,10 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 		// source does not read as complete to an MCP client.
 		var skippedArchives []string
 		var misfiledScanFailed bool
+		// Duplicate event_ids whose live and archive copies disagreed in the
+		// merge (#1325) — same blindness: the merge layer slog.Warns, but an
+		// MCP client sees only the result text.
+		var divergedEvents int
 		if len(archSources) == 0 && !t.RedactStatementText {
 			// Fast path: no archives and no post-fetch redaction — fetch and
 			// format in one step.
@@ -657,7 +661,7 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 				results = append(results, ar...)
 			}
 			if len(archSources) > 0 {
-				results = query.MergeResults(results, opts.Limit, opts.Order)
+				results, divergedEvents = query.MergeResultsReport(results, opts.Limit, opts.Order)
 			}
 			t.stripStatementText(results)
 			n, err = query.Format(results, format, &buf)
@@ -672,6 +676,7 @@ func MakeQueryTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Query
 		}
 		text += QueryResultNotice(ceilingApplied, requestedLimit, ceiling, n, opts.Limit)
 		text += ArchiveSkipNotice(discoveryFailed, skippedArchives)
+		text += EventDivergenceNotice(divergedEvents)
 		if misfiledScanFailed {
 			text += "\nWarning: " + archiveScanIncompleteWarning() + "\n"
 		}
@@ -785,6 +790,14 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 		// warns-and-continues (#1285).
 		var skippedArchives []string
 		var rows []query.ResultRow
+		// Diverging duplicates in the merge (#1325) stay a WARNING here, not a
+		// refusal like the archive-trouble gates above: both copies of the
+		// event exist and one — the live index's, the same one recover would
+		// use with no archives at all — is used, so the script is not
+		// knowingly incomplete. But the disagreement itself is a data-integrity
+		// finding the reviewing operator must see: the kept copy's row images
+		// become the reversal SQL.
+		var divergedEvents int
 		if len(archSources) > 0 {
 			fetchOpts := opts
 			extraHours, misfiledScanFailed := misfiledArchiveHours(ctx, t.DB, opts.Since, opts.Until)
@@ -812,7 +825,7 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 				}
 				rows = append(rows, ar...)
 			}
-			rows = query.MergeResults(rows, opts.Limit, opts.Order)
+			rows, divergedEvents = query.MergeResultsReport(rows, opts.Limit, opts.Order)
 		} else {
 			rows, err = engine.Fetch(ctx, opts)
 			if err != nil {
@@ -877,6 +890,12 @@ func MakeRecoverTool(cfg Config) func(context.Context, *mcp.CallToolRequest, Rec
 		}
 		if n >= opts.Limit {
 			text += fmt.Sprintf("\n-- Warning: results truncated at %d rows. Use a narrower since/until range or increase the limit to see more.\n", opts.Limit)
+		}
+		if divergedEvents > 0 {
+			// SQL-comment form so the warning survives inside the script text an
+			// agent may hand to an operator verbatim (the truncation warning
+			// above is the precedent).
+			text += "\n-- Warning: " + eventDivergenceWarning(divergedEvents) + "\n"
 		}
 
 		ext.Record(ctx, ext.AuditEvent{
@@ -1210,6 +1229,31 @@ func archiveDiscoveryFailedWarning() string {
 // skipped backfilled files — softer than archive_discovery_failed.
 func archiveScanIncompleteWarning() string {
 	return "archive_scan_incomplete: the archive registry could not be checked for misfiled (backfilled) archives; time-scoped pruning may have skipped archived events in the window"
+}
+
+// eventDivergenceWarning is the ONE wording for a merge divergence (#1325):
+// two copies of the same event_id — the live index's and an archived
+// partition's — disagreed, and one was silently chosen. Shared by the query
+// tool's trailing notice, the recover tool's SQL-comment warning and the
+// reconstruct tool's warnings array, same single-wording contract as
+// archiveSourceSkippedWarning. Deliberately no remediation command and no
+// flag-shaped tokens: per-event detail (event_id, schema, table, pk) is in the
+// server log, which is where the diagnosis lives.
+func eventDivergenceWarning(n int) string {
+	return fmt.Sprintf("event_divergence: %d duplicate event(s) disagreed between the live index and an archive copy; the first copy fetched (normally the live index) was used. "+
+		"An archived partition should be a byte-for-byte copy of the index rows — a mismatch means the index row changed after archiving, or two index generations wrote under the same bintrail_id. "+
+		"Per-event detail is in the server log", n)
+}
+
+// EventDivergenceNotice renders the query tool's trailing warning line for a
+// merge divergence (#1325). Empty when nothing diverged — the cry-wolf rule:
+// an agreeing duplicate (the normal archived-but-not-dropped overlap) must
+// render nothing.
+func EventDivergenceNotice(n int) string {
+	if n == 0 {
+		return ""
+	}
+	return "\nWarning: " + eventDivergenceWarning(n) + "\n"
 }
 
 // ArchiveSkipNotice renders the query tool's trailing warning lines for

--- a/internal/mcptools/reconstruct.go
+++ b/internal/mcptools/reconstruct.go
@@ -371,7 +371,7 @@ func MakeReconstructTool(cfg Config) func(context.Context, *mcp.CallToolRequest,
 		// failure under allow_gaps must land in Warnings (#1281) — the same
 		// no-silent-incompleteness contract CaptureGapStatus enforces for
 		// source-side loss.
-		rows, plan, skippedSources, err := query.FetchMergedFull(ctx, t.DB, query.New(t.DB), fmOpts)
+		rows, plan, skippedSources, diverged, err := query.FetchMergedFull(ctx, t.DB, query.New(t.DB), fmOpts)
 		if err != nil {
 			return ErrorResult(reconstructFetchError(err)), nil, nil
 		}
@@ -405,6 +405,13 @@ func MakeReconstructTool(cfg Config) func(context.Context, *mcp.CallToolRequest,
 			BaselineTime: snapshotTime.Format(reconstructTSFormat),
 			EventCount:   len(rows),
 			Warnings:     reconstructWarnings(plan, stale, baselineRow, rows, captureGap, skippedSources, args.AllowGaps),
+		}
+		if diverged > 0 {
+			// A diverging duplicate between the index and an archive (#1325)
+			// means the deltas folded below may carry the wrong row images —
+			// the same no-silent-incompleteness contract as skippedSources
+			// above, so it lands in the same Warnings list.
+			res.Warnings = append(res.Warnings, eventDivergenceWarning(diverged))
 		}
 
 		// 4. Fold baseline + deltas. baselineRow may be nil. "existed" = the row

--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -176,7 +176,7 @@ func FetchMerged(
 	engine *Engine,
 	o FetchMergedOptions,
 ) ([]ResultRow, *QueryPlan, error) {
-	rows, plan, _, err := FetchMergedFull(ctx, db, engine, o)
+	rows, plan, _, _, err := FetchMergedFull(ctx, db, engine, o)
 	return rows, plan, err
 }
 
@@ -189,32 +189,34 @@ const DiscoveryFailedSource = "(archive source discovery failed)"
 
 // FetchMergedFull is FetchMerged plus the archive sources that FAILED and
 // were skipped — non-empty only under AllowGaps=true (a failing source is
-// fatal otherwise). A discovery failure appears as DiscoveryFailedSource.
+// fatal otherwise) — plus the number of duplicate event_ids whose two merged
+// copies DISAGREED (#1325, see MergeResultsReport). A discovery failure
+// appears as DiscoveryFailedSource.
 // Surfaces whose user cannot see the server log (the console and the MCP
-// tool, #1281) need the list to put the incompleteness in the response;
+// tool, #1281) need both to put the incompleteness in the response;
 // callers that log are fine with FetchMerged, whose slog.Warn already names
-// the skipped sources.
+// the skipped sources and the diverging events.
 func FetchMergedFull(
 	ctx context.Context,
 	db *sql.DB,
 	engine *Engine,
 	o FetchMergedOptions,
-) ([]ResultRow, *QueryPlan, []string, error) {
+) ([]ResultRow, *QueryPlan, []string, int, error) {
 	if err := o.validate(); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, 0, err
 	}
 	src, err := resolveMergeSources(ctx, db, o)
 	if err != nil {
-		return nil, src.plan, nil, err
+		return nil, src.plan, nil, 0, err
 	}
-	rows, skipped, _, err := fetchPage(ctx, engine, o, src)
+	rows, skipped, _, diverged, err := fetchPage(ctx, engine, o, src)
 	if err != nil {
-		return nil, src.plan, nil, err
+		return nil, src.plan, nil, 0, err
 	}
 	if src.discoveryFailed {
 		skipped = append(skipped, DiscoveryFailedSource)
 	}
-	return rows, src.plan, skipped, nil
+	return rows, src.plan, skipped, diverged, nil
 }
 
 // topNSatisfiedLive reports whether the live partitions alone already hold the
@@ -341,7 +343,12 @@ func FetchMergedStream(
 
 	for {
 		pageOpts.Opts.AfterEvent = cursor
-		rows, skipped, exhausted, err := fetchPage(ctx, engine, pageOpts, src)
+		// The per-page diverged count is deliberately dropped: every stream
+		// caller in this repo is a logging surface (CLI reconstruct / verify
+		// folds), and MergeResultsReport's slog.Warn already reports each
+		// divergence there. The response-level plumbing (#1325) covers the
+		// log-blind surfaces via FetchMergedFull.
+		rows, skipped, exhausted, _, err := fetchPage(ctx, engine, pageOpts, src)
 		if err != nil {
 			return src.plan, err
 		}
@@ -565,22 +572,24 @@ func resolveMergeSources(ctx context.Context, db *sql.DB, o FetchMergedOptions) 
 // and returned nothing. Paginating callers need both, for opposite reasons: a
 // skipped source shortens a page without proving anything (so a short or empty
 // page must not be read as end-of-stream), while an exhausted one can be
-// retired from the walk entirely.
+// retired from the walk entirely. diverged counts the duplicate event_ids
+// whose two merged copies disagreed (#1325); zero on every path that reads a
+// single source, since no duplicate can exist there.
 func fetchPage(
 	ctx context.Context,
 	engine *Engine,
 	o FetchMergedOptions,
 	src mergeSources,
-) (rows []ResultRow, skipped, exhausted []string, err error) {
+) (rows []ResultRow, skipped, exhausted []string, diverged int, err error) {
 	// Fast path: no archives → single fetch from MySQL, no merge. engine.Fetch
 	// already applied ORDER BY and LIMIT in SQL, so MergeAndTrim would be a
 	// no-op over a single source.
 	if len(src.archSources) == 0 {
 		r, ferr := engine.Fetch(ctx, o.Opts)
 		if ferr != nil {
-			return nil, nil, nil, ferr
+			return nil, nil, nil, 0, ferr
 		}
-		return r, nil, nil, nil
+		return r, nil, nil, 0, nil
 	}
 
 	// Archives present: fetch from MySQL unless the planner says we can skip
@@ -590,7 +599,7 @@ func fetchPage(
 	} else {
 		r, ferr := engine.Fetch(ctx, o.Opts)
 		if ferr != nil {
-			return nil, nil, nil, ferr
+			return nil, nil, nil, 0, ferr
 		}
 		rows = r
 	}
@@ -598,7 +607,7 @@ func fetchPage(
 	if topNSatisfiedLive(o.Opts, rows, src.plan) {
 		slog.Debug("planner: skipping archive sources (newest-first page filled from contiguous live coverage)",
 			"limit", o.Opts.Limit, "sources", len(src.archSources))
-		return rows[:o.Opts.Limit], nil, nil, nil
+		return rows[:o.Opts.Limit], nil, nil, 0, nil
 	}
 
 	// Archive fetches get the misfiled-archive file-scoping hint (#1037); the
@@ -625,7 +634,7 @@ func fetchPage(
 			// fetch — so skipping the source would return an incomplete
 			// result the caller has no way to detect (#377).
 			if !o.AllowGaps {
-				return nil, nil, nil, fmt.Errorf("archive source %s failed under strict mode, cannot verify coverage: %w", s, aerr)
+				return nil, nil, nil, 0, fmt.Errorf("archive source %s failed under strict mode, cannot verify coverage: %w", s, aerr)
 			}
 			// Permissive mode: a broken archive must not block the entire
 			// query. Log and move on.
@@ -636,5 +645,6 @@ func fetchPage(
 		rows = append(rows, ar...)
 	}
 
-	return MergeAndTrim(rows, o.Opts.Limit, o.Opts.LimitPerPK, o.Opts.Order), skipped, exhausted, nil
+	rows, diverged = MergeAndTrimReport(rows, o.Opts.Limit, o.Opts.LimitPerPK, o.Opts.Order)
+	return rows, skipped, exhausted, diverged, nil
 }

--- a/internal/query/fetchmerged_test.go
+++ b/internal/query/fetchmerged_test.go
@@ -146,7 +146,7 @@ func TestFetchMerged_partialArchiveFailureAbortsStrictUnit(t *testing.T) {
 	// what log-blind surfaces (console, MCP) rely on to warn in-response.
 	expectQueries(mock)
 	var skipped []string
-	if _, _, skipped, err = FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
+	if _, _, skipped, _, err = FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
 		AllowGaps:      true,
 		ArchiveFetcher: stubFetcher,
 	}); err != nil {
@@ -222,7 +222,7 @@ func TestFetchMergedResolverFailure(t *testing.T) {
 		mock.ExpectQuery("FROM binlog_events").WillReturnRows(sqlmock.NewRows([]string{"event_id"}))
 		fetcherCalled := false
 		var skipped []string
-		_, _, skipped, err = FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
+		_, _, skipped, _, err = FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
 			AllowGaps: true,
 			ArchiveFetcher: func(_ context.Context, _ Options, _ string) ([]ResultRow, error) {
 				fetcherCalled = true
@@ -266,7 +266,7 @@ func TestFetchPage_forwardsMisfiledHoursToArchiveFetcher(t *testing.T) {
 	}
 	o := FetchMergedOptions{Opts: Options{}, AllowGaps: true, ArchiveFetcher: fetcher}
 
-	rows, skipped, exhausted, err := fetchPage(context.Background(), nil, o, src)
+	rows, skipped, exhausted, _, err := fetchPage(context.Background(), nil, o, src)
 	if err != nil {
 		t.Fatalf("fetchPage: %v", err)
 	}
@@ -280,5 +280,89 @@ func TestFetchPage_forwardsMisfiledHoursToArchiveFetcher(t *testing.T) {
 		if len(hours) != 1 || !hours[0].Equal(misfiled[0]) {
 			t.Errorf("fetch %d: ExtraArchiveHours = %v, want %v", i, hours, misfiled)
 		}
+	}
+}
+
+// #1325: a diverging duplicate found during the merge must reach the caller
+// as a COUNT, not only as a slog.Warn — FetchMergedFull is what the log-blind
+// surfaces (console, MCP) build their response warnings from. Two archive
+// sources return the same event_id with disagreeing row images; zero live
+// rows keep sqlmock trivial (the divergence check is source-agnostic).
+func TestFetchMergedFull_reportsDivergedDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	aBase := filepath.Join(dir, "bintrail_id=a")
+	bBase := filepath.Join(dir, "bintrail_id=b")
+	for _, d := range []string{aBase, bBase} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+	mk := func(name string) ResultRow {
+		return ResultRow{
+			EventID:        7,
+			BinlogFile:     "bin.000001",
+			StartPos:       4,
+			EndPos:         40,
+			EventTimestamp: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC),
+			SchemaName:     "app",
+			TableName:      "users",
+			EventType:      1,
+			PKValues:       "1",
+			RowAfter:       map[string]any{"name": name},
+		}
+	}
+	expectQueries := func(mock sqlmock.Sqlmock) {
+		mock.ExpectQuery("FROM archive_state").WillReturnRows(
+			sqlmock.NewRows([]string{"bintrail_id", "sample_local", "sample_bucket", "sample_key"}).
+				AddRow("a", filepath.Join(aBase, "events.parquet"), nil, nil).
+				AddRow("b", filepath.Join(bBase, "events.parquet"), nil, nil))
+		mock.ExpectQuery("FROM binlog_events").WillReturnRows(
+			sqlmock.NewRows([]string{"event_id"}))
+	}
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// Disagreeing copies → count 1, dedup still returns one row.
+	expectQueries(mock)
+	divergeFetcher := func(_ context.Context, _ Options, src string) ([]ResultRow, error) {
+		if strings.Contains(src, "bintrail_id=a") {
+			return []ResultRow{mk("alice")}, nil
+		}
+		return []ResultRow{mk("MUTATED")}, nil
+	}
+	rows, _, skipped, diverged, err := FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
+		AllowGaps:      true,
+		ArchiveFetcher: divergeFetcher,
+	})
+	if err != nil {
+		t.Fatalf("FetchMergedFull: %v", err)
+	}
+	if len(rows) != 1 || len(skipped) != 0 {
+		t.Fatalf("unexpected fetch outcome: rows=%d skipped=%v", len(rows), skipped)
+	}
+	if diverged != 1 {
+		t.Errorf("diverged = %d, want 1", diverged)
+	}
+
+	// Cry-wolf control: agreeing copies must report zero.
+	expectQueries(mock)
+	agreeFetcher := func(_ context.Context, _ Options, _ string) ([]ResultRow, error) {
+		return []ResultRow{mk("alice")}, nil
+	}
+	if _, _, _, diverged, err = FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
+		AllowGaps:      true,
+		ArchiveFetcher: agreeFetcher,
+	}); err != nil {
+		t.Fatalf("FetchMergedFull (agreeing): %v", err)
+	}
+	if diverged != 0 {
+		t.Errorf("agreeing duplicate reported diverged = %d, want 0", diverged)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
 	}
 }

--- a/internal/query/merge.go
+++ b/internal/query/merge.go
@@ -100,6 +100,19 @@ func sameRowImage(a, b map[string]any) bool {
 // "DESC" (case-insensitive) → descending. The same direction is applied to
 // both sort keys so the ordering is total and deterministic.
 func MergeResults(rows []ResultRow, limit int, order string) []ResultRow {
+	merged, _ := MergeResultsReport(rows, limit, order)
+	return merged
+}
+
+// MergeResultsReport is MergeResults plus the number of duplicate event_ids
+// whose two copies DISAGREED (#1325). The slog.Warn below is the right channel
+// for the CLI, but the console and MCP surfaces serve callers who never see
+// the server log — for them a silent coin-flip between two disagreeing
+// before-images is a data-integrity event that must land in the RESPONSE, the
+// same split CaptureGapStatus makes for capture gaps (the finding travels even
+// when policy lets the query proceed). Callers that log are fine with
+// MergeResults, which discards the count.
+func MergeResultsReport(rows []ResultRow, limit int, order string) ([]ResultRow, int) {
 	seen := make(map[uint64]int, len(rows))
 	unique := rows[:0]
 	var diverged, reported int
@@ -161,7 +174,7 @@ func MergeResults(rows []ResultRow, limit int, order string) []ResultRow {
 	if limit > 0 && len(unique) > limit {
 		unique = unique[:limit]
 	}
-	return unique
+	return unique, diverged
 }
 
 // MergeAndTrim runs the full post-fetch pipeline: dedup+sort, then the per-PK
@@ -183,10 +196,21 @@ func MergeResults(rows []ResultRow, limit int, order string) []ResultRow {
 // order is passed through to MergeResults (see its doc); pre-#1511 callers
 // that pass "" get the historical ascending behavior.
 func MergeAndTrim(rows []ResultRow, limit, limitPerPK int, order string) []ResultRow {
+	merged, _ := MergeAndTrimReport(rows, limit, limitPerPK, order)
+	return merged
+}
+
+// MergeAndTrimReport is MergeAndTrim plus the diverged-duplicate count from
+// the dedup pass (#1325, see MergeResultsReport). Only the FIRST merge can
+// observe a divergence — the optional DESC re-sort below runs over rows that
+// are already deduplicated, so its count is structurally zero and is
+// discarded.
+func MergeAndTrimReport(rows []ResultRow, limit, limitPerPK int, order string) ([]ResultRow, int) {
+	var diverged int
 	if limitPerPK > 0 {
 		// LimitPerPK requires ASC-sorted input to pick the timestamp-latest
 		// events per PK.
-		rows = MergeResults(rows, 0, "ASC")
+		rows, diverged = MergeResultsReport(rows, 0, "ASC")
 		rows = LimitPerPK(rows, limitPerPK)
 		// Re-sort in the caller's direction before slicing — otherwise
 		// "limit N + Order=DESC" would slice from the wrong end of the
@@ -195,12 +219,12 @@ func MergeAndTrim(rows []ResultRow, limit, limitPerPK int, order string) []Resul
 			rows = MergeResults(rows, 0, "DESC")
 		}
 	} else {
-		rows = MergeResults(rows, 0, order)
+		rows, diverged = MergeResultsReport(rows, 0, order)
 	}
 	if limit > 0 && len(rows) > limit {
 		rows = rows[:limit]
 	}
-	return rows
+	return rows, diverged
 }
 
 // LimitPerPK trims rows to keep at most n per pk_values, preserving the input

--- a/internal/query/merge_divergence_test.go
+++ b/internal/query/merge_divergence_test.go
@@ -230,7 +230,70 @@ func TestMergeResults_divergenceLogIsBounded(t *testing.T) {
 	}
 }
 
-// captureWarn swaps the process-global slog.Default. Safe today because these
-// tests run sequentially; it would race the moment anything in package query
-// calls t.Parallel().
-var _ = captureWarn
+// #1325: the count is the merge layer's RESPONSE-LEVEL signal — the log line
+// above dies in the daemon log, and the console/MCP surfaces build their
+// warnings from this number. One count per diverging duplicate; agreeing
+// duplicates and legacy-archive NULLs stay zero (the cry-wolf rule), and the
+// wrapper must return byte-identical rows so no call site changes behavior.
+func TestMergeResultsReport_countsDivergingDuplicates(t *testing.T) {
+	agreeA, agreeB := row(10), row(10)
+	divLiveA, divArchA := row(11), row(11)
+	divArchA.RowAfter = map[string]any{"id": 7, "name": "MUTATED"}
+	divLiveB, divArchB := row(12), row(12)
+	divArchB.RowBefore = map[string]any{"id": 7, "name": "old"}
+
+	in := []ResultRow{agreeA, agreeB, divLiveA, divArchA, divLiveB, divArchB}
+	var merged []ResultRow
+	var diverged int
+	captureWarn(t, func() { merged, diverged = MergeResultsReport(in, 0, "ASC") })
+	if diverged != 2 {
+		t.Errorf("diverged = %d, want 2 (one per disagreeing duplicate, none for the agreeing pair)", diverged)
+	}
+	if len(merged) != 3 {
+		t.Errorf("dedup broken: got %d rows, want 3", len(merged))
+	}
+
+	captureWarn(t, func() { _, diverged = MergeResultsReport([]ResultRow{agreeA, agreeB}, 0, "ASC") })
+	if diverged != 0 {
+		t.Errorf("agreeing duplicates reported diverged = %d, want 0", diverged)
+	}
+
+	// The wrapper is the compatibility contract: same rows, count discarded.
+	var viaWrapper []ResultRow
+	captureWarn(t, func() { viaWrapper = MergeResults(append([]ResultRow(nil), in...), 0, "ASC") })
+	if len(viaWrapper) != len(merged) {
+		t.Errorf("MergeResults returned %d rows, MergeResultsReport %d — the wrapper must be behavior-identical", len(viaWrapper), len(merged))
+	}
+}
+
+// NOTE: captureWarn swaps the process-global slog.Default. Safe today because
+// these tests run sequentially; it would race the moment anything in package
+// query calls t.Parallel().
+
+// MergeAndTrimReport must propagate the count on BOTH branches: the plain
+// merge, and the limitPerPK path whose DESC re-sort runs a second (already
+// deduplicated) merge that must not zero the finding out.
+func TestMergeAndTrimReport_propagatesCount(t *testing.T) {
+	mk := func() []ResultRow {
+		live, arch := row(20), row(20)
+		arch.RowAfter = map[string]any{"id": 7, "name": "MUTATED"}
+		return []ResultRow{live, arch}
+	}
+	for _, tc := range []struct {
+		name       string
+		limitPerPK int
+		order      string
+	}{
+		{"plain merge", 0, "ASC"},
+		{"limitPerPK", 1, "ASC"},
+		{"limitPerPK with DESC re-sort", 1, "DESC"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var diverged int
+			captureWarn(t, func() { _, diverged = MergeAndTrimReport(mk(), 0, tc.limitPerPK, tc.order) })
+			if diverged != 1 {
+				t.Errorf("diverged = %d, want 1", diverged)
+			}
+		})
+	}
+}

--- a/internal/query/topn_skip_test.go
+++ b/internal/query/topn_skip_test.go
@@ -155,7 +155,7 @@ func TestFetchPageSkipsArchivesOnFilledTopN(t *testing.T) {
 		},
 	}
 
-	rows, _, _, err := fetchPage(context.Background(), New(db), o, src)
+	rows, _, _, _, err := fetchPage(context.Background(), New(db), o, src)
 	if err != nil {
 		t.Fatalf("fetchPage: %v", err)
 	}


### PR DESCRIPTION
closes #1325

## Summary

#1319 added a `slog.Warn` when two copies of one `event_id` disagree between the live index and a Parquet archive. For two of the three surfaces that merge those sources the operator could never see it: the console operator is in a browser and an MCP client sees only the response — the warning died in the daemon log while, on the recover path, the chosen copy's row images silently became the `SET` clauses of the generated reversal SQL.

This mirrors the `CaptureGapStatus` split (the finding travels even when policy lets the query proceed):

- **Merge layer**: `query.MergeResultsReport` / `MergeAndTrimReport` return the merged rows plus the diverged-duplicate count; `MergeResults` / `MergeAndTrim` stay as thin wrappers so no call site changes behavior. The `slog.Warn` is kept — still the right channel for the CLI.
- **`FetchMergedFull`** grows a fifth return value (the count), threaded out of `fetchPage`'s merge. `FetchMergedStream` deliberately keeps dropping it: every stream caller is a logging surface.
- **Console**: `fetchRestricted` switches to `FetchMergedFull`; `handleEvents` and `handleRecover` append a warning to the response `Warnings` their views already render. The reconstruct endpoint appends the same warning next to its skipped-sources entries. The wording carries a COUNT only — no row internals cross the `eventDTO` boundary; per-event detail stays in the server log.
- **MCP**: the query tool renders a trailing `Warning: event_divergence: …` line (`ArchiveSkipNotice` precedent), the recover tool embeds the same wording as a SQL comment in the script (truncation-warning precedent), and the reconstruct tool appends it to its `Warnings` array. No flag-shaped token reaches the client text.

Two deliberate calls beyond the issue's literal proposal:

- MCP **recover warns rather than refuses** on divergence, unlike its #1285 archive-trouble gates: both copies exist and the live index's — the same one recover would use with no archives at all — is used, so the script is not knowingly incomplete. The reviewing operator still sees the finding inside the script text.
- The **reconstruct surfaces** (console endpoint + MCP tool) also carry the warning: the signature change touched their `FetchMergedFull` call sites anyway, and dropping the count there would recreate the exact finding-dies-before-the-response pattern this issue is about.

## Testing

- Unit: `MergeResultsReport` counts one per disagreeing duplicate and zero for agreeing/legacy-NULL duplicates (cry-wolf rule); `MergeAndTrimReport` propagates on both branches including the DESC re-sort; `FetchMergedFull` threading via sqlmock + stub archive fetchers with a disagreeing-copies round and an agreeing control; `EventDivergenceNotice` / `appendDivergenceWarning` rendering guards (no flag-shaped tokens, no row internals).
- Integration (Docker MySQL, verified they RAN): wiring tests drive the REAL `handleEvents` / `handleRecover` and the REAL MCP query/recover tools against a live index plus a registered Parquet archive holding the live row's `event_id` with a mutated row image **and** an archive-only sibling — the sibling reaching the merged result is asserted first, so the warning assertion cannot pass vacuously (#1321's lesson). No-archive control asserts silence.
- Mutation checks: silencing the count at each of the four wiring points (console events, console recover, MCP query notice, MCP recover SQL comment) turns the integration tests red while unit tests stay green.
- `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, `gofmt -l` clean on changed files; full unit suite and full `-tags integration` suites for `internal/query`, `internal/mcptools`, `internal/console` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
