### PR TITLE
agent: pass --source-flavor to the BYOS stream (MariaDB support)

### DIFF
--- a/cliapp/agent.go
+++ b/cliapp/agent.go
@@ -43,9 +43,10 @@ The connection auto-reconnects with exponential backoff on failure and sends
 periodic heartbeats to report agent status.
 
 In BYOS mode (when --source-dsn and --server-id are provided), the agent also
-reads binlogs from the customer MySQL and keeps recent events in an in-memory
-buffer. Recovery and pk resolution queries check the buffer first (fastest,
-recent data), then fall back to S3 Parquet archives.
+reads binlogs from the customer MySQL (or MariaDB, with --source-flavor
+mariadb) and keeps recent events in an in-memory buffer. Recovery and pk
+resolution queries check the buffer first (fastest, recent data), then fall
+back to S3 Parquet archives.
 
 Examples:
   # Start agent with index database
@@ -68,6 +69,7 @@ var (
 	agtEndpoint             string
 	agtIndexDSN             string
 	agtSourceDSN            string
+	agtFlavor               string
 	agtArchiveDir           string
 	agtArchiveS3            string
 	agtBufferRetain         string
@@ -92,6 +94,7 @@ func init() {
 	agentCmd.Flags().StringVar(&agtEndpoint, "endpoint", "", "dbtrail WebSocket endpoint URL (required)")
 	agentCmd.Flags().StringVar(&agtIndexDSN, "index-dsn", "", "DSN for the index MySQL database")
 	agentCmd.Flags().StringVar(&agtSourceDSN, "source-dsn", "", "DSN for the source MySQL database (enables forensics queries; required for BYOS streaming)")
+	agentCmd.Flags().StringVar(&agtFlavor, "source-flavor", "mysql", "Source database flavor for BYOS streaming: mysql or mariadb (MariaDB source support is alpha)")
 	agentCmd.Flags().StringVar(&agtArchiveDir, "archive-dir", "", "Local directory containing Parquet archives")
 	agentCmd.Flags().StringVar(&agtArchiveS3, "archive-s3", "", "S3 path to Parquet archives (e.g. s3://bucket/prefix/)")
 	agentCmd.Flags().StringVar(&agtBufferRetain, "buffer-retain", "6h", "How long to retain events in the in-memory buffer (e.g. 6h, 24h)")
@@ -117,6 +120,12 @@ func init() {
 }
 
 func runAgent(cmd *cobra.Command, args []string) error {
+	flavor, err := normalizeAgentFlavor(agtFlavor)
+	if err != nil {
+		return err
+	}
+	agtFlavor = flavor
+
 	if agtValidate {
 		return runAgentValidate(cmd.Context())
 	}
@@ -633,8 +642,11 @@ func (s *flushPipelineState) toFlushStatus() *agent.FlushStatus {
 // Both DSNs are required: --source-dsn is the live server a job observes, and
 // the index is the only place a job can persist what it observes — a stateless
 // BYOS agent (no --index-dsn) has neither a local destination nor a schema to
-// write into. Flavor is always MySQL: the agent carries no --source-flavor
-// flag, and its BYOS stream is the MySQL binlog reader.
+// write into. Flavor is the agent's --source-flavor (normalized at the top of
+// runAgent), so a flavor-gated source job sees the flavor the BYOS stream
+// actually runs with. The cmp.Or default only matters when the globals are set
+// without going through cobra (tests): a job must never be told an empty
+// flavor, which a flavor-gated job would silently skip on.
 func agentSourceJobInfo() (ext.SourceJobInfo, bool) {
 	if agtSourceDSN == "" || agtIndexDSN == "" {
 		return ext.SourceJobInfo{}, false
@@ -642,14 +654,31 @@ func agentSourceJobInfo() (ext.SourceJobInfo, bool) {
 	return ext.SourceJobInfo{
 		SourceDSN: agtSourceDSN,
 		IndexDSN:  agtIndexDSN,
-		Flavor:    "mysql",
+		Flavor:    cmp.Or(agtFlavor, gomysql.MySQLFlavor),
 	}, true
+}
+
+// normalizeAgentFlavor validates --source-flavor and maps the empty string to
+// the default. Mirrors internal/streamrun's normalizeFlavor (same accepted
+// literals, same defaulting) so the agent and `bintrail stream` reject and
+// accept identically. postgres is deliberately not accepted: the BYOS stream
+// is a binlog reader.
+func normalizeAgentFlavor(flavor string) (string, error) {
+	switch flavor {
+	case "":
+		return gomysql.MySQLFlavor, nil
+	case gomysql.MySQLFlavor, gomysql.MariaDBFlavor:
+		return flavor, nil
+	default:
+		return "", fmt.Errorf("invalid --source-flavor %q: must be %q or %q", flavor, gomysql.MySQLFlavor, gomysql.MariaDBFlavor)
+	}
 }
 
 // ─── BYOS streaming ────────────────────────────────────────────────────────
 
-// runBYOSStream reads binlogs from the source MySQL and writes events to
-// the in-memory buffer, and optionally flushes metadata/payload to sinks.
+// runBYOSStream reads binlogs from the source MySQL (or MariaDB, under
+// --source-flavor mariadb) and writes events to the in-memory buffer, and
+// optionally flushes metadata/payload to sinks.
 func runBYOSStream(ctx context.Context, sourceDB *sql.DB, buf *buffer.Buffer, fc *byosFlushConfig) error {
 	// Validate binlog settings.
 	if err := metadata.ValidateBinlogFormat(sourceDB); err != nil {
@@ -681,28 +710,11 @@ func runBYOSStream(ctx context.Context, sourceDB *sql.DB, buf *buffer.Buffer, fc
 		return err
 	}
 
-	syncerCfg := replication.BinlogSyncerConfig{
-		ServerID:                agtServerID,
-		Flavor:                  "mysql",
-		Host:                    host,
-		Port:                    port,
-		User:                    user,
-		Password:                password,
-		HeartbeatPeriod:         30 * time.Second,
-		MaxReconnectAttempts:    0,
-		TimestampStringLocation: time.UTC, // see internal/parser/parser.go (#757)
-		// MariaDB 11.4+ zero-LogPos compensation (#1117; see the syncer in
-		// internal/streamrun for the full rationale). Library-gated to the
-		// MariaDB flavor, so it is inert under this syncer's fixed "mysql"
-		// flavor today — set so the site stays correct if the agent ever
-		// grows a flavor flag.
-		FillZeroLogPos: true,
-	}
-	syncer := replication.NewBinlogSyncer(syncerCfg)
+	syncer := replication.NewBinlogSyncer(byosSyncerConfig(agtServerID, agtFlavor, host, port, user, password))
 	defer syncer.Close()
 
 	// Determine start position.
-	streamer, err := startBYOSSyncer(sourceDB, syncer, agtStartGTID)
+	streamer, err := startBYOSSyncer(sourceDB, syncer, agtFlavor, agtStartGTID)
 	if err != nil {
 		return err
 	}
@@ -727,13 +739,40 @@ func runBYOSStream(ctx context.Context, sourceDB *sql.DB, buf *buffer.Buffer, fc
 	return err
 }
 
+// byosSyncerConfig builds the BYOS binlog syncer's config. Pure — extracted
+// from runBYOSStream so the flavor fan-out is unit-testable without a live
+// source (mirrors consoleapp's sourceStreamConfig extraction).
+func byosSyncerConfig(serverID uint32, flavor, host string, port uint16, user, password string) replication.BinlogSyncerConfig {
+	cfg := replication.BinlogSyncerConfig{
+		ServerID:                serverID,
+		Flavor:                  flavor,
+		Host:                    host,
+		Port:                    port,
+		User:                    user,
+		Password:                password,
+		HeartbeatPeriod:         30 * time.Second,
+		MaxReconnectAttempts:    0,
+		TimestampStringLocation: time.UTC, // see internal/parser/parser.go (#757)
+	}
+	if flavor == gomysql.MariaDBFlavor {
+		// Ask the MariaDB source to send ANNOTATE_ROWS events — MariaDB only
+		// forwards them to a replica that set this dump flag (#699) — and
+		// compensate the MariaDB 11.4+ zero-LogPos events (#1117). Both
+		// mirror the streamrun syncer's MariaDB branch; see the full
+		// rationale there.
+		cfg.DumpCommandFlag |= replication.BINLOG_SEND_ANNOTATE_ROWS_EVENT
+		cfg.FillZeroLogPos = true
+	}
+	return cfg
+}
+
 // startBYOSSyncer starts the binlog syncer from the given GTID set or
 // from the server's current binlog position.
-func startBYOSSyncer(sourceDB *sql.DB, syncer *replication.BinlogSyncer, startGTID string) (*replication.BinlogStreamer, error) {
+func startBYOSSyncer(sourceDB *sql.DB, syncer *replication.BinlogSyncer, flavor, startGTID string) (*replication.BinlogStreamer, error) {
 	if startGTID != "" {
-		gset, err := gomysql.ParseGTIDSet("mysql", startGTID)
+		gset, err := parseBYOSStartGTID(flavor, startGTID)
 		if err != nil {
-			return nil, fmt.Errorf("parse start GTID set: %w", err)
+			return nil, err
 		}
 		return syncer.StartSyncGTID(gset)
 	}
@@ -744,6 +783,18 @@ func startBYOSSyncer(sourceDB *sql.DB, syncer *replication.BinlogSyncer, startGT
 	}
 	slog.Info("starting from current binlog position", "file", file, "pos", pos)
 	return syncer.StartSync(gomysql.Position{Name: file, Pos: pos})
+}
+
+// parseBYOSStartGTID parses --start-gtid with the parser for the configured
+// source flavor. A MariaDB GTID set ("0-2-71") is not parseable as a MySQL
+// set, so the hardwired "mysql" literal this replaces made --start-gtid
+// unusable against a MariaDB source.
+func parseBYOSStartGTID(flavor, startGTID string) (gomysql.GTIDSet, error) {
+	gset, err := gomysql.ParseGTIDSet(flavor, startGTID)
+	if err != nil {
+		return nil, fmt.Errorf("parse start GTID set: %w", err)
+	}
+	return gset, nil
 }
 
 // byosStreamLoop reads events from the parser channel and writes them to

--- a/cliapp/agent_flavor_test.go
+++ b/cliapp/agent_flavor_test.go
@@ -1,0 +1,107 @@
+package cliapp
+
+import (
+	"strings"
+	"testing"
+
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/replication"
+)
+
+// TestAgentCmdSourceFlavorFlag pins the flag registration and its default:
+// every pre-existing agent invocation (no flag, no env) must keep streaming
+// with the MySQL flavor. Mirrors TestStreamCmd_sourceFlavorDefault.
+func TestAgentCmdSourceFlavorFlag(t *testing.T) {
+	f := agentCmd.Flag("source-flavor")
+	if f == nil {
+		t.Fatal("flag --source-flavor not registered on agentCmd")
+	}
+	if f.DefValue != "mysql" {
+		t.Errorf("expected default source-flavor=mysql, got %q", f.DefValue)
+	}
+}
+
+func TestNormalizeAgentFlavor(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{in: "", want: gomysql.MySQLFlavor},
+		{in: "mysql", want: gomysql.MySQLFlavor},
+		{in: "mariadb", want: gomysql.MariaDBFlavor},
+		// The BYOS stream is a binlog reader; postgres is a different capturer.
+		{in: "postgres", wantErr: true},
+		// go-mysql's flavor literals are lowercase; a case-mismatch must fail
+		// loudly here, not surface as a cryptic syncer handshake error.
+		{in: "MySQL", wantErr: true},
+		{in: "percona", wantErr: true},
+	}
+	for _, tc := range tests {
+		got, err := normalizeAgentFlavor(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("normalizeAgentFlavor(%q) = %q, want error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("normalizeAgentFlavor(%q) error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("normalizeAgentFlavor(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestBYOSSyncerConfigFlavor is the wiring test for the syncer config:
+// hardwire "mysql" back into byosSyncerConfig (or drop its MariaDB branch)
+// and a case here fails.
+func TestBYOSSyncerConfigFlavor(t *testing.T) {
+	my := byosSyncerConfig(42, gomysql.MySQLFlavor, "src-host", 3306, "u", "pw")
+	if my.Flavor != gomysql.MySQLFlavor {
+		t.Errorf("mysql config Flavor = %q, want %q", my.Flavor, gomysql.MySQLFlavor)
+	}
+	if my.DumpCommandFlag&replication.BINLOG_SEND_ANNOTATE_ROWS_EVENT != 0 {
+		t.Error("mysql config must not set the MariaDB ANNOTATE dump flag")
+	}
+	if my.FillZeroLogPos {
+		t.Error("FillZeroLogPos is the MariaDB 11.4+ compensation (#1117); the mysql config keeps it off (streamrun parity)")
+	}
+	if my.ServerID != 42 || my.Host != "src-host" || my.Port != 3306 || my.User != "u" || my.Password != "pw" {
+		t.Errorf("connection fields not carried through: %+v", my)
+	}
+
+	ma := byosSyncerConfig(42, gomysql.MariaDBFlavor, "src-host", 3306, "u", "pw")
+	if ma.Flavor != gomysql.MariaDBFlavor {
+		t.Errorf("mariadb config Flavor = %q, want %q (a hardwired mysql flavor makes the syncer parse MariaDB GTID events as MySQL's)", ma.Flavor, gomysql.MariaDBFlavor)
+	}
+	if ma.DumpCommandFlag&replication.BINLOG_SEND_ANNOTATE_ROWS_EVENT == 0 {
+		t.Error("mariadb config must request ANNOTATE_ROWS (#699): MariaDB only forwards them to a replica that set the dump flag")
+	}
+	if !ma.FillZeroLogPos {
+		t.Error("mariadb config must set FillZeroLogPos (#1117 zero-LogPos compensation)")
+	}
+}
+
+// TestParseBYOSStartGTIDFlavor pins that --start-gtid is parsed with the
+// configured flavor: before the flavor flag, the parse was hardwired to
+// "mysql" and a MariaDB GTID set was unusable.
+func TestParseBYOSStartGTIDFlavor(t *testing.T) {
+	if _, err := parseBYOSStartGTID(gomysql.MariaDBFlavor, "0-2-71"); err != nil {
+		t.Errorf("mariadb flavor rejected a MariaDB GTID set: %v", err)
+	}
+	if _, err := parseBYOSStartGTID(gomysql.MySQLFlavor, "0-2-71"); err == nil {
+		t.Error("mysql flavor accepted a MariaDB GTID set — the flavor is not reaching the parser")
+	}
+	// Lowercase UUID on purpose: go-mysql lowercases GTID UUIDs.
+	if _, err := parseBYOSStartGTID(gomysql.MySQLFlavor, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5"); err != nil {
+		t.Errorf("mysql flavor rejected a MySQL GTID set: %v", err)
+	}
+	if _, err := parseBYOSStartGTID(gomysql.MySQLFlavor, "not-a-gtid"); err == nil {
+		t.Error("garbage GTID set parsed without error")
+	} else if !strings.Contains(err.Error(), "parse start GTID set") {
+		t.Errorf("want the wrapped parse error, got %v", err)
+	}
+}

--- a/cliapp/sourcejob_wiring_test.go
+++ b/cliapp/sourcejob_wiring_test.go
@@ -63,17 +63,25 @@ func TestUpReachesTheSeamWithItsOwnConfiguration(t *testing.T) {
 }
 
 func TestAgentSourceJobInfoRequiresSourceAndIndex(t *testing.T) {
-	origSource, origIndex := agtSourceDSN, agtIndexDSN
-	t.Cleanup(func() { agtSourceDSN, agtIndexDSN = origSource, origIndex })
+	origSource, origIndex, origFlavor := agtSourceDSN, agtIndexDSN, agtFlavor
+	t.Cleanup(func() { agtSourceDSN, agtIndexDSN, agtFlavor = origSource, origIndex, origFlavor })
 
 	tests := []struct {
 		name             string
 		source, index    string
+		flavor           string
 		wantOK           bool
 		wantSrc, wantIdx string
+		wantFlavor       string
 	}{
 		{name: "both set", source: "u:p@tcp(src:3306)/", index: "u:p@tcp(idx:3306)/bintrail_index",
-			wantOK: true, wantSrc: "u:p@tcp(src:3306)/", wantIdx: "u:p@tcp(idx:3306)/bintrail_index"},
+			wantOK: true, wantSrc: "u:p@tcp(src:3306)/", wantIdx: "u:p@tcp(idx:3306)/bintrail_index",
+			wantFlavor: "mysql"},
+		// --source-flavor mariadb must reach the source job — a flavor-gated
+		// job otherwise observes a MariaDB source believing it is MySQL.
+		{name: "mariadb flavor", source: "u:p@tcp(src:3306)/", index: "u:p@tcp(idx:3306)/bintrail_index",
+			flavor: "mariadb", wantOK: true, wantSrc: "u:p@tcp(src:3306)/", wantIdx: "u:p@tcp(idx:3306)/bintrail_index",
+			wantFlavor: "mariadb"},
 		// Stateless BYOS: a live source, but nowhere to persist an
 		// observation — jobs must not start and then fail on an empty DSN.
 		{name: "no index", source: "u:p@tcp(src:3306)/", index: "", wantOK: false},
@@ -83,7 +91,7 @@ func TestAgentSourceJobInfoRequiresSourceAndIndex(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			agtSourceDSN, agtIndexDSN = tc.source, tc.index
+			agtSourceDSN, agtIndexDSN, agtFlavor = tc.source, tc.index, tc.flavor
 			got, ok := agentSourceJobInfo()
 			if ok != tc.wantOK {
 				t.Fatalf("agentSourceJobInfo() ok = %v, want %v", ok, tc.wantOK)
@@ -94,8 +102,8 @@ func TestAgentSourceJobInfoRequiresSourceAndIndex(t *testing.T) {
 			if got.SourceDSN != tc.wantSrc || got.IndexDSN != tc.wantIdx {
 				t.Errorf("agentSourceJobInfo() = %+v, want the agent's DSNs", got)
 			}
-			if got.Flavor != "mysql" {
-				t.Errorf("agentSourceJobInfo().Flavor = %q, want \"mysql\" (the agent streams MySQL binlogs and has no flavor flag)", got.Flavor)
+			if got.Flavor != tc.wantFlavor {
+				t.Errorf("agentSourceJobInfo().Flavor = %q, want %q (an empty flavor would make a flavor-gated source job skip with no signal)", got.Flavor, tc.wantFlavor)
 			}
 		})
 	}

--- a/docs/mariadb.md
+++ b/docs/mariadb.md
@@ -165,10 +165,13 @@ silently become the write key for every server. Two caveats:
   sequences per domain (correct for single-server and multi-domain topologies),
   but a primary failover that changes the `server_id` *within* a domain mid-stream
   has not been validated against a live multi-server MariaDB cluster.
-- **No BYOS agent support.** `bintrail agent` does not yet support MariaDB
-  (it streams with the fixed `mysql` flavor). The web console **does** capture
-  MariaDB sources (**+ Add server** → MariaDB, with a flavor chip in the server
-  list).
+- **BYOS agent support is the least exercised path.** `bintrail agent` accepts
+  `--source-flavor mariadb` (same flag and `BINTRAIL_SOURCE_FLAVOR` env as
+  `stream`) for its BYOS streaming, but unlike `stream` it has no saved
+  checkpoint — on restart it resumes from `--start-gtid` (parsed with the
+  configured flavor) or the server's current binlog position. The web console
+  also captures MariaDB sources (**+ Add server** → MariaDB, with a flavor chip
+  in the server list).
 - **Index-on-MariaDB is out of scope** — the index database stays MySQL.
 
 ---


### PR DESCRIPTION
closes #623

## Summary

Completes the remaining scope of #623 (the grooming note narrowed it after #1019/#1023 shipped the registry `flavor` field, the +Add server MariaDB option, and the supervisor's `sourceStreamConfig` flavor plumbing): the BYOS agent was the last capture surface with a hardwired `"mysql"` flavor.

- `bintrail agent` gains `--source-flavor` (mysql | mariadb, default `mysql` — every existing invocation is unchanged). The existing `BINTRAIL_SOURCE_FLAVOR` env binding applies automatically through the per-flag env table, same as `stream`'s.
- `normalizeAgentFlavor` validates at the top of `runAgent`, mirroring streamrun's `normalizeFlavor` (same literals, empty defaults to mysql; postgres rejected — the BYOS stream is a binlog reader).
- `byosSyncerConfig` (pure, extracted from `runBYOSStream` — mirrors consoleapp's `sourceStreamConfig` extraction) carries the flavor into the `BinlogSyncerConfig` and mirrors the streamrun syncer's MariaDB branch: `BINLOG_SEND_ANNOTATE_ROWS_EVENT` (#699) and `FillZeroLogPos` (#1117), both gated to the mariadb flavor.
- `startBYOSSyncer` parses `--start-gtid` with the configured flavor (`parseBYOSStartGTID`) — a MariaDB GTID set (`0-2-71`) was previously unparseable because the parse was hardwired to `"mysql"`.
- `agentSourceJobInfo` reports the real flavor to the ext source-job seam instead of the `"mysql"` literal.
- docs/mariadb.md: the "No BYOS agent support" alpha limitation is replaced with the actual contract (flag + env; no saved checkpoint — resume is `--start-gtid` or the server's current position).

## Testing

- New `cliapp/agent_flavor_test.go`: flag registration + default, `normalizeAgentFlavor` table, `byosSyncerConfig` flavor fan-out (mysql keeps ANNOTATE/FillZeroLogPos off; mariadb sets both), `parseBYOSStartGTID` per-flavor parse.
- Mutation-verified wiring: hardwiring `"mysql"` back into `byosSyncerConfig` makes `TestBYOSSyncerConfigFlavor` fail (`mariadb config Flavor = "mysql", want "mariadb"`), then reverted.
- `cliapp/sourcejob_wiring_test.go` extended with a mariadb case (and pins that an empty flavor never reaches a flavor-gated source job).
- `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, `go test ./... -count=1` all green; `gofmt -l` clean on the changed files.
- Integration (Docker MySQL on 13306): `go test -tags integration -count=1 ./cliapp/ ./internal/console/ ./consoleapp/` — all `ok`; a `-v -run TestIntegration` pass over internal/console + consoleapp shows PASS with zero SKIPs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
