### PR TITLE
release: migrate cosign signing to the Sigstore bundle format, exercise it on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,3 +592,93 @@ jobs:
             ${{ runner.temp }}/console-e2e-failure.png
             ${{ runner.temp }}/console-e2e-daemon.log
           if-no-files-found: ignore
+
+  # The .goreleaser.yaml signs block only ever executes on a tag push, so no
+  # PR check can catch a broken flag set until a release run fails — the worst
+  # possible moment (recovery is delete-tag, fix, re-tag; cosign v3 made the
+  # Sigstore bundle sign-blob's default output, and an installer-action major
+  # bump is what pulls a new cosign in). This job replays the EXACT cmd/args
+  # from the config against a throwaway file, with the same keyless OIDC flow
+  # and the same cosign-installer pin the release uses, then verifies the
+  # bundle it produced. A cosign bump or a signs-block edit that would break
+  # the release now fails here instead (#1350). Fork PRs carry no id-token,
+  # so they skip rather than fail; pushes and same-repo PRs (dependabot
+  # included) always run it. No `changes` gate on purpose: it must fire on
+  # workflow/config-only PRs, which the go filter would skip.
+  signing:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write # keyless signing via OIDC, same as the release job
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The action pin determines which cosign BINARY ships (v4.x of the
+      # action installs cosign v3.x) — which is why the lockstep check below
+      # insists ci.yml and release.yaml carry the same SHA.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Replay the signs block against a throwaway artifact
+        run: |
+          set -euo pipefail
+          shopt -s inherit_errexit
+
+          # What CI proves must be what the release runs: same action pin.
+          # Comment-enforced lockstep rots silently; this does not.
+          ci_pin="$(grep -oE 'cosign-installer@[0-9a-f]{40}' .github/workflows/ci.yml | sort -u)"
+          rel_pin="$(grep -oE 'cosign-installer@[0-9a-f]{40}' .github/workflows/release.yaml | sort -u)"
+          if [ "$ci_pin" != "$rel_pin" ]; then
+            echo "cosign-installer pins diverged: ci.yml has '$ci_pin', release.yaml has '$rel_pin'" >&2
+            exit 1
+          fi
+
+          artifact="$(mktemp)"
+          echo "signing probe ${GITHUB_SHA}" > "$artifact"
+
+          cmd="$(yq -r '.signs[0].cmd' .goreleaser.yaml)"
+          sig_tpl="$(yq -r '.signs[0].signature // "${artifact}.sig"' .goreleaser.yaml)"
+          cert_tpl="$(yq -r '.signs[0].certificate // ""' .goreleaser.yaml)"
+          args_raw="$(yq -r '.signs[0].args[]' .goreleaser.yaml)"
+
+          # Fail closed on template forms this replay does not implement: the
+          # renderer below knows exactly ${artifact}/${signature}/${certificate}.
+          # A {{ }} goreleaser template or an unknown ${} placeholder would
+          # otherwise reach cosign as literal bytes — a green proving the
+          # wrong invocation. Teach the renderer first, then use the form.
+          probe="$(printf '%s\n%s\n%s\n%s' "$cmd" "$sig_tpl" "$cert_tpl" "$args_raw")"
+          probe="${probe//\$\{artifact\}/}"
+          probe="${probe//\$\{signature\}/}"
+          probe="${probe//\$\{certificate\}/}"
+          case "$probe" in *'{{'*|*'${'*)
+            echo "signs block uses template forms the CI replay cannot render — teach the replay first" >&2
+            exit 1 ;;
+          esac
+
+          signature=""
+          certificate=""
+          render() {
+            local s="$1"
+            s="${s//\$\{artifact\}/$artifact}"
+            s="${s//\$\{signature\}/$signature}"
+            s="${s//\$\{certificate\}/$certificate}"
+            printf '%s' "$s"
+          }
+          signature="$(render "$sig_tpl")"
+          certificate="$(render "$cert_tpl")"
+          args=()
+          while IFS= read -r a; do args+=("$(render "$a")"); done <<< "$args_raw"
+          echo "replaying: $cmd ${args[*]}"
+          "$cmd" "${args[@]}"
+          test -s "$signature" || { echo "signs block produced no signature at $signature" >&2; exit 1; }
+
+          # This run's Fulcio identity is THIS workflow's ref (ci.yml@...), so
+          # that is what the verify pins. The user-facing recipe in
+          # docs/install.md pins release.yaml@refs/tags/ instead and is
+          # exercised by nothing here — review it by hand when it changes.
+          cosign verify-blob \
+            --bundle "$signature" \
+            --certificate-identity-regexp "^https://github\.com/${GITHUB_REPOSITORY}/\.github/workflows/ci\.yml@" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "$artifact"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -314,8 +314,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Required by the .goreleaser.yaml signs/docker_signs/sboms blocks.
+      # The signs block emits the Sigstore bundle (the cosign v3+ default;
+      # #1350), and the ci.yml `signing` job replays those exact args against
+      # this same action on every PR. The action pin determines which cosign
+      # BINARY ships, so the two pins must stay in LOCKSTEP — the signing job
+      # asserts that executably.
       - name: Install cosign
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Install syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -490,13 +490,23 @@ sboms:
   - id: packages
     artifacts: package
 
+# Keyless cosign signature over checksums.txt (which itself covers every
+# artifact). The signature is a Sigstore BUNDLE — checksums.txt.sigstore.json:
+# certificate, signature and transparency-log entry in one file, the default
+# sign-blob output since cosign v3 (#1350; the older .sig/.pem pair is gone;
+# the installer ACTION major is v4 — do not confuse the two). The ci.yml
+# `signing` job replays this exact block against a throwaway file on every
+# push and same-repo PR, so a cosign or config change that would break the
+# release fails while a failed run is cheap — signing otherwise only executes
+# on tag push. Contract with that replay: only the ${artifact}/${signature}/
+# ${certificate} placeholders, no {{ }} templates — it fails closed on
+# anything else. Verification recipe: docs/install.md "Verify a download".
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
     artifacts: checksum

--- a/docs/install.md
+++ b/docs/install.md
@@ -144,6 +144,32 @@ sudo rpm -i bintrail_VERSION_linux_amd64.rpm
 Each `.deb`/`.rpm`, like each tarball, has a syft SPDX SBOM sidecar —
 `<artifact>.sbom.json` — attached to the release.)
 
+### Verify a download
+
+`checksums.txt` is signed keylessly with cosign; the signature is attached to
+the release as a Sigstore **bundle** — `checksums.txt.sigstore.json`
+(certificate, signature and transparency-log entry in one file). Verifying it
+needs **cosign v3.0 or newer** (`cosign version`; on older cosign, `--bundle`
+names a different legacy format and verification fails on a genuinely valid
+artifact). With the bundle, `checksums.txt`, and your downloaded artifacts in
+one directory:
+
+```sh
+cosign verify-blob \
+  --bundle checksums.txt.sigstore.json \
+  --certificate-identity-regexp '^https://github\.com/dbtrail/dbtrail/\.github/workflows/release\.yaml@refs/tags/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  checksums.txt
+sha256sum --check --ignore-missing checksums.txt   # macOS: shasum -a 256 --check
+```
+
+The first command proves `checksums.txt` was produced by this repository's
+release workflow on a tag; the second proves your downloads match what the
+release shipped. (Releases up to v0.53.0 attached the older
+`checksums.txt.sig` + `checksums.txt.pem` pair instead — verify those with
+`--signature`/`--certificate` in place of `--bundle`.) Container images are
+signed separately — see [docker.md](./docker.md).
+
 The `bintrail` package carries the core CLI + `bintrail-mcp`; the web console
 is a separate `bintrail-console` package — install it only where an operator
 wants the UI. PostgreSQL-source capture is a separate `bintrail-pg`


### PR DESCRIPTION
Implements #1350:

- **`signs:` block → bundle format**: `sign-blob --bundle=${signature}` emitting `checksums.txt.sigstore.json`. `--bundle` exists under cosign v3 AND v4, so the config works before and after the installer bump — no broken window.
- **cosign-installer v3.9.1 → v4.1.2** in release.yaml, with a lockstep note.
- **PR-time signing check**: new `signing` job in ci.yml replays the EXACT cmd/args parsed from `.goreleaser.yaml` (yq, template placeholders rendered) against a throwaway file, same keyless OIDC flow + same installer pin as the release, then `cosign verify-blob --bundle`s the result. Config edits and installer bumps are both proven before any tag — **this PR's own CI run is the first execution of that proof**. Fork PRs skip (no id-token available); pushes and same-repo PRs (dependabot included) always run it. Deliberately not behind the `changes` path filter: it must fire on workflow/config-only PRs.
- **Verification recipe** added to docs/install.md (bundle form; legacy `.sig`/`.pem` noted for releases ≤ v0.53.0).

`docker_signs:` (image signing via `cosign sign`) is unaffected by the sign-blob bundle change and unchanged.

The release now attaches `checksums.txt.sigstore.json` INSTEAD of `checksums.txt.sig` + `checksums.txt.pem`.

Closes #1350

🤖 Generated with [Claude Code](https://claude.com/claude-code)
