### PR TITLE
PG round-trip matrix: empirical coverage for extension types (PostGIS, pgvector, composite)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,6 +419,103 @@ jobs:
           grep -q -- '--- PASS: TestPGWire_PostgresSourceRoundTrip' /tmp/pg-it.out \
             || { echo "FATAL: pgwire PostgreSQL-source E2E did not run — false-green tripwire" >&2; exit 1; }
 
+  integration-postgres-extensions:
+    # Extension-type round-trip coverage (#1210): PostGIS geometry/geography
+    # and pgvector's vector are text-decoded through pgoutput like any other
+    # type, but the plain postgres:N images above cannot host the extensions —
+    # so this job pairs the same MySQL index container with one extension-
+    # bearing PostgreSQL image per cell (no single stock image ships both
+    # extensions) and runs ONLY the extension matrix test; the full PG suite
+    # already runs in integration-postgres-source. One modern PG major per
+    # extension, not a full version matrix: the extension's text I/O is what's
+    # under test, not the server version (that axis is covered above).
+    #
+    # BINTRAIL_REQUIRE_PGEXT names the extension each cell guarantees, turning
+    # the test's per-extension skip into a FAILURE here — plus the usual
+    # PASS-line tripwire, so a renamed test cannot go green-via-empty `-run`.
+    needs: changes
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: "postgis/postgis:16-3.4"
+            ext: "postgis"
+          - image: "pgvector/pgvector:pg16"
+            ext: "vector"
+    env:
+      BINTRAIL_TEST_DSN: "root:testroot@tcp(127.0.0.1:13306)"
+      BINTRAIL_TEST_PG_DSN: "postgres://postgres:testpg@127.0.0.1:15432/pgtest?sslmode=disable"
+      BINTRAIL_REQUIRE_POSTGRES: "1"
+      BINTRAIL_REQUIRE_PGEXT: ${{ matrix.ext }}
+    steps:
+      # Step-level (not job-level) `if:` — see the note on the `integration`
+      # job above; this job's matrix has the same requirement.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: github.event_name == 'push' || needs.changes.outputs.go == 'true'
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        if: github.event_name == 'push' || needs.changes.outputs.go == 'true'
+        with:
+          go-version-file: go.mod
+
+      - name: Start MySQL index (bintrail-test-mysql, 8.4)
+        if: github.event_name == 'push' || needs.changes.outputs.go == 'true'
+        run: |
+          docker run -d --name bintrail-test-mysql \
+            -e MYSQL_ROOT_PASSWORD=testroot \
+            -p 13306:3306 \
+            mysql:8.4 \
+            --binlog-format=ROW --binlog-row-image=FULL --log-bin=binlog --server-id=1
+          # See the "integration" job's MySQL-start step for why this probes
+          # host TCP with full auth + a real query, requiring 3 consecutive
+          # successes, instead of `docker exec ... mysqladmin ping` (#949).
+          consecutive=0
+          for i in $(seq 1 60); do
+            if docker run --rm --network host mysql:8.4 \
+                 mysql --protocol=TCP -h 127.0.0.1 -P 13306 -u root -ptestroot -e "SELECT 1" >/dev/null 2>&1; then
+              consecutive=$((consecutive + 1))
+              [ "$consecutive" -ge 3 ] && { echo "MySQL index is ready."; exit 0; }
+            else
+              consecutive=0
+            fi
+            sleep 2
+          done
+          echo "MySQL did not become ready in time" >&2
+          docker logs bintrail-test-mysql >&2 || true
+          exit 1
+
+      - name: Start PostgreSQL source (bintrail-test-postgres, ${{ matrix.image }})
+        if: github.event_name == 'push' || needs.changes.outputs.go == 'true'
+        run: |
+          docker run -d --name bintrail-test-postgres \
+            -e POSTGRES_PASSWORD=testpg \
+            -e POSTGRES_DB=pgtest \
+            -p 15432:5432 \
+            ${{ matrix.image }} \
+            -c wal_level=logical -c max_replication_slots=10 -c max_wal_senders=10
+          # Same in-container TCP probe as integration-postgres-source (the
+          # postgis/pgvector images reuse the official postgres entrypoint,
+          # first-init unix-socket-only phase included).
+          for i in $(seq 1 60); do
+            if docker exec bintrail-test-postgres pg_isready -h 127.0.0.1 -U postgres -d pgtest --quiet 2>/dev/null; then
+              echo "PostgreSQL source is ready."; exit 0
+            fi
+            sleep 2
+          done
+          echo "PostgreSQL did not become ready in time" >&2
+          docker logs bintrail-test-postgres >&2 || true
+          exit 1
+
+      - name: Extension-type round-trip test (${{ matrix.ext }})
+        if: github.event_name == 'push' || needs.changes.outputs.go == 'true'
+        run: |
+          set -o pipefail
+          go test -tags=integration -race -p 1 -count=1 -v \
+            -run 'TestOne_PGExtensionTypeRoundTripMatrix' ./internal/pgstreamrun/ 2>&1 | tee /tmp/pgext-it.out
+          grep -q -- '--- PASS: TestOne_PGExtensionTypeRoundTripMatrix' /tmp/pgext-it.out \
+            || { echo "FATAL: PG extension-type round-trip test did not run — false-green tripwire" >&2; exit 1; }
+
   console-e2e:
     # Headless-Chrome regression guard for the console SPA: go test never
     # renders assets/*, so CSS/DOM/presentation bugs (invisible buttons, a

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -440,10 +440,10 @@ directly.
 > `real`/`double precision`, `bytea`, `interval`), whose text rendering is
 > pinned identically on the baseline COPY connections and the logical-decoding
 > session (`TimeZone=UTC`, `DateStyle=ISO`, `extra_float_digits=3`,
-> `bytea_output=hex`, `IntervalStyle=postgres`). Container types (arrays
-> beyond the tested `integer[]`/`text[]`, composite, range/multirange,
-> `hstore`, geometric) remain untested through the fold — validate your own
-> round-trip. **Re-baseline after upgrading:** baselines taken before the
+> `bytea_output=hex`, `IntervalStyle=postgres`) — and user-defined
+> **composite** types. Container types beyond that (arrays beyond the tested
+> `integer[]`/`text[]`, range/multirange, `hstore`, geometric) remain
+> untested through the fold — validate your own round-trip. **Re-baseline after upgrading:** baselines taken before the
 > rendering-GUC pin were rendered under your server's session defaults; on a
 > server whose defaults differ from the pinned values, re-run
 > `bintrail-pg baseline` — the baseline↔delta merge is an exact text join
@@ -650,6 +650,7 @@ run across the PG 14/15/16/17 CI matrix:
 | Array | `integer[]`, `text[]` | element quoting/escaping (e.g. a comma inside an element) preserved |
 | Geometric | `point` | |
 | Enum | user `ENUM` types | recovered **by label** — the target must declare the same enum type |
+| Composite | user-defined composite types | field quoting preserved (embedded comma, doubled quote); the target must declare the same composite type |
 | Money | `money` | round-trips, but its text form is **locale-dependent** (`$`-prefixed); recover into a target with the same `lc_monetary` |
 
 The generated reversal SQL is PostgreSQL dialect (double-quoted identifiers,
@@ -658,9 +659,15 @@ guard) — the dialect is selected automatically from the source recorded in the
 so `bintrail-pg recover`, the console, and the MCP server all emit valid PostgreSQL
 for a PostgreSQL source.
 
+**Extension types** — PostGIS `geometry`/`geography` and pgvector `vector` — are
+round-trip tested the same insert → capture → `recover` → re-execute way, in
+dedicated CI cells running extension-bearing images
+(`TestOne_PGExtensionTypeRoundTripMatrix`); see
+[Extensions and custom types](#extensions-and-custom-types) below.
+
 **Untested / best-effort:** `hstore` and other extension-provided types are covered
-under [Extensions and custom types](#extensions-and-custom-types) below. Composite
-types, range types beyond `int4range`, multirange, geometric types beyond `point`,
+under [Extensions and custom types](#extensions-and-custom-types) below. Range
+types beyond `int4range`, multirange, geometric types beyond `point`,
 arrays beyond the tested `integer[]`/`text[]` (multi-dimensional, `NULL`-containing)
 are not yet in the round-trip suite — they are captured as text and are expected to
 coerce, but verify your own round-trip.
@@ -673,15 +680,21 @@ coerce, but verify your own round-trip.
   `pgoutput` plugin only — no output plugin, no `CREATE EXTENSION`, no event
   trigger. This is a deliberate red line, and it is what lets bintrail-pg work
   against managed PostgreSQL (which forbids custom extensions).
-- **PostGIS works well.** Geometry columns stream as hex-EWKB, which embeds the
-  SRID and round-trips losslessly back into PostgreSQL — the target just needs
-  PostGIS installed. (Set `REPLICA IDENTITY FULL` as for any table; large
-  geometries are TOASTed, so FULL matters.)
-- **Other extension/custom types** (`vector`/pgvector, composite types) are
-  captured **as their text representation**. Recovery into a target that has the
-  same extension installed works; treat exotic types as best-effort and test your
-  round-trip. (Enums and ranges are round-trip tested — see the
-  [Type support](#type-support) matrix.)
+- **PostGIS is round-trip tested.** `geometry` and `geography` columns stream
+  as hex-EWKB, which embeds the SRID and round-trips losslessly back into
+  PostgreSQL — proven empirically by `TestOne_PGExtensionTypeRoundTripMatrix`
+  against the `postgis/postgis` image in CI. The target just needs PostGIS
+  installed. (Set `REPLICA IDENTITY FULL` as for any table; large geometries
+  are TOASTed, so FULL matters.)
+- **pgvector is round-trip tested.** `vector` columns stream as their bracketed
+  text form (`[0.5,-1.25,3.75]`) and round-trip byte-for-byte — same test,
+  against the `pgvector/pgvector` image in CI. The target needs the extension
+  installed.
+- **Other extension/custom types** (`hstore`, …) are captured **as their text
+  representation**. Recovery into a target that has the same extension installed
+  is expected to work; treat exotic types as best-effort and test your
+  round-trip. (Enums, ranges and user-defined composite types are round-trip
+  tested — see the [Type support](#type-support) matrix.)
 - **TimescaleDB hypertables are out of scope.** Logical decoding emits the
   underlying *chunk* tables (`_timescaledb_internal._hyper_*`), not the
   hypertable, so a hypertable is not captured coherently in this release.

--- a/internal/pgstreamrun/extensiontypes_integration_test.go
+++ b/internal/pgstreamrun/extensiontypes_integration_test.go
@@ -1,0 +1,218 @@
+//go:build integration
+
+package pgstreamrun_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbtrail/dbtrail/internal/event"
+	"github.com/dbtrail/dbtrail/internal/metadata"
+	"github.com/dbtrail/dbtrail/internal/pgstreamrun"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/recovery"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// pgExtTypeCase is one row of the EXTENSION-type round-trip matrix (#1210):
+// like pgTypeCase, but each case names the extension whose CREATE EXTENSION
+// must succeed before the case's column type exists. The plain postgres CI
+// cells ship none of these extensions, so those cases skip there (loudly);
+// the dedicated extension cells (postgis/postgis and pgvector/pgvector
+// images, job integration-postgres-extensions) set
+// BINTRAIL_REQUIRE_PGEXT=<ext>, which turns that skip into a FAILURE —
+// mirroring BINTRAIL_REQUIRE_POSTGRES's green-via-skip guard.
+type pgExtTypeCase struct{ name, ext, typeDDL, valSQL string }
+
+var pgExtTypeMatrixCases = []pgExtTypeCase{
+	// PostGIS: geometry/geography render through their output function (and
+	// ::text) as hex EWKB with the SRID embedded — a self-contained text form
+	// the input function accepts back, so the pgoutput text decode should be
+	// lossless. Binary-heavy custom send/recv is exactly why this needs
+	// empirical proof rather than "should".
+	{"geometry", "postgis", "geometry", "'SRID=4326;POINT(1 2)'"},
+	{"geometry_typed", "postgis", "geometry(Point,4326)", "'SRID=4326;POINT(-70.5 42.1)'"},
+	{"geography", "postgis", "geography(Point,4326)", "'SRID=4326;POINT(-70.5 42.1)'"},
+	// pgvector: components chosen float4-exact (0.5, -1.25, 3.75) so the text
+	// rendering is bit-stable and a mismatch means capture loss, not float
+	// formatting noise.
+	{"vector", "vector", "vector(3)", "'[0.5,-1.25,3.75]'"},
+}
+
+// TestOne_PGExtensionTypeRoundTripMatrix extends the #533 type-fidelity audit
+// to extension-provided types (#1210): a value flows PG → pgoutput → index →
+// recover → EXECUTE the reverse-INSERT against live PostgreSQL, and the
+// column's canonical ::text rendering must round-trip byte-for-byte. Same
+// shape as TestOne_PGTypeRoundTripMatrix, restricted to the cases whose
+// extension is actually installable in the test database.
+//
+// CREATE EXTENSION here is the TEST HARNESS preparing its own throwaway
+// server — capture itself stays a pure logical-replication client over the
+// built-in pgoutput plugin (the red line); bintrail never installs anything
+// in a source database.
+func TestOne_PGExtensionTypeRoundTripMatrix(t *testing.T) {
+	pgDSN := testutil.SkipIfNoPostgres(t)
+	testutil.SkipIfNoMySQL(t)
+	ctx := context.Background()
+
+	pg, err := pgx.Connect(ctx, pgDSN)
+	if err != nil {
+		t.Fatalf("connect PG: %v", err)
+	}
+	t.Cleanup(func() { pg.Close(context.Background()) })
+
+	// ── Extension availability probe ────────────────────────────────────────
+	// CREATE EXTENSION IF NOT EXISTS per distinct extension; the ones that
+	// fail (packages not in the image) drop their cases — loudly, and fatally
+	// when BINTRAIL_REQUIRE_PGEXT names them. Extensions are left installed:
+	// they are harmless server-wide state in a throwaway test container.
+	required := testutil.RequiredPGExtensions()
+	available := map[string]bool{}
+	for _, c := range pgExtTypeMatrixCases {
+		if _, probed := available[c.ext]; probed {
+			continue
+		}
+		if _, err := pg.Exec(ctx, "CREATE EXTENSION IF NOT EXISTS "+c.ext); err != nil {
+			if required[c.ext] {
+				t.Fatalf("BINTRAIL_REQUIRE_PGEXT requires extension %q but CREATE EXTENSION failed — the extension CI cell must run an image that ships it: %v", c.ext, err)
+			}
+			t.Logf("SKIPPING %q cases: extension not installable in the test database (expected on plain postgres images): %v", c.ext, err)
+			available[c.ext] = false
+			continue
+		}
+		available[c.ext] = true
+	}
+	cases := make([]pgExtTypeCase, 0, len(pgExtTypeMatrixCases))
+	for _, c := range pgExtTypeMatrixCases {
+		if available[c.ext] {
+			cases = append(cases, c)
+		}
+	}
+	if len(cases) == 0 {
+		t.Skip("skipping: no PG extension (postgis/pgvector) installable here — the integration-postgres-extensions CI cells run this for real")
+	}
+
+	indexDB, dbName := testutil.CreateTestDB(t)
+	indexDSN := testutil.BaseDSN() + "/" + dbName
+
+	const slot = "bintrail_pgexttypes"
+	const pub = "bintrail_pgexttypes_pub"
+	tblOf := func(name string) string { return "pgexttype_" + name }
+
+	dropAll := func() {
+		bg := context.Background()
+		_, _ = pg.Exec(bg, "DROP PUBLICATION IF EXISTS "+pub)
+		for _, c := range pgExtTypeMatrixCases {
+			_, _ = pg.Exec(bg, "DROP TABLE IF EXISTS "+tblOf(c.name))
+		}
+		_, _ = pg.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
+	}
+	dropAll()
+	t.Cleanup(dropAll)
+
+	mustExec := func(sqlStr string) {
+		t.Helper()
+		if _, err := pg.Exec(ctx, sqlStr); err != nil {
+			t.Fatalf("exec %q: %v", sqlStr, err)
+		}
+	}
+	tbls := make([]string, len(cases))
+	for i, c := range cases {
+		tbl := tblOf(c.name)
+		tbls[i] = tbl
+		mustExec(fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY, val %s)", tbl, c.typeDDL))
+		mustExec(fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL", tbl))
+	}
+	mustExec("CREATE PUBLICATION " + pub + " FOR TABLE " + strings.Join(tbls, ", "))
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	cfg := pgstreamrun.Config{
+		IndexDSN: indexDSN, ReplDSN: replDSN(pgDSN), QueryDSN: pgDSN,
+		SlotName: slot, Publication: pub, ServerID: 47,
+		BatchSize: 200, Checkpoint: 200 * time.Millisecond,
+	}
+	runErr := make(chan error, 1)
+	go func() { runErr <- pgstreamrun.One(runCtx, cfg) }()
+	waitFor(t, 15*time.Second, func() bool {
+		var active bool
+		if err := pg.QueryRow(ctx, "SELECT active FROM pg_replication_slots WHERE slot_name=$1", slot).Scan(&active); err != nil {
+			return false
+		}
+		return active
+	}, "replication slot active")
+
+	// INSERT then DELETE one row per type; capture the original canonical
+	// ::text first (hex EWKB for PostGIS, bracketed float list for vector).
+	orig := make(map[string]string, len(cases))
+	for _, c := range cases {
+		tbl := tblOf(c.name)
+		mustExec(fmt.Sprintf("INSERT INTO %s (id, val) VALUES (1, %s)", tbl, c.valSQL))
+		var got sql.NullString
+		if err := pg.QueryRow(ctx, fmt.Sprintf("SELECT val::text FROM %s WHERE id=1", tbl)).Scan(&got); err != nil {
+			t.Fatalf("%s: capture original: %v", c.name, err)
+		}
+		orig[c.name] = got.String
+		mustExec(fmt.Sprintf("DELETE FROM %s WHERE id=1", tbl))
+	}
+
+	wantEvents := 2 * len(cases) // INSERT + DELETE per table
+	waitFor(t, 30*time.Second, func() bool {
+		var n int
+		if err := indexDB.QueryRow("SELECT COUNT(*) FROM binlog_events WHERE schema_name='public'").Scan(&n); err != nil {
+			return false
+		}
+		return n >= wantEvents
+	}, "all extension-type events indexed")
+
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("One returned error: %v", err)
+	}
+
+	resolver, err := metadata.NewResolver(indexDB, 0)
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tbl := tblOf(c.name)
+			rows, err := query.New(indexDB).Fetch(ctx, query.Options{Schema: "public", Table: tbl, Order: "ASC"})
+			if err != nil {
+				t.Fatalf("fetch: %v", err)
+			}
+			var del *query.ResultRow
+			for i := range rows {
+				if rows[i].EventType == event.EventDelete {
+					del = &rows[i]
+				}
+			}
+			if del == nil {
+				t.Fatalf("no DELETE event indexed for %s", tbl)
+			}
+			var buf bytes.Buffer
+			if _, err := recovery.NewForDialect(indexDB, resolver, recovery.PostgresDialect).
+				GenerateSQLFromRows([]query.ResultRow{*del}, &buf); err != nil {
+				t.Fatalf("generate: %v", err)
+			}
+			if _, err := pg.Exec(ctx, buf.String()); err != nil {
+				t.Fatalf("reverse INSERT did not execute against PostgreSQL: %v\nSQL:\n%s", err, buf.String())
+			}
+			var got sql.NullString
+			if err := pg.QueryRow(ctx, fmt.Sprintf("SELECT val::text FROM %s WHERE id=1", tbl)).Scan(&got); err != nil {
+				t.Fatalf("re-select: %v", err)
+			}
+			if got.String != orig[c.name] {
+				t.Errorf("round-trip mismatch (%s):\n got  %q\n want %q", c.typeDDL, got.String, orig[c.name])
+			}
+		})
+	}
+}

--- a/internal/pgstreamrun/pgstreamrun_integration_test.go
+++ b/internal/pgstreamrun/pgstreamrun_integration_test.go
@@ -1061,6 +1061,7 @@ func TestOne_PGTypeRoundTripMatrix(t *testing.T) {
 			_, _ = pg.Exec(bg, "DROP TABLE IF EXISTS "+tblOf(c.name))
 		}
 		_, _ = pg.Exec(bg, "DROP TYPE IF EXISTS mood")
+		_, _ = pg.Exec(bg, "DROP TYPE IF EXISTS pgt_pair")
 		_, _ = pg.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
 	}
 	dropAll()
@@ -1073,6 +1074,7 @@ func TestOne_PGTypeRoundTripMatrix(t *testing.T) {
 		}
 	}
 	mustExec("CREATE TYPE mood AS ENUM ('happy','sad')")
+	mustExec("CREATE TYPE pgt_pair AS (a int, b text)")
 	tbls := make([]string, len(cases))
 	for i, c := range cases {
 		tbl := tblOf(c.name)

--- a/internal/pgstreamrun/typematrix_fold_integration_test.go
+++ b/internal/pgstreamrun/typematrix_fold_integration_test.go
@@ -68,6 +68,7 @@ var pgTypeMatrixCases = []pgTypeCase{
 	{"point", "point", "'(1,2)'", ""},
 	{"money", "money", "'1.50'", ""}, // locale-dependent output ('$1.50'); lc_monetary deliberately NOT pinned — same instance, so stable
 	{"enum", "mood", "'happy'", "'sad'"},
+	{"composite", "pgt_pair", `'(7,"a,b ""c""")'`, `'(8,"x y")'`}, // user-defined composite (#1210): embedded comma + doubled quote exercise record field quoting
 }
 
 // updOf returns the fold test's second literal for a case (falls back to valSQL).
@@ -168,6 +169,7 @@ func TestOne_PGTypeMatrixThroughReconstructFold(t *testing.T) {
 			_, _ = pg.Exec(bg, "DROP TABLE IF EXISTS "+tblOf(c.name))
 		}
 		_, _ = pg.Exec(bg, "DROP TYPE IF EXISTS mood")
+		_, _ = pg.Exec(bg, "DROP TYPE IF EXISTS pgt_pair")
 		_, _ = pg.Exec(bg, "SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name=$1)", slot)
 	}
 	dropAll()
@@ -180,6 +182,7 @@ func TestOne_PGTypeMatrixThroughReconstructFold(t *testing.T) {
 		}
 	}
 	mustExec("CREATE TYPE mood AS ENUM ('happy','sad')")
+	mustExec("CREATE TYPE pgt_pair AS (a int, b text)")
 	tbls := make([]string, len(pgTypeMatrixCases))
 	for i, c := range pgTypeMatrixCases {
 		tbl := tblOf(c.name)

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -19,6 +20,25 @@ func PostgresDSN() string { return os.Getenv("BINTRAIL_TEST_PG_DSN") }
 // unset, so PG tests skip cleanly there. Mirrors MariaDBRequired.
 func PostgresRequired() bool {
 	return os.Getenv("BINTRAIL_REQUIRE_POSTGRES") == "1"
+}
+
+// RequiredPGExtensions returns the set of PostgreSQL extensions the
+// extension-type integration tests must exercise, from the comma-separated
+// BINTRAIL_REQUIRE_PGEXT (e.g. "postgis" or "vector"). When an extension named
+// here cannot be created in the test database, the extension-type round-trip
+// test FAILS instead of skipping its cases: the dedicated CI cells run images
+// that guarantee the extension (postgis/postgis, pgvector/pgvector), so an
+// unavailable extension there is a misconfiguration to surface loudly, not a
+// green-via-skip. Cells without the env var (the plain postgres matrix) skip
+// the extension cases cleanly. Mirrors PostgresRequired / MariaDBRequired.
+func RequiredPGExtensions() map[string]bool {
+	req := map[string]bool{}
+	for _, e := range strings.Split(os.Getenv("BINTRAIL_REQUIRE_PGEXT"), ",") {
+		if e = strings.TrimSpace(e); e != "" {
+			req[e] = true
+		}
+	}
+	return req
 }
 
 // SkipIfNoPostgres skips the test unless BINTRAIL_TEST_PG_DSN is set, and returns


### PR DESCRIPTION
closes #1210

## Summary

The PG type round-trip matrix had zero empirical coverage for extension types — PostGIS geometry, pgvector vectors and user-defined composite types were documented as "should work" through pgoutput's text decode. This PR replaces "should" with evidence:

- **Composite types** (no extension needed) join the shared `pgTypeMatrixCases`, so they now run through **both** the recover round-trip (`TestOne_PGTypeRoundTripMatrix`) and the baseline+delta reconstruct fold (`TestOne_PGTypeMatrixThroughReconstructFold`) on every plain `postgres:14–17` CI cell. The value exercises record field quoting: embedded comma + doubled quote inside a quoted field.
- **PostGIS** (`geometry`, `geometry(Point,4326)`, `geography(Point,4326)`) and **pgvector** (`vector(3)`): new `TestOne_PGExtensionTypeRoundTripMatrix` mirrors the round-trip matrix — insert → pgoutput capture → index → `recover` → re-execute the reversal against live PostgreSQL, asserting the canonical `::text` is byte-for-byte identical. `CREATE EXTENSION` is the test harness preparing its own throwaway server; capture stays a pure logical-replication client over built-in pgoutput.
- **CI**: new `integration-postgres-extensions` job, one cell per extension-bearing image (`postgis/postgis:16-3.4`, `pgvector/pgvector:pg16` — no stock image ships both extensions), running ONLY the extension test; the full PG suite already runs in `integration-postgres-source`, which is untouched except for the shared-matrix composite addition. `BINTRAIL_REQUIRE_PGEXT=<ext>` turns the per-extension skip into a failure (mirrors `BINTRAIL_REQUIRE_POSTGRES`), plus a `--- PASS` tripwire against an empty `-run`. Plain postgres cells skip the extension cases loudly and stay green.
- **docs/postgres.md**: composite row added to the type-support table; PostGIS and pgvector promoted from "expected to coerce" to round-trip tested; the fold-coverage note now includes composite.

**Finding: everything round-tripped byte-for-byte.** Geometry/geography stream as hex EWKB (SRID embedded), vector as its bracketed float text, composite with field quoting preserved. No fidelity gaps to report.

## Testing

Local runs against real containers, MySQL 8.0 index on 13306 in all cases (PASS lines verified per subtest, not just `ok`):

- `postgis/postgis:16-3.4` (`wal_level=logical`, `BINTRAIL_REQUIRE_PGEXT=postgis`): `TestOne_PGExtensionTypeRoundTripMatrix` PASS with subtests `geometry`, `geometry_typed`, `geography` all PASS; `vector` cases skipped loudly (`extension "vector" is not available`).
- `pgvector/pgvector:pg16` (`BINTRAIL_REQUIRE_PGEXT=vector`): PASS with subtest `vector` PASS; `postgis` cases skipped loudly.
- `postgres:16` (plain): `TestOne_PGTypeRoundTripMatrix` PASS — all 32 subtests including the new `composite`; `TestOne_PGTypeMatrixThroughReconstructFold` PASS — all 32 subtests including `composite`; `TestOne_PGExtensionTypeRoundTripMatrix` SKIP with a loud reason (no extension available, `BINTRAIL_REQUIRE_PGEXT` unset).
- Green-via-skip guard verified negatively: `BINTRAIL_REQUIRE_PGEXT=postgis` against plain `postgres:16` → exit 1 with `BINTRAIL_REQUIRE_PGEXT requires extension "postgis" but CREATE EXTENSION failed`.
- `go build ./...`, `go test ./... -count=1`, `go vet ./...`, `go vet -tags integration ./...`, `gofmt -l` all clean; ci.yml validated with a YAML parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
