### PR TITLE
mariadb: pin the --no-gap-fill refusal, drop dead wrapper, count unhandled-row drops

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -15,10 +15,11 @@ Under `bintrail-console watch` the daemon serves one `/metrics` endpoint for
 every monitored source; the per-source `source` label keeps them distinct.
 
 Every stream and index metric carries a `source` label (the supervisor's entry
-ID when monitored, else the resolved `bintrail_id`, or `default`). The one
-exception is the top-level capture-loss counter
-[`bintrail_statement_dml_dropped_total`](#capture-loss-bintrail_statement_dml_dropped_total),
-which has no `source` label.
+ID when monitored, else the resolved `bintrail_id`, or `default`). The
+exceptions are the top-level capture-loss counters
+[`bintrail_statement_dml_dropped_total` and
+`bintrail_unhandled_rows_dropped_total`](#capture-loss-bintrail_statement_dml_dropped_total),
+which have no `source` label.
 
 ## Stream metrics (`bintrail_stream_*`)
 
@@ -66,6 +67,7 @@ non-replication producer built — is **skipped**, never recorded as a
 | Metric | Type | Meaning |
 |---|---|---|
 | `bintrail_statement_dml_dropped_total` | counter | DML statements (INSERT/UPDATE/DELETE/REPLACE/LOAD DATA) seen in the binlog as SQL text instead of row events — the signature of `binlog_format=STATEMENT`/`MIXED` or a session-level override away from ROW. Each one is a change bintrail could **not** capture. |
+| `bintrail_unhandled_rows_dropped_total` | counter | Rows carried by a binlog row event of a type bintrail does not decode — skipped at capture, never indexed. Incremented **per dropped row** (one event can carry many rows). |
 
 **Nonzero means changes are being missed.** bintrail validates
 `binlog_format=ROW` at startup against the global value, but the variable is
@@ -74,12 +76,19 @@ The stream is not aborted — each dropped statement emits a loud warning
 (`statement-format DML in binlog — event NOT captured …`) plus one increment
 of this counter.
 
-This counter is deliberately **top-level**: it is not part of
-`bintrail_stream_*` and carries **no `source` label**, so under
-`bintrail-console watch` concurrent streams conflate into one counter. The
-paired warning carries the binlog file/position (and the statement type —
-never the SQL text, which embeds row values); use the log line to tell which
-source produced the drop.
+`bintrail_unhandled_rows_dropped_total` is the row-event sibling: rows carried
+by a binlog row event of a type bintrail does not decode are skipped with a
+loud warning (`unhandled row event type — rows skipped`) plus one counter
+increment per dropped row. Nonzero means row changes reached the parser but
+were never indexed.
+
+Both counters are deliberately **top-level**: they are not part of
+`bintrail_stream_*` and carry **no `source` label**, so under
+`bintrail-console watch` concurrent streams conflate into one counter each. The
+paired warning carries the binlog file/position (plus the statement type for
+the former — never the SQL text, which embeds row values — and the
+schema.table and raw event type for the latter); use the log line to tell
+which source produced the drop.
 
 ## Index metrics (`bintrail_index_*`)
 
@@ -126,11 +135,16 @@ bintrail_index_retention_horizon_seconds < 7 * 24 * 3600
 bintrail_index_gap_hours > 0
 ```
 
-**Changes slipping past capture** — statement-format DML the index will never
-contain (see [Capture loss](#capture-loss-bintrail_statement_dml_dropped_total)):
+**Changes slipping past capture** — statement-format DML, or rows from
+undecodable row events, that the index will never contain (see
+[Capture loss](#capture-loss-bintrail_statement_dml_dropped_total)):
 
 ```promql
 rate(bintrail_statement_dml_dropped_total[5m]) > 0
+```
+
+```promql
+rate(bintrail_unhandled_rows_dropped_total[5m]) > 0
 ```
 
 **Index disk growth** — MySQL index size trend, to project a disk-full date

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -343,7 +343,8 @@ When `--metrics-addr :9090` is set, a Prometheus HTTP endpoint starts at `/metri
 
 Every metric in the table above carries a `source` label so concurrent streams
 in one process stay distinguishable (the top-level
-`bintrail_statement_dml_dropped_total` counter is the exception — see
+`bintrail_statement_dml_dropped_total` and
+`bintrail_unhandled_rows_dropped_total` counters are the exception — see
 [observability.md](observability.md#capture-loss-bintrail_statement_dml_dropped_total)). For a standalone `bintrail stream` it is the server's resolved
 `bintrail_id` (`default` if unresolved); under `bintrail-console watch` it is the
 monitored entry's ID, and the **daemon** serves one `/metrics` endpoint covering

--- a/internal/observe/metrics.go
+++ b/internal/observe/metrics.go
@@ -133,6 +133,23 @@ var (
 		Name:      "statement_dml_dropped_total",
 		Help:      "DML statements seen in the binlog under STATEMENT/MIXED format (or a session override) — changes bintrail could not capture as row events.",
 	})
+
+	// unhandledRowsDropped counts ROWS carried by a binlog row event whose type
+	// handleRows does not decode — the warn-and-skip default arm shared by the
+	// file and stream parsers. Each such row is a change bintrail could NOT
+	// capture; the sibling of statementDMLDropped above for the row-event side
+	// of the capture boundary.
+	//
+	// Same shape as its sibling, for the same reasons: top-level (no "stream"
+	// subsystem, no "source" label — the parser has no source handle to curry)
+	// and no schema/table labels (the documented stance in observability.md:
+	// per-table label sets grow as tables come and go). The paired warn carries
+	// file/pos, schema.table and the raw event type as the disambiguator.
+	unhandledRowsDropped = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "bintrail",
+		Name:      "unhandled_rows_dropped_total",
+		Help:      "Rows carried by binlog row events of a type bintrail does not decode — changes dropped at capture, never indexed.",
+	})
 )
 
 // StatementDMLDropped increments the statement-DML-dropped counter. Called from
@@ -140,6 +157,13 @@ var (
 // statement — not DDL, not transaction-control — is observed, i.e. the
 // row-capture invariant (binlog_format=ROW) has been violated at the source.
 func StatementDMLDropped() { statementDMLDropped.Inc() }
+
+// UnhandledRowsDropped adds n — the row count of one skipped event — to the
+// unhandled-rows-dropped counter. Called from handleRows' default arm (shared
+// by the file and stream parsers) when a RowsEvent arrives with a type bintrail
+// does not decode: the rows are dropped, so the operator needs a metric to
+// alert on, not just the paired warn.
+func UnhandledRowsDropped(n int) { unhandledRowsDropped.Add(float64(n)) }
 
 // StreamMetrics is the full set of stream metrics curried to one source
 // label — call sites keep the ergonomics of plain counters/gauges.

--- a/internal/observe/metrics_test.go
+++ b/internal/observe/metrics_test.go
@@ -119,3 +119,28 @@ func TestStatementDMLDropped(t *testing.T) {
 		t.Errorf("statement_dml_dropped_total = %v after two increments, want %v", got, before+2)
 	}
 }
+
+// TestUnhandledRowsDropped verifies the unhandled-row-event drop counter adds
+// the per-event ROW count (an unhandled event can carry many rows), rendered
+// under the exact top-level name alerts key off. Global-registry singleton, so
+// before/after delta like its statement-DML sibling.
+func TestUnhandledRowsDropped(t *testing.T) {
+	read := func() float64 {
+		mfs, err := prometheus.DefaultGatherer.Gather()
+		if err != nil {
+			t.Fatalf("Gather: %v", err)
+		}
+		for _, mf := range mfs {
+			if mf.GetName() == "bintrail_unhandled_rows_dropped_total" {
+				return mf.GetMetric()[0].GetCounter().GetValue()
+			}
+		}
+		return 0
+	}
+	before := read()
+	observe.UnhandledRowsDropped(3)
+	observe.UnhandledRowsDropped(1)
+	if got := read(); got != before+4 {
+		t.Errorf("unhandled_rows_dropped_total = %v after adding 3+1, want %v", got, before+4)
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -753,6 +753,7 @@ func handleRows(
 			"table", table,
 			"event_type", binlogEv.Header.EventType,
 			"rows_skipped", len(rowsEv.Rows))
+		observe.UnhandledRowsDropped(len(rowsEv.Rows))
 		skips.RecordSkip(SkipUnhandledRowEvent)
 	}
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-mysql-org/go-mysql/replication"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/dbtrail/dbtrail/internal/metadata"
 )
@@ -177,6 +178,24 @@ func TestFormatGTID_anonymousEvent(t *testing.T) {
 // through to `return nil`, dropping every row with no trace (a silent data-loss
 // class). The guarantee is that unrecognized row events are never dropped
 // silently.
+// readUnhandledRowsDropped reads bintrail_unhandled_rows_dropped_total from the
+// default Prometheus registry. It is a process-global singleton other tests may
+// touch, so callers assert before/after deltas, never absolute values (same
+// pattern as readStatementDMLDropped in skips_test.go).
+func readUnhandledRowsDropped(t *testing.T) float64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() == "bintrail_unhandled_rows_dropped_total" {
+			return mf.GetMetric()[0].GetCounter().GetValue()
+		}
+	}
+	return 0
+}
+
 func TestHandleRows_unhandledEventTypeLogsNotSilent(t *testing.T) {
 	tm := &metadata.TableMeta{
 		Schema:    "shop",
@@ -207,6 +226,7 @@ func TestHandleRows_unhandledEventTypeLogsNotSilent(t *testing.T) {
 	rowsEv := binlogEv.Event.(*replication.RowsEvent)
 
 	out := make(chan Event, 4)
+	before := readUnhandledRowsDropped(t)
 	if err := handleRows(context.Background(), logger, resolver, &Filters{}, binlogEv, rowsEv, "mariadb-bin.000001", "0-1-1", 0, 0, "", 1, emitTo(out), nil, nil); err != nil {
 		t.Fatalf("handleRows: %v", err)
 	}
@@ -215,10 +235,15 @@ func TestHandleRows_unhandledEventTypeLogsNotSilent(t *testing.T) {
 	if !strings.Contains(strings.ToLower(logged), "unhandled") {
 		t.Errorf("expected a warn mentioning the unhandled row event type, got logs: %q", logged)
 	}
-	// The anti-silent-data-loss contract is two-part: the warn must quantify the
-	// drop (rows_skipped) and nothing may leak onto the output channel.
+	// The anti-silent-data-loss contract is three-part: the warn must quantify
+	// the drop (rows_skipped), the drop must move the alertable counter (the
+	// fixture event carries exactly one row), and nothing may leak onto the
+	// output channel.
 	if !strings.Contains(logged, "rows_skipped") {
 		t.Errorf("expected rows_skipped count in the warn, got logs: %q", logged)
+	}
+	if got := readUnhandledRowsDropped(t); got != before+1 {
+		t.Errorf("bintrail_unhandled_rows_dropped_total moved %v -> %v, want +1 (one dropped row)", before, got)
 	}
 	if len(out) != 0 {
 		t.Errorf("unhandled event must emit no rows downstream, got %d", len(out))

--- a/internal/streamrun/nogapfill_mariadb_integration_test.go
+++ b/internal/streamrun/nogapfill_mariadb_integration_test.go
@@ -1,0 +1,193 @@
+//go:build integration
+
+package streamrun
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// newestSurvivingBinlog returns the last row of SHOW BINARY LOGS (newest
+// binlog). Column-tolerant scan like earliestBinlogFile: only Log_name is
+// needed, and the column count varies across versions.
+func newestSurvivingBinlog(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	rows, err := db.Query("SHOW BINARY LOGS")
+	if err != nil {
+		t.Fatalf("SHOW BINARY LOGS: %v", err)
+	}
+	defer rows.Close()
+	cols, err := rows.Columns()
+	if err != nil {
+		t.Fatalf("SHOW BINARY LOGS columns: %v", err)
+	}
+	var newest string
+	for rows.Next() {
+		var name string
+		dest := make([]any, len(cols))
+		dest[0] = &name
+		for i := 1; i < len(dest); i++ {
+			dest[i] = new(sql.RawBytes)
+		}
+		if err := rows.Scan(dest...); err != nil {
+			t.Fatalf("scan SHOW BINARY LOGS: %v", err)
+		}
+		newest = name
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate SHOW BINARY LOGS: %v", err)
+	}
+	if newest == "" {
+		t.Fatal("SHOW BINARY LOGS returned no rows")
+	}
+	return newest
+}
+
+// TestOne_MariaDBGTID_noGapFillRefusesUnfillableGap is the regression test for
+// the --no-gap-fill refusal under an unfillable MariaDB GTID gap (#517
+// residual, review-deferred from #515). It drives the SAME cmd-layer One()
+// entry point the CLI uses — a pure unit test cannot reach this refusal: the
+// decision sits inline in One() after live-server-only steps (connectHelper,
+// binlog-format validation, resolver bootstrap), and the MariaDB gap detector
+// it must flow through queries a real source. The staging:
+//
+//  1. write transactions, rotate, then PURGE BINARY LOGS so the purge floor
+//     (BINLOG_GTID_POS over the oldest surviving binlog — MariaDB has no
+//     @@gtid_purged) is non-empty and covers those transactions;
+//  2. plant a GTID-mode checkpoint strictly BEHIND that floor in stream_state;
+//  3. run One() with NoGapFill — detectMariaDBGTIDGap must classify the gap
+//     unfillable and One() must refuse to start instead of auto-advancing.
+func TestOne_MariaDBGTID_noGapFillRefusesUnfillableGap(t *testing.T) {
+	indexDB, indexName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, indexDB)
+
+	sourceDB, sourceName := testutil.CreateTestMariaDB(t)
+
+	var logBin string
+	if err := sourceDB.QueryRow("SELECT @@log_bin").Scan(&logBin); err != nil || logBin != "1" {
+		testutil.SkipOrFailMariaDB(t, "binary logging not enabled on test MariaDB")
+	}
+
+	testutil.MustExec(t, sourceDB, `CREATE TABLE orders (
+		id     INT PRIMARY KEY AUTO_INCREMENT,
+		amount DECIMAL(10,2) NOT NULL
+	)`)
+	for i := range 3 {
+		testutil.MustExec(t, sourceDB,
+			"INSERT INTO orders (amount) VALUES (?)", float64(i+1)*10.0)
+	}
+
+	// Rotate and purge until the oldest SURVIVING binlog carries a non-empty
+	// starting GTID state (the purge floor). Two MariaDB wrinkles make this a
+	// loop rather than one FLUSH+PURGE: the binlog created at server startup
+	// has an EMPTY Gtid_list (nothing executed yet, so purging up to it still
+	// yields no floor), and PURGE silently KEEPS any file still referenced by
+	// the crash-safe binlog checkpoint. Writing a transaction after each
+	// rotation advances the checkpoint into the new file so the next PURGE can
+	// drop the older ones; one or two rounds normally converge, the loop
+	// absorbs checkpoint lag. (PURGE cannot go through a prepared statement;
+	// the filename comes from SHOW BINARY LOGS, not user input.)
+	var floor string
+	for attempt := 0; attempt < 5 && floor == ""; attempt++ {
+		testutil.MustExec(t, sourceDB, "FLUSH BINARY LOGS")
+		testutil.MustExec(t, sourceDB, "INSERT INTO orders (amount) VALUES (999.99)")
+		newest := newestSurvivingBinlog(t, sourceDB)
+		testutil.MustExec(t, sourceDB, fmt.Sprintf("PURGE BINARY LOGS TO '%s'", newest))
+
+		earliest, err := earliestBinlogFile(context.Background(), sourceDB)
+		if err != nil {
+			t.Fatalf("earliestBinlogFile: %v", err)
+		}
+		var floorNS sql.NullString
+		if err := sourceDB.QueryRow("SELECT BINLOG_GTID_POS(?, 4)", earliest).Scan(&floorNS); err != nil {
+			t.Fatalf("BINLOG_GTID_POS(%q, 4): %v", earliest, err)
+		}
+		floor = strings.TrimSpace(floorNS.String)
+		if floor == "" {
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+	if floor == "" {
+		testutil.SkipOrFailMariaDB(t,
+			"purge floor still empty after repeated FLUSH+PURGE — cannot stage an unfillable gap")
+	}
+
+	// Plant a checkpoint strictly behind the floor: the floor's first triple's
+	// domain and server, at sequence 1. The floor's max sequence covers at
+	// least the CREATE TABLE + 3 INSERTs above, so seq 1 can never cover it —
+	// exactly the "required GTIDs have been purged" shape.
+	first := strings.TrimSpace(strings.SplitN(floor, ",", 2)[0])
+	parts := strings.Split(first, "-")
+	if len(parts) != 3 {
+		t.Fatalf("unexpected purge floor triple %q (full floor %q)", first, floor)
+	}
+	if seq, perr := strconv.ParseUint(parts[2], 10, 64); perr != nil || seq < 2 {
+		t.Fatalf("purge floor %q max seq %q must be >= 2 for a seq-1 checkpoint to be behind it", floor, parts[2])
+	}
+	stale := parts[0] + "-" + parts[1] + "-1"
+
+	testutil.MustExec(t, indexDB, `INSERT INTO stream_state
+		(id, mode, gtid_set, flavor, last_checkpoint, server_id)
+		VALUES (1, 'gtid', ?, 'mariadb', UTC_TIMESTAMP(), 1)`, stale)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	err := One(ctx, Config{
+		IndexDSN:   testutil.IntegrationDSN(indexName),
+		SourceDSN:  testutil.MariaDBBaseDSN() + "/" + sourceName + "?parseTime=true",
+		Flavor:     gomysql.MariaDBFlavor,
+		ServerID:   99993,
+		BatchSize:  100,
+		Schemas:    sourceName,
+		Checkpoint: 5,
+		GapTimeout: 30,
+		Format:     "text",
+		SSLMode:    "preferred",
+		NoGapFill:  true,
+		Deps:       testStreamDeps(),
+	})
+	if err == nil {
+		t.Fatal("One() with --no-gap-fill must refuse to start over an unfillable MariaDB GTID gap, got nil")
+	}
+
+	// Pin the refusal MESSAGE shape: it must name the flag the operator set
+	// and carry the MariaDB detector's diagnosis, so the refusal is
+	// actionable, not a bare "gap detected".
+	msg := err.Error()
+	for _, want := range []string{
+		"binlog gap detected and --no-gap-fill is set", // the refusal, naming the flag
+		"CANNOT be filled", // the MariaDB detector's verdict...
+		"purge floor",      // ...its mechanism (GTIDs purged past the floor)...
+		"permanently lost", // ...and its consequence
+		stale,              // the operator's own checkpoint, for orientation
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("refusal message missing %q:\n%s", want, msg)
+		}
+	}
+
+	// A refusal must be a pure refusal: no auto-advance, no gap_lost stamp.
+	// The planted checkpoint survives byte-identical so the operator decides
+	// what happens to the lost window, not bintrail.
+	var gtidSet string
+	var gapLostAt sql.NullTime
+	if qerr := indexDB.QueryRow(
+		"SELECT gtid_set, gap_lost_at FROM stream_state WHERE id = 1").Scan(&gtidSet, &gapLostAt); qerr != nil {
+		t.Fatalf("reload stream_state: %v", qerr)
+	}
+	if gtidSet != stale {
+		t.Errorf("stream_state.gtid_set = %q after the refusal, want the untouched %q", gtidSet, stale)
+	}
+	if gapLostAt.Valid {
+		t.Errorf("gap_lost_at was stamped (%v) by a --no-gap-fill refusal; must remain NULL", gapLostAt.Time)
+	}
+}

--- a/internal/streamrun/streamrun.go
+++ b/internal/streamrun/streamrun.go
@@ -849,28 +849,17 @@ func resolveStartForFlavor(
 			"provide --start-file or --start-gtid to begin streaming")
 }
 
-// resolveStartWithAutoDiscover wraps resolveStart with an auto-discover
-// fallback for the first-run, no-flags case. When neither --start-file nor
-// --start-gtid is set AND no checkpoint exists yet, the provided autoDiscover
-// callback is invoked to query the source's current binlog position (matching
-// the behavior of `bintrail agent` BYOS mode). The callback is typically
-// config.CurrentBinlogPosition(sourceDB).
+// resolveStartWithAutoDiscoverForFlavor wraps resolveStartForFlavor with an
+// auto-discover fallback for the first-run, no-flags case. When neither
+// --start-file nor --start-gtid is set AND no checkpoint exists yet, the
+// provided callbacks are invoked to query the source's current coordinates
+// (matching the behavior of `bintrail agent` BYOS mode); they are typically
+// config.CurrentGTIDExecuted / config.CurrentBinlogPosition over sourceDB, and
+// exist as callbacks so the discovery side-effect can be unit-tested without a
+// real *sql.DB.
 //
 // All other paths (saved checkpoint, explicit flags, mutually-exclusive flags,
-// invalid GTID, etc.) delegate to resolveStart unchanged. The wrapper exists
-// so the discovery side-effect can be unit-tested without a real *sql.DB —
-// callers pass a stub function.
-func resolveStartWithAutoDiscover(
-	startFile, startGTID string, startPos uint32,
-	saved *streamState,
-	autoDiscover func() (string, uint32, error),
-	gtidAutoDiscover func() (string, error),
-) (mode, file, gtidStr string, pos uint32, accGTID gomysql.GTIDSet, err error) {
-	return resolveStartWithAutoDiscoverForFlavor(startFile, startGTID, startPos, saved, gomysql.MySQLFlavor, autoDiscover, gtidAutoDiscover)
-}
-
-// resolveStartWithAutoDiscoverForFlavor is the flavor-aware variant of
-// resolveStartWithAutoDiscover; see that function for the contract. flavor is
+// invalid GTID, etc.) delegate to resolveStartForFlavor unchanged. flavor is
 // threaded into resolveStartForFlavor so saved/flag GTID sets parse with the
 // right flavor.
 //

--- a/internal/streamrun/streamrun_test.go
+++ b/internal/streamrun/streamrun_test.go
@@ -1285,14 +1285,14 @@ func TestGtidSetsEqual(t *testing.T) {
 	}
 }
 
-// ─── resolveStartWithAutoDiscover ────────────────────────────────────────────
+// ─── resolveStartWithAutoDiscoverForFlavor ────────────────────────────────────────────
 
 // TestResolveStartWithAutoDiscover_firesOnFirstRun verifies that the
 // auto-discover callback is invoked when saved is nil and no flags are set,
 // and that its result becomes the start position.
 func TestResolveStartWithAutoDiscover_firesOnFirstRun(t *testing.T) {
 	called := false
-	mode, file, _, pos, _, err := resolveStartWithAutoDiscover("", "", 4, nil,
+	mode, file, _, pos, _, err := resolveStartWithAutoDiscoverForFlavor("", "", 4, nil, gomysql.MySQLFlavor,
 		func() (string, uint32, error) {
 			called = true
 			return "mysql-bin.000042", 1234, nil
@@ -1313,7 +1313,7 @@ func TestResolveStartWithAutoDiscover_firesOnFirstRun(t *testing.T) {
 // explicit --start-file bypasses auto-discover (preserves operator override).
 func TestResolveStartWithAutoDiscover_skippedWhenFlagSet(t *testing.T) {
 	called := false
-	mode, file, _, pos, _, err := resolveStartWithAutoDiscover("binlog.000001", "", 100, nil,
+	mode, file, _, pos, _, err := resolveStartWithAutoDiscoverForFlavor("binlog.000001", "", 100, nil, gomysql.MySQLFlavor,
 		func() (string, uint32, error) {
 			called = true
 			return "should-not-be-used", 999, nil
@@ -1339,7 +1339,7 @@ func TestResolveStartWithAutoDiscover_skippedWhenFlagSet(t *testing.T) {
 func TestResolveStartWithAutoDiscover_skippedWhenGTIDFlagSet(t *testing.T) {
 	gtidSet := "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5"
 	called := false
-	mode, _, returnedGTID, _, accGTID, err := resolveStartWithAutoDiscover("", gtidSet, 4, nil,
+	mode, _, returnedGTID, _, accGTID, err := resolveStartWithAutoDiscoverForFlavor("", gtidSet, 4, nil, gomysql.MySQLFlavor,
 		func() (string, uint32, error) {
 			called = true
 			return "should-not-be-used", 999, nil
@@ -1368,7 +1368,7 @@ func TestResolveStartWithAutoDiscover_skippedWhenSavedExists(t *testing.T) {
 		mode: "position", binlogFile: "saved.000007", binlogPos: 500,
 	}
 	called := false
-	mode, file, _, pos, _, err := resolveStartWithAutoDiscover("", "", 4, saved,
+	mode, file, _, pos, _, err := resolveStartWithAutoDiscoverForFlavor("", "", 4, saved, gomysql.MySQLFlavor,
 		func() (string, uint32, error) {
 			called = true
 			return "should-not-be-used", 999, nil
@@ -1389,7 +1389,7 @@ func TestResolveStartWithAutoDiscover_skippedWhenSavedExists(t *testing.T) {
 // that when no callback is wired and no flags/saved exist, the original
 // "no start position" error still surfaces (back-compat).
 func TestResolveStartWithAutoDiscover_nilCallbackPreservesOriginalError(t *testing.T) {
-	_, _, _, _, _, err := resolveStartWithAutoDiscover("", "", 4, nil, nil, nil)
+	_, _, _, _, _, err := resolveStartWithAutoDiscoverForFlavor("", "", 4, nil, gomysql.MySQLFlavor, nil, nil)
 	if err == nil {
 		t.Fatal("expected error when nil callback and no flags/saved, got nil")
 	}
@@ -1402,7 +1402,7 @@ func TestResolveStartWithAutoDiscover_nilCallbackPreservesOriginalError(t *testi
 // auto-discover failure is surfaced (wrapped) rather than silently masked.
 func TestResolveStartWithAutoDiscover_discoveryErrorWrapped(t *testing.T) {
 	stubErr := errors.New("SHOW BINARY LOG STATUS returned no rows")
-	_, _, _, _, _, err := resolveStartWithAutoDiscover("", "", 4, nil,
+	_, _, _, _, _, err := resolveStartWithAutoDiscoverForFlavor("", "", 4, nil, gomysql.MySQLFlavor,
 		func() (string, uint32, error) {
 			return "", 0, stubErr
 		}, nil)
@@ -1422,7 +1422,7 @@ func TestResolveStartWithAutoDiscover_discoveryErrorWrapped(t *testing.T) {
 // auto-discover instead.
 func TestResolveStartWithAutoDiscover_mutuallyExclusiveFlagsErrorPropagates(t *testing.T) {
 	called := false
-	_, _, _, _, _, err := resolveStartWithAutoDiscover("binlog.000001", "uuid:1", 4, nil,
+	_, _, _, _, _, err := resolveStartWithAutoDiscoverForFlavor("binlog.000001", "uuid:1", 4, nil, gomysql.MySQLFlavor,
 		func() (string, uint32, error) {
 			called = true
 			return "", 0, nil
@@ -1456,7 +1456,7 @@ func gtidDiscoverMustNotBeCalled(t *testing.T) func() (string, error) {
 func TestResolveStartWithAutoDiscover_gtidDiscoveredSelectsGTIDMode(t *testing.T) {
 	const set = "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-77"
 	posCalled := false
-	mode, file, gtidStr, _, accGTID, err := resolveStartWithAutoDiscover("", "", 4, nil,
+	mode, file, gtidStr, _, accGTID, err := resolveStartWithAutoDiscoverForFlavor("", "", 4, nil, gomysql.MySQLFlavor,
 		func() (string, uint32, error) {
 			posCalled = true
 			return "should-not-be-used", 999, nil
@@ -1489,7 +1489,7 @@ func TestResolveStartWithAutoDiscover_gtidDiscoveredSelectsGTIDMode(t *testing.T
 // instead of "starting from now".
 func TestResolveStartWithAutoDiscover_gtidEmptyFallsBackToPosition(t *testing.T) {
 	gtidCalled := false
-	mode, file, _, pos, _, err := resolveStartWithAutoDiscover("", "", 4, nil,
+	mode, file, _, pos, _, err := resolveStartWithAutoDiscoverForFlavor("", "", 4, nil, gomysql.MySQLFlavor,
 		func() (string, uint32, error) { return "mysql-bin.000042", 1234, nil },
 		func() (string, error) {
 			gtidCalled = true
@@ -1514,7 +1514,7 @@ func TestResolveStartWithAutoDiscover_gtidEmptyFallsBackToPosition(t *testing.T)
 func TestResolveStartWithAutoDiscover_gtidErrorIsFatal(t *testing.T) {
 	stubErr := errors.New("SELECT @@GLOBAL.gtid_mode: connection reset")
 	posCalled := false
-	_, _, _, _, _, err := resolveStartWithAutoDiscover("", "", 4, nil,
+	_, _, _, _, _, err := resolveStartWithAutoDiscoverForFlavor("", "", 4, nil, gomysql.MySQLFlavor,
 		func() (string, uint32, error) {
 			posCalled = true
 			return "mysql-bin.000042", 1234, nil
@@ -1538,7 +1538,7 @@ func TestResolveStartWithAutoDiscover_gtidErrorIsFatal(t *testing.T) {
 // discovered set the flavor parser rejects fails loud instead of degrading to
 // position mode.
 func TestResolveStartWithAutoDiscover_gtidUnparseableIsFatal(t *testing.T) {
-	_, _, _, _, _, err := resolveStartWithAutoDiscover("", "", 4, nil,
+	_, _, _, _, _, err := resolveStartWithAutoDiscoverForFlavor("", "", 4, nil, gomysql.MySQLFlavor,
 		func() (string, uint32, error) { return "mysql-bin.000042", 1234, nil },
 		func() (string, error) { return "not-a-gtid-set", nil })
 	if err == nil {
@@ -1572,7 +1572,7 @@ func TestResolveStartWithAutoDiscoverForFlavor_mariadbSkipsGTIDDiscovery(t *test
 // re-discover.
 func TestResolveStartWithAutoDiscover_gtidSkippedWhenSavedExists(t *testing.T) {
 	saved := &streamState{mode: "position", binlogFile: "saved.000007", binlogPos: 500}
-	mode, file, _, pos, _, err := resolveStartWithAutoDiscover("", "", 4, saved,
+	mode, file, _, pos, _, err := resolveStartWithAutoDiscoverForFlavor("", "", 4, saved, gomysql.MySQLFlavor,
 		func() (string, uint32, error) {
 			t.Error("position auto-discover must not be called with a saved checkpoint")
 			return "", 0, nil


### PR DESCRIPTION
Part of #517 — the three quality/polish residuals review-deferred from the MariaDB alpha (#515).

## Summary

- **Regression test for the `--no-gap-fill` MariaDB-GTID refusal.** New mariadb-gated integration test (`TestOne_MariaDBGTID_noGapFillRefusesUnfillableGap`) drives the SAME cmd-layer `One()` entry point the CLI uses against a real MariaDB source. It stages a genuinely unfillable gap — rotate + `PURGE BINARY LOGS` in a short loop, because the binlog created at server startup has an empty `Gtid_list` and PURGE silently keeps files still referenced by the crash-safe binlog checkpoint — plants a GTID checkpoint behind the purge floor, and asserts `One()` refuses to start. The test pins the refusal MESSAGE shape (it names `--no-gap-fill` and carries the detector's `CANNOT be filled` / `purge floor` / `permanently lost` diagnosis plus the operator's own checkpoint) and that the refusal is *pure*: the planted checkpoint survives byte-identical and `gap_lost_at` stays NULL. It went integration (not unit) because the refusal sits inline in `One()` after live-server-only steps (connectHelper, binlog-format validation, resolver bootstrap) — no seam reaches it without a server, which is what the epic's "needs a cmd-layer `One()` + MariaDB harness" note anticipated. Runs in the `integration-mariadb-source` CI job (name matches its `-run` filter; `SkipOrFailMariaDB` keeps it fail-not-skip there, polite-skip elsewhere).
- **Deleted the dead `resolveStartWithAutoDiscover` wrapper.** Production code only calls the flavor-aware variant; the wrapper served 12 test call sites, now migrated to `resolveStartWithAutoDiscoverForFlavor(..., gomysql.MySQLFlavor, ...)`. Its contract doc is merged into the surviving function's comment.
- **Prometheus counter for the `handleRows` unhandled-row drop.** `bintrail_unhandled_rows_dropped_total`, incremented per dropped ROW at the warn-and-skip default arm shared by the file and stream parsers (previously a loud warn with `rows_skipped` and nothing to alert on). Same shape as its `bintrail_statement_dml_dropped_total` sibling: top-level, no subsystem, no `source` label (the parser has no source handle to curry), and no schema/table labels — following the documented observability.md stance against per-table label growth; the paired warn (file/pos, schema.table, raw event type) stays the per-source disambiguator. Documented in `docs/observability.md` (label-exception note, capture-loss table + prose, PromQL recipe) and `docs/streaming.md`.

## Testing

- `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, `gofmt -l` clean on touched files.
- Unit suite: `go test ./... -count=1` — 51 packages ok, including the new/extended tests:
  - `TestHandleRows_unhandledEventTypeLogsNotSilent` now asserts a before/after delta of `bintrail_unhandled_rows_dropped_total` (+1 for the one-row fixture) — mutation-checked: removing the `observe.UnhandledRowsDropped` call fails it.
  - `TestUnhandledRowsDropped` (observe) pins the rendered metric name and per-row `Add` semantics.
  - The 12 migrated `resolveStartWithAutoDiscoverForFlavor` unit tests keep passing unchanged in behavior.
- Integration, MySQL index (13306) + MariaDB 11.4 source: `TestOne_MariaDBGTID_noGapFillRefusesUnfillableGap` PASS on both a fresh container (CI's server args; refusal observed live: `purge floor 0-2-13 is beyond checkpoint 0-2-1`) and the long-lived local fixture container (`purge floor 0-2-1325`). Full `-tags integration -race -p 1` runs of `internal/parser` (incl. the docker-cp fixture tests), `internal/streamrun` and `internal/observe` with `BINTRAIL_REQUIRE_MARIADB=1`: all green except the pre-existing `TestDetectMariaDBGTIDGap_livePurge`, which fails identically from an untouched `main` checkout on that aged local container (its `PURGE BINARY LOGS` is a no-op — `Note 1375: ... not purged because it is the current active binlog` while the server is writing a much newer file), i.e. environmental, and passes on a fresh container. The staging loop in the new test (rotate + write + purge until the floor is non-empty) is what keeps it robust on both container shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
