### PR TITLE
console: answer the default Events browse from the live index when archives cannot change it

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -1096,6 +1096,17 @@ script. The recover screen renders those warnings prominently, so an
 incomplete-coverage undo is flagged to the operator rather than silently
 presented as complete.
 
+On an archive-heavy server the default Events browse (newest first, no time
+filter) is answered from the live index alone whenever the live index fills
+the whole page: rotation only archives hours **older** than the oldest live
+partition, so archived events cannot appear in a newest-first page the live
+index already filled. When that shortcut is taken the response says so with a
+notice in `warnings` ("Archived (rotated) hours were not searched for this
+page because they could not change it…") — that notice records a
+completeness-preserving optimization, nothing is missing from the page. Older
+pages, time filters that reach archived hours, and pages the live index cannot
+fill read the archives exactly as before.
+
 One residual limitation: a few failure modes are logged server-side but not
 surfaced to the browser (this matches the CLI `recover`, which warns to stderr
 and continues; both apply only to these permissive `AllowGaps=true` endpoints —

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -296,7 +296,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	// row is not a paging escape hatch for pulling the index into a browser.
 	pageLimit := opts.Limit
 	opts.Limit = pageLimit + 1
-	rows, plan, excl, diverged, err := s.fetchRestricted(r.Context(), r, b, opts)
+	rows, plan, excl, diverged, archivesElided, err := s.fetchRestricted(r.Context(), r, b, opts)
 	if err != nil {
 		writeFetchError(w, err)
 		return
@@ -312,8 +312,11 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		HasMore: hasMore,
 		// The divergence finding (#1325) rides the same warnings list: the
 		// merge's slog.Warn dies in the daemon log, and this operator is in a
-		// browser.
-		Warnings: appendDivergenceWarning(restrictedFetchWarnings(plan, excl), diverged),
+		// browser. So does the archive-elision notice (#1353): a page served
+		// fast because the archives provably could not change it must still
+		// SAY the archives went unread.
+		Warnings: appendDivergenceWarning(
+			appendArchiveElisionNotice(restrictedFetchWarnings(plan, excl), archivesElided), diverged),
 	}
 	// The cursor comes from the last row of the page the client is about to
 	// see, in the direction it is reading. Built server-side from a served row
@@ -393,7 +396,7 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 	// Coverage gaps come back in plan.GapHours and are surfaced as warnings
 	// below — the recover UI renders them, so an incomplete-coverage undo is
 	// flagged to the operator rather than silently presented as complete.
-	rows, plan, excl, diverged, err := s.fetchRestricted(r.Context(), r, b, opts)
+	rows, plan, excl, diverged, archivesElided, err := s.fetchRestricted(r.Context(), r, b, opts)
 	if err != nil {
 		writeFetchError(w, err)
 		return
@@ -401,8 +404,11 @@ func (s *Server) handleRecover(w http.ResponseWriter, r *http.Request) {
 	// The divergence finding (#1325) is sharpest here: the kept copy's row
 	// images become the SET/WHERE clauses of the generated reversal SQL, so a
 	// silent coin-flip between two disagreeing before-images must reach the
-	// operator reviewing the script.
-	warnings := appendDivergenceWarning(restrictedFetchWarnings(plan, excl), diverged)
+	// operator reviewing the script. The elision notice (#1353) matters too:
+	// this fetch runs DESC with a limit, so a filled page can skip the
+	// archives, and the reviewer of an undo script must see that stated.
+	warnings := appendDivergenceWarning(
+		appendArchiveElisionNotice(restrictedFetchWarnings(plan, excl), archivesElided), diverged)
 
 	// The fetch above ran Order=DESC so the limit kept the newest suffix of
 	// the window (#981). Detect truncation on the FETCHED row count — before

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1443,6 +1443,19 @@ async function runEventsQuery(form, keepPage) {
   const before = evPages[evPageIdx] && evPages[evPageIdx].before;
   if (before) pageParams.before = before;
 
+  // Loading state (#1353): skeleton rows from the moment the fetch starts — a
+  // blank list must never be the "busy" rendering (it reads as "no events" or
+  // "broken", on the page an operator opens mid-incident). Past ~2s the
+  // skeleton names what is happening, so a slow archive read looks like work
+  // instead of a hang. The skeleton lives inside #ev-rows, so the success path
+  // (buildEventRows) and the error path (renderError) both sweep it away with
+  // their own clear() — a failed fetch can never leave a stuck skeleton. The
+  // isConnected guard keeps a superseded search's timer from touching the
+  // newer render.
+  const skel = renderEventsLoading(rowsEl);
+  const slowT = setTimeout(() => { if (skel.isConnected) skel.classList.add("slow"); }, 2000);
+  if (countEl) countEl.textContent = "…";
+
   let data;
   try {
     data = await api("/api/events?" + new URLSearchParams(pageParams).toString());
@@ -1451,6 +1464,8 @@ async function runEventsQuery(form, keepPage) {
     clear(rowsEl); renderError(rowsEl, err);
     if (countEl) countEl.textContent = "0";
     return;
+  } finally {
+    clearTimeout(slowT);
   }
   if (gen !== serverGen) return;
   renderWarnings($("#ev-warnings", VIEW()), data.warnings);
@@ -1498,6 +1513,26 @@ async function runEventsQuery(form, keepPage) {
   if (prevBtn) prevBtn.disabled = evPageIdx === 0;
   if (nextBtn) nextBtn.disabled = !data.has_more;
   buildEventRows(rowsEl, events, scopeNote);
+}
+
+// renderEventsLoading paints the Events list's busy state (#1353): skeleton
+// rows in the shape of the real ones, plus a what's-happening note that stays
+// hidden until the caller's slow-fetch timer flips the wrapper to "slow".
+// Returns the wrapper so that timer can check it is still on screen
+// (isConnected) before speaking — a superseded search repaints its own
+// skeleton, and the stale timer must not touch it.
+function renderEventsLoading(container) {
+  clear(container);
+  const wrap = el("div", { class: "ev-loading", role: "status", "aria-label": "Loading events" });
+  for (let i = 0; i < 8; i++) {
+    const r = el("div", { class: "ev-skel-row" });
+    ["time", "table", "type", "pk", "cols"].forEach((c) => r.append(el("span", { class: "ev-skel-bar ev-skel-" + c })));
+    wrap.append(r);
+  }
+  wrap.append(el("div", { class: "ev-skel-note",
+    text: "Still working — reading history (archived hours can take a while)…" }));
+  container.append(wrap);
+  return wrap;
 }
 
 // refineEvents applies the client-side free-text / unscoped-pk refine. Shared

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -589,6 +589,32 @@ button { font-family: inherit; }
 .ev-row:hover .ev-caret { opacity: 1; }
 .ev-row.open .ev-caret { transform: translateY(-50%) rotate(90deg); color: var(--accent); opacity: 1; }
 
+/* events loading state (#1353): skeleton rows while the fetch is in flight —
+   a blank list must never be the busy rendering. The note under the rows is
+   revealed by .ev-loading.slow (fetch ran past ~2s, see runEventsQuery). */
+.ev-skel-row {
+  display: grid;
+  grid-template-columns: 200px 1fr 116px 88px 1.2fr;
+  align-items: center; gap: 12px;
+  padding: 13px 14px; border-bottom: 1px solid var(--line-soft);
+}
+.ev-skel-bar { height: 12px; border-radius: 6px; background: var(--surface-3); }
+.ev-skel-time { width: 76%; }
+.ev-skel-table { width: 58%; }
+.ev-skel-type { width: 62%; }
+.ev-skel-pk { width: 46%; }
+.ev-skel-cols { width: 70%; }
+.ev-skel-row:nth-child(2n) .ev-skel-bar { animation-delay: .18s; }
+@media (prefers-reduced-motion: no-preference) {
+  .ev-skel-bar { animation: skelpulse 1.3s ease-in-out infinite; }
+}
+@keyframes skelpulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
+.ev-skel-note {
+  display: none; padding: 18px 14px; text-align: center;
+  color: var(--ink-3); font-size: 13px;
+}
+.ev-loading.slow .ev-skel-note { display: block; }
+
 /* diff panel (expand) */
 .diff-wrap { overflow: hidden; }
 .diff {

--- a/internal/console/coverage_warnings.go
+++ b/internal/console/coverage_warnings.go
@@ -64,6 +64,34 @@ func appendDivergenceWarning(w []string, diverged int) []string {
 	return w
 }
 
+// archiveElisionNotice is the response-level record of the newest-first
+// short-circuit (#1353): registered archives were deliberately not read
+// because they provably could not change this page — every archived hour sits
+// below the live rotation floor, and the live index filled the requested page
+// with events newer than that floor. Unlike archiveExclusion's notices this
+// describes a CORRECTNESS-PRESERVING optimization, not a scope reduction, and
+// the wording must carry that distinction: the #1311/#1321 contract is that a
+// result says what scope was read, and "we skipped the archives because they
+// could not matter" is a different fact from "we skipped the archives and your
+// result may be incomplete". It still must be said — silence here would make
+// the fast path indistinguishable from a fetch that never knew archives
+// existed.
+func archiveElisionNotice() string {
+	return "Archived (rotated) hours were not searched for this page because they could not change it: " +
+		"the live index filled the page with the newest matching events, and every archived hour is older " +
+		"than what the live index still holds. Nothing is missing from this page. Paging further back, or " +
+		"filtering to a time range that reaches archived hours, does search the archives."
+}
+
+// appendArchiveElisionNotice appends archiveElisionNotice when the fetch
+// reported the newest-first short-circuit, else returns w unchanged.
+func appendArchiveElisionNotice(w []string, archivesElided bool) []string {
+	if archivesElided {
+		w = append(w, archiveElisionNotice())
+	}
+	return w
+}
+
 // restrictedFetchWarnings is gapWarnings for a fetch that may have excluded the
 // archives (#1311). It closes two holes the plan alone cannot:
 //

--- a/internal/console/events_browse_shortcircuit_integration_test.go
+++ b/internal/console/events_browse_shortcircuit_integration_test.go
@@ -1,0 +1,235 @@
+//go:build integration
+
+package console
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/ext"
+	"github.com/dbtrail/dbtrail/internal/parquetquery"
+	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/rotation"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// The archive-heavy default browse (#1353), driven through the REAL handler
+// against a fixture built by the REAL rotation: most hours archived to Parquet
+// and dropped from live, a thin live remnant on top. The unit tests prove the
+// browse plan and the elision flag; this proves the whole claim on the wire:
+//
+//   - EQUIVALENCE, not just speed: the fast path (archives skipped) returns
+//     exactly the rows the slow complete merge would have — the skip is
+//     correct by construction, and this test is what fails if the fill-check
+//     is ever weakened (a short page that wrongly skips returns different
+//     rows than the ground truth, or panics on the trim).
+//   - AUDITABILITY: the response SAYS the archives went unread when they were
+//     skipped, and does NOT say it when they were read or when they were
+//     excluded by a session profile (#1311's exclusion is a different fact
+//     and keeps its own notice).
+func TestIntegrationEventsBrowseArchiveShortCircuit(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	// Six past hourly partitions, 60 events each. Timestamps are spaced inside
+	// each hour so (event_timestamp, event_id) ordering is total.
+	now := time.Now().UTC()
+	var hours []time.Time
+	for h := 6; h >= 1; h-- {
+		hours = append(hours, now.Truncate(time.Hour).Add(-time.Duration(h)*time.Hour))
+	}
+	testutil.SetupPartitionedTable(t, db, dbName, hours)
+	const perHour = 60
+	for hi, hour := range hours {
+		var sb strings.Builder
+		sb.WriteString(`INSERT INTO binlog_events
+			(binlog_file, start_pos, end_pos, event_timestamp, schema_name, table_name, event_type, pk_values, row_after)
+			VALUES `)
+		for i := range perHour {
+			if i > 0 {
+				sb.WriteString(",")
+			}
+			ts := hour.Add(time.Duration(i) * 30 * time.Second).Format("2006-01-02 15:04:05")
+			pk := hi*perHour + i
+			fmt.Fprintf(&sb, `('bin.000001', %d, %d, '%s', 'shop', 'orders', 1, '%d', '{"id":%d}')`,
+				1000+pk, 1200+pk, ts, pk, pk)
+		}
+		testutil.MustExec(t, db, sb.String())
+	}
+	total := len(hours) * perHour
+
+	// The real rotation: archive to Parquet, register archive_state, drop the
+	// partitions past retention. Retention ages a partition by its label hour,
+	// so 2h keeps the newest one or two of the six depending on where in the
+	// hour this runs; the assertions below derive their expectations from the
+	// live remnant rather than hardcoding it.
+	if _, err := rotation.Perform(context.Background(), db, dbName, rotation.Options{
+		RetainDur:          2 * time.Hour,
+		RetainRaw:          "2h",
+		ArchiveDir:         t.TempDir(),
+		ArchiveCompression: "zstd",
+		BintrailID:         "browse-sc",
+		Format:             "json",
+	}); err != nil {
+		t.Fatalf("rotation.Perform: %v", err)
+	}
+	var liveCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM binlog_events`).Scan(&liveCount); err != nil {
+		t.Fatalf("count live: %v", err)
+	}
+	var archived int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM archive_state`).Scan(&archived); err != nil {
+		t.Fatalf("count archive_state: %v", err)
+	}
+	// Premises, asserted so a fixture drift fails loudly instead of making the
+	// assertions below vacuously pass: the live remnant must FILL a 50-event
+	// page (fast-path premise) and must NOT fill a 200-event one (slow-path
+	// premise), with real archived hours behind it.
+	if liveCount <= 50 || liveCount >= 200 || archived == 0 {
+		t.Fatalf("fixture premise broken: live=%d (want 51..199), archived partitions=%d (want >0)", liveCount, archived)
+	}
+	// Rendered in the eventDTO's timestamp format so the string comparisons
+	// below compare like with like.
+	var liveFloorT time.Time
+	if err := db.QueryRow(`SELECT MIN(event_timestamp) FROM binlog_events`).Scan(&liveFloorT); err != nil {
+		t.Fatalf("live floor: %v", err)
+	}
+	liveFloor := liveFloorT.Format("2006-01-02 15:04:05")
+
+	// Ground truth: the slow, complete, merged read — every live and archived
+	// event, fetched with no limit so no short-circuit can fire — sorted
+	// newest-first the same way MergeResults sorts.
+	truth, _, err := query.FetchMerged(context.Background(), db, query.New(db), query.FetchMergedOptions{
+		Opts:           query.Options{Order: "ASC"},
+		DBName:         dbName,
+		AllowGaps:      true,
+		ArchiveFetcher: parquetquery.Fetch,
+	})
+	if err != nil {
+		t.Fatalf("ground-truth FetchMerged: %v", err)
+	}
+	if len(truth) != total {
+		t.Fatalf("ground truth fetched %d events, want %d — the archive tier is not being read, every assertion below would be vacuous", len(truth), total)
+	}
+	slices.SortFunc(truth, func(a, b query.ResultRow) int {
+		if c := b.EventTimestamp.Compare(a.EventTimestamp); c != 0 {
+			return c
+		}
+		switch {
+		case b.EventID > a.EventID:
+			return 1
+		case b.EventID < a.EventID:
+			return -1
+		}
+		return 0
+	})
+
+	srv, err := New(Config{DB: db, DBName: dbName, Listen: "127.0.0.1:8090", Token: intToken})
+	if err != nil {
+		t.Fatal(err)
+	}
+	type eventsResp struct {
+		Events []struct {
+			EventID        uint64 `json:"event_id"`
+			EventTimestamp string `json:"event_timestamp"`
+		} `json:"events"`
+		Count    int      `json:"count"`
+		HasMore  bool     `json:"has_more"`
+		Warnings []string `json:"warnings"`
+	}
+	get := func(t *testing.T, params string, profile string) eventsResp {
+		t.Helper()
+		r := httptest.NewRequest("GET", "http://127.0.0.1:8090/api/events?"+params, nil)
+		r.Host = "127.0.0.1:8090"
+		if profile != "" {
+			r = r.WithContext(context.WithValue(r.Context(),
+				policyCtxKey{}, &ext.AccessPolicy{Profile: profile, Permissions: ext.AllPermissions()}))
+		}
+		w := httptest.NewRecorder()
+		srv.handleEvents(w, r)
+		if w.Code != 200 {
+			t.Fatalf("events code = %d, body = %s", w.Code, w.Body.String())
+		}
+		var resp eventsResp
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v\n%s", err, w.Body.String())
+		}
+		return resp
+	}
+	wantIDs := func(t *testing.T, resp eventsResp, n int) {
+		t.Helper()
+		if resp.Count != n || len(resp.Events) != n {
+			t.Fatalf("count = %d (events %d), want %d", resp.Count, len(resp.Events), n)
+		}
+		for i, e := range resp.Events {
+			if e.EventID != truth[i].EventID {
+				t.Fatalf("event[%d].event_id = %d, want %d — the fast path returned different rows than the complete merge", i, e.EventID, truth[i].EventID)
+			}
+		}
+	}
+
+	t.Run("filled page: archives skipped, result identical, skip audited", func(t *testing.T) {
+		resp := get(t, "limit=50", "")
+		wantIDs(t, resp, 50)
+		if !resp.HasMore {
+			t.Error("has_more = false with events behind the page")
+		}
+		joined := strings.Join(resp.Warnings, "\n")
+		if !strings.Contains(joined, "could not change it") {
+			t.Errorf("the archive skip is not auditable in the response warnings: %#v", resp.Warnings)
+		}
+		if strings.Contains(joined, "does not mean nothing happened") {
+			t.Errorf("the elision must not be phrased as a scope reduction: %#v", resp.Warnings)
+		}
+		for _, e := range resp.Events {
+			if e.EventTimestamp < liveFloor {
+				t.Fatalf("fast path returned an event below the live floor (%s < %s); the skip premise is broken", e.EventTimestamp, liveFloor)
+			}
+		}
+	})
+
+	t.Run("short page: archives read, no elision claimed", func(t *testing.T) {
+		resp := get(t, "limit=200", "")
+		wantIDs(t, resp, 200)
+		var belowFloor int
+		for _, e := range resp.Events {
+			if e.EventTimestamp < liveFloor {
+				belowFloor++
+			}
+		}
+		if belowFloor == 0 {
+			t.Fatal("no archived (below live floor) events in a 200-event page the live index cannot fill — the archives were not read")
+		}
+		if strings.Contains(strings.Join(resp.Warnings, "\n"), "could not change it") {
+			t.Errorf("elision claimed on a page that read the archives: %#v", resp.Warnings)
+		}
+	})
+
+	t.Run("profiled session: exclusion notice, never the elision notice", func(t *testing.T) {
+		if _, err := db.Exec(`INSERT INTO profiles (name) VALUES ('analyst')`); err != nil {
+			t.Fatalf("seed profile: %v", err)
+		}
+		resp := get(t, "limit=50", "analyst")
+		if resp.Count != 50 {
+			t.Fatalf("profiled count = %d, want 50 (live remnant fills the page)", resp.Count)
+		}
+		joined := strings.Join(resp.Warnings, "\n")
+		if !strings.Contains(joined, "LIVE INDEX ONLY") {
+			t.Errorf("profiled session lost its scope notice (#1321 regression): %#v", resp.Warnings)
+		}
+		if strings.Contains(joined, "could not change it") {
+			t.Errorf("a profiled session's exclusion must not be reframed as a harmless elision: %#v", resp.Warnings)
+		}
+		for _, e := range resp.Events {
+			if e.EventTimestamp < liveFloor {
+				t.Fatalf("profiled session was served an archived event (%s < %s)", e.EventTimestamp, liveFloor)
+			}
+		}
+	})
+}

--- a/internal/console/reconstruct.go
+++ b/internal/console/reconstruct.go
@@ -431,7 +431,9 @@ func (s *Server) handleReconstruct(w http.ResponseWriter, r *http.Request) {
 		AllowGaps:      allowGaps,
 		ArchiveFetcher: parquetquery.Fetch,
 	}
-	rows, plan, skippedSources, diverged, err := query.FetchMergedFull(ctx, b.db, b.engine, fmOpts)
+	// The elision flag is structurally always false here (this fetch is ASC
+	// with no limit, which the newest-first short-circuit never takes).
+	rows, plan, skippedSources, diverged, _, err := query.FetchMergedFull(ctx, b.db, b.engine, fmOpts)
 	if err != nil {
 		var gapErr *query.GapError
 		if errors.As(err, &gapErr) {

--- a/internal/console/session_profile.go
+++ b/internal/console/session_profile.go
@@ -225,16 +225,26 @@ func (s *Server) applySessionProfile(ctx context.Context, r *http.Request, b *bu
 // partially-failing archive source remains a log-only condition (the
 // documented trade-off on Server.fetch), and adopting it is a separate
 // decision from surfacing divergence.
-func (s *Server) fetchRestricted(ctx context.Context, r *http.Request, b *bundle, opts query.Options) ([]query.ResultRow, *query.QueryPlan, archiveExclusion, int, error) {
+//
+// archivesElided reports the newest-first short-circuit (#1353): registered
+// archives were deliberately not read because the live index filled the page
+// and every archived hour sits below the live rotation floor — they could not
+// have changed the answer. The handlers surface it as a response notice
+// (appendArchiveElisionNotice) so the skip is auditable, per the #1311/#1321
+// contract that a result always says what scope was read. Structurally always
+// false for a profiled session or a --no-archive console: there the archives
+// are EXCLUDED (excl says so and its notice speaks), not elided — nothing was
+// resolved that could have been skipped.
+func (s *Server) fetchRestricted(ctx context.Context, r *http.Request, b *bundle, opts query.Options) ([]query.ResultRow, *query.QueryPlan, archiveExclusion, int, bool, error) {
 	excl := archiveExclusionFor(r, b)
-	rows, plan, _, diverged, err := query.FetchMergedFull(ctx, b.db, b.engine, query.FetchMergedOptions{
+	rows, plan, _, diverged, archivesElided, err := query.FetchMergedFull(ctx, b.db, b.engine, query.FetchMergedOptions{
 		Opts:           opts,
 		DBName:         b.dbName,
 		NoArchive:      excl.any(),
 		AllowGaps:      true,
 		ArchiveFetcher: parquetquery.Fetch,
 	})
-	return rows, plan, excl, diverged, err
+	return rows, plan, excl, diverged, archivesElided, err
 }
 
 // archiveExclusion records WHY a fetch left the Parquet archives out (#1311),

--- a/internal/mcptools/reconstruct.go
+++ b/internal/mcptools/reconstruct.go
@@ -371,7 +371,9 @@ func MakeReconstructTool(cfg Config) func(context.Context, *mcp.CallToolRequest,
 		// failure under allow_gaps must land in Warnings (#1281) — the same
 		// no-silent-incompleteness contract CaptureGapStatus enforces for
 		// source-side loss.
-		rows, plan, skippedSources, diverged, err := query.FetchMergedFull(ctx, t.DB, query.New(t.DB), fmOpts)
+		// The elision flag is structurally always false here (this fetch is
+		// ASC with no limit, which the newest-first short-circuit never takes).
+		rows, plan, skippedSources, diverged, _, err := query.FetchMergedFull(ctx, t.DB, query.New(t.DB), fmOpts)
 		if err != nil {
 			return ErrorResult(reconstructFetchError(err)), nil, nil
 		}

--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -176,7 +176,7 @@ func FetchMerged(
 	engine *Engine,
 	o FetchMergedOptions,
 ) ([]ResultRow, *QueryPlan, error) {
-	rows, plan, _, _, err := FetchMergedFull(ctx, db, engine, o)
+	rows, plan, _, _, _, err := FetchMergedFull(ctx, db, engine, o)
 	return rows, plan, err
 }
 
@@ -196,27 +196,38 @@ const DiscoveryFailedSource = "(archive source discovery failed)"
 // tool, #1281) need both to put the incompleteness in the response;
 // callers that log are fine with FetchMerged, whose slog.Warn already names
 // the skipped sources and the diverging events.
+//
+// archivesElided reports that resolved archive sources were deliberately NOT
+// read because they provably could not change the result — the newest-first
+// short-circuit (topNSatisfiedLive: the live index filled a DESC page whose
+// span is live-covered from the cutoff upward). It is a completeness-
+// preserving optimization, never a scope reduction, but a caller rendering
+// the result to a human must still be able to SAY the archives went unread
+// (#1353's audit requirement) — which is why it is a return value and not a
+// log line. Always false when no archive sources were resolved (nothing was
+// elided if nothing was there to read) and on every path that read or tried
+// to read them.
 func FetchMergedFull(
 	ctx context.Context,
 	db *sql.DB,
 	engine *Engine,
 	o FetchMergedOptions,
-) ([]ResultRow, *QueryPlan, []string, int, error) {
+) (rows []ResultRow, plan *QueryPlan, skipped []string, diverged int, archivesElided bool, err error) {
 	if err := o.validate(); err != nil {
-		return nil, nil, nil, 0, err
+		return nil, nil, nil, 0, false, err
 	}
 	src, err := resolveMergeSources(ctx, db, o)
 	if err != nil {
-		return nil, src.plan, nil, 0, err
+		return nil, src.plan, nil, 0, false, err
 	}
-	rows, skipped, _, diverged, err := fetchPage(ctx, engine, o, src)
+	rows, skipped, _, diverged, elided, err := fetchPage(ctx, engine, o, src)
 	if err != nil {
-		return nil, src.plan, nil, 0, err
+		return nil, src.plan, nil, 0, false, err
 	}
 	if src.discoveryFailed {
 		skipped = append(skipped, DiscoveryFailedSource)
 	}
-	return rows, src.plan, skipped, diverged, nil
+	return rows, src.plan, skipped, diverged, elided, nil
 }
 
 // topNSatisfiedLive reports whether the live partitions alone already hold the
@@ -348,7 +359,7 @@ func FetchMergedStream(
 		// folds), and MergeResultsReport's slog.Warn already reports each
 		// divergence there. The response-level plumbing (#1325) covers the
 		// log-blind surfaces via FetchMergedFull.
-		rows, skipped, exhausted, _, err := fetchPage(ctx, engine, pageOpts, src)
+		rows, skipped, exhausted, _, _, err := fetchPage(ctx, engine, pageOpts, src)
 		if err != nil {
 			return src.plan, err
 		}
@@ -544,6 +555,25 @@ func resolveMergeSources(ctx context.Context, db *sql.DB, o FetchMergedOptions) 
 		}
 	}
 
+	// The default browse — no since, no until — is the one shape Plan cannot
+	// serve (no window to classify), which used to leave topNSatisfiedLive
+	// without a proof: a newest-first page the live index filled still opened
+	// every archive source only to sort every archived row in below the cutoff
+	// (#1353 — on S3-backed archives, a per-request multi-file download).
+	// PlanBrowse supplies the missing proof from partition metadata and scoped
+	// archive_state coverage alone: archives strictly below the live floor, or
+	// no plan. Optimization-only, so a failure to build it never fails the
+	// fetch — the merged read is the correct fallback, just slower.
+	if src.plan == nil && len(src.archSources) > 0 && o.DBName != "" &&
+		o.Opts.Since == nil && o.Opts.Until == nil {
+		p, err := PlanBrowse(ctx, db, o.DBName, ScopeFromPaths(src.archSources))
+		if err != nil {
+			slog.Debug("browse planner failed; archives will be consulted", "error", err)
+		} else {
+			src.plan = p
+		}
+	}
+
 	// Gap enforcement runs before any fetch so we fail fast in strict mode.
 	if src.plan != nil && len(src.plan.GapHours) > 0 {
 		if !o.AllowGaps {
@@ -565,22 +595,24 @@ func resolveMergeSources(ctx context.Context, db *sql.DB, o FetchMergedOptions) 
 // page must not be read as end-of-stream), while an exhausted one can be
 // retired from the walk entirely. diverged counts the duplicate event_ids
 // whose two merged copies disagreed (#1325); zero on every path that reads a
-// single source, since no duplicate can exist there.
+// single source, since no duplicate can exist there. archivesElided reports
+// the topNSatisfiedLive short-circuit fired — resolved archives went unread
+// because they provably could not change this page (see FetchMergedFull).
 func fetchPage(
 	ctx context.Context,
 	engine *Engine,
 	o FetchMergedOptions,
 	src mergeSources,
-) (rows []ResultRow, skipped, exhausted []string, diverged int, err error) {
+) (rows []ResultRow, skipped, exhausted []string, diverged int, archivesElided bool, err error) {
 	// Fast path: no archives → single fetch from MySQL, no merge. engine.Fetch
 	// already applied ORDER BY and LIMIT in SQL, so MergeAndTrim would be a
 	// no-op over a single source.
 	if len(src.archSources) == 0 {
 		r, ferr := engine.Fetch(ctx, o.Opts)
 		if ferr != nil {
-			return nil, nil, nil, 0, ferr
+			return nil, nil, nil, 0, false, ferr
 		}
-		return r, nil, nil, 0, nil
+		return r, nil, nil, 0, false, nil
 	}
 
 	// Archives present: fetch from MySQL unless the planner says we can skip
@@ -590,7 +622,7 @@ func fetchPage(
 	} else {
 		r, ferr := engine.Fetch(ctx, o.Opts)
 		if ferr != nil {
-			return nil, nil, nil, 0, ferr
+			return nil, nil, nil, 0, false, ferr
 		}
 		rows = r
 	}
@@ -598,7 +630,7 @@ func fetchPage(
 	if topNSatisfiedLive(o.Opts, rows, src.plan) {
 		slog.Debug("planner: skipping archive sources (newest-first page filled from contiguous live coverage)",
 			"limit", o.Opts.Limit, "sources", len(src.archSources))
-		return rows[:o.Opts.Limit], nil, nil, 0, nil
+		return rows[:o.Opts.Limit], nil, nil, 0, true, nil
 	}
 
 	// Archive fetches get the misfiled-archive file-scoping hint (#1037); the
@@ -625,7 +657,7 @@ func fetchPage(
 			// fetch — so skipping the source would return an incomplete
 			// result the caller has no way to detect (#377).
 			if !o.AllowGaps {
-				return nil, nil, nil, 0, fmt.Errorf("archive source %s failed under strict mode, cannot verify coverage: %w", s, aerr)
+				return nil, nil, nil, 0, false, fmt.Errorf("archive source %s failed under strict mode, cannot verify coverage: %w", s, aerr)
 			}
 			// Permissive mode: a broken archive must not block the entire
 			// query. Log and move on.
@@ -637,5 +669,5 @@ func fetchPage(
 	}
 
 	rows, diverged = MergeAndTrimReport(rows, o.Opts.Limit, o.Opts.LimitPerPK, o.Opts.Order)
-	return rows, skipped, exhausted, diverged, nil
+	return rows, skipped, exhausted, diverged, false, nil
 }

--- a/internal/query/fetchmerged_browse_test.go
+++ b/internal/query/fetchmerged_browse_test.go
@@ -1,0 +1,159 @@
+package query
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+// The default browse — newest-first, no since/until — through the REAL
+// FetchMergedFull stack (#1353): resolveMergeSources must build the browse
+// plan from partition metadata + scoped archive coverage, and a filled DESC
+// page must then skip every archive source AND say so (archivesElided). A
+// short page must fail open to the merged read and NOT claim elision.
+//
+// All timestamps are fixed (the browse plan reads no clock), so this cannot
+// flake across an hour boundary.
+func TestFetchMergedFull_defaultBrowse(t *testing.T) {
+	wideCols := []string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
+	}
+	liveHour := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	liveRows := func(n int) *sqlmock.Rows {
+		rows := sqlmock.NewRows(wideCols)
+		for i := range n {
+			rows.AddRow(uint64(100-i), "mysql-bin.000001", 100, 200, liveHour.Add(-time.Duration(i)*time.Minute),
+				nil, nil, "shop", "orders", 2, "1",
+				nil, nil, nil, 1, nil, nil,
+				nil)
+		}
+		return rows
+	}
+	// Arms the prologue every default browse runs: source discovery (one S3
+	// source, so no filesystem is touched), then the browse plan's partition
+	// and scoped-coverage reads. The archived hour sits below the live floor —
+	// the layout rotation always produces.
+	armPrologue := func(mock sqlmock.Sqlmock) {
+		mock.ExpectQuery("SELECT bintrail_id").WillReturnRows(
+			sqlmock.NewRows([]string{"bintrail_id", "sample_local", "sample_bucket", "sample_key"}).
+				AddRow("x", nil, "bkt", "archives/bintrail_id=x/date=2026-06-09/hour=00/events.parquet"))
+		mock.ExpectQuery("information_schema.PARTITIONS").WillReturnRows(
+			sqlmock.NewRows([]string{"PARTITION_NAME"}).
+				AddRow("p_2026061010").AddRow("p_2026061011").AddRow("p_2026061012"))
+		mock.ExpectQuery("SELECT partition_name, min_event_ts").WithArgs("x").WillReturnRows(
+			sqlmock.NewRows([]string{"partition_name", "min_event_ts", "max_event_ts"}).
+				AddRow("p_2026060900", nil, nil))
+	}
+
+	const limit = 3
+	archivedRow := ResultRow{EventID: 7, EventTimestamp: time.Date(2026, 6, 9, 0, 30, 0, 0, time.UTC),
+		SchemaName: "shop", TableName: "orders", EventType: 2, PKValues: "9"}
+
+	t.Run("filled page skips archives and reports the elision", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		armPrologue(mock)
+		mock.ExpectQuery("FROM binlog_events").WillReturnRows(liveRows(limit))
+
+		var archiveCalls int
+		rows, plan, skipped, _, elided, err := FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
+			Opts:      Options{Limit: limit, Order: "DESC"},
+			DBName:    "testdb",
+			AllowGaps: true,
+			ArchiveFetcher: func(context.Context, Options, string) ([]ResultRow, error) {
+				archiveCalls++
+				return []ResultRow{archivedRow}, nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("FetchMergedFull: %v", err)
+		}
+		if archiveCalls != 0 {
+			t.Errorf("archive fetcher called %d time(s); the browse plan must let a filled page skip S3", archiveCalls)
+		}
+		if !elided {
+			t.Error("archivesElided = false; the skip must be reportable in the response, not silent")
+		}
+		if plan == nil || len(plan.MySQLRanges) != 1 {
+			t.Errorf("browse plan not built: %+v", plan)
+		}
+		if len(rows) != limit || len(skipped) != 0 {
+			t.Errorf("rows=%d skipped=%v, want %d rows and no skips", len(rows), skipped, limit)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("unmet sqlmock expectations: %v", err)
+		}
+	})
+
+	t.Run("short page reads archives and does not claim elision", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		armPrologue(mock)
+		mock.ExpectQuery("FROM binlog_events").WillReturnRows(liveRows(limit - 1))
+
+		var archiveCalls int
+		rows, _, _, _, elided, err := FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
+			Opts:      Options{Limit: limit, Order: "DESC"},
+			DBName:    "testdb",
+			AllowGaps: true,
+			ArchiveFetcher: func(context.Context, Options, string) ([]ResultRow, error) {
+				archiveCalls++
+				return []ResultRow{archivedRow}, nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("FetchMergedFull: %v", err)
+		}
+		if archiveCalls != 1 {
+			t.Errorf("archive fetcher called %d time(s), want 1 — a short live page means the archives genuinely extend it", archiveCalls)
+		}
+		if elided {
+			t.Error("archivesElided = true on a page that READ the archives")
+		}
+		if len(rows) != limit {
+			t.Fatalf("rows = %d, want %d (live %d + archived 1)", len(rows), limit, limit-1)
+		}
+		if rows[limit-1].EventID != archivedRow.EventID {
+			t.Errorf("the archived row did not survive the merge: %+v", rows[limit-1])
+		}
+	})
+
+	t.Run("NoArchive never claims elision", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		// Exclusion is the caller's decision (profiled session, --no-archive):
+		// no discovery, no browse plan, one live fetch — and the fetch must
+		// not report "skipped because they could not matter" when the truth is
+		// "excluded by policy" (#1311's distinction).
+		mock.ExpectQuery("FROM binlog_events").WillReturnRows(liveRows(limit))
+		_, _, _, _, elided, err := FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
+			Opts:      Options{Limit: limit, Order: "DESC"},
+			DBName:    "testdb",
+			NoArchive: true,
+			AllowGaps: true,
+		})
+		if err != nil {
+			t.Fatalf("FetchMergedFull: %v", err)
+		}
+		if elided {
+			t.Error("archivesElided = true under NoArchive; exclusion and elision are different facts")
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("unmet sqlmock expectations: %v", err)
+		}
+	})
+}

--- a/internal/query/fetchmerged_test.go
+++ b/internal/query/fetchmerged_test.go
@@ -146,7 +146,7 @@ func TestFetchMerged_partialArchiveFailureAbortsStrictUnit(t *testing.T) {
 	// what log-blind surfaces (console, MCP) rely on to warn in-response.
 	expectQueries(mock)
 	var skipped []string
-	if _, _, skipped, _, err = FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
+	if _, _, skipped, _, _, err = FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
 		AllowGaps:      true,
 		ArchiveFetcher: stubFetcher,
 	}); err != nil {
@@ -222,7 +222,7 @@ func TestFetchMergedResolverFailure(t *testing.T) {
 		mock.ExpectQuery("FROM binlog_events").WillReturnRows(sqlmock.NewRows([]string{"event_id"}))
 		fetcherCalled := false
 		var skipped []string
-		_, _, skipped, _, err = FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
+		_, _, skipped, _, _, err = FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
 			AllowGaps: true,
 			ArchiveFetcher: func(_ context.Context, _ Options, _ string) ([]ResultRow, error) {
 				fetcherCalled = true
@@ -266,7 +266,7 @@ func TestFetchPage_forwardsMisfiledHoursToArchiveFetcher(t *testing.T) {
 	}
 	o := FetchMergedOptions{Opts: Options{}, AllowGaps: true, ArchiveFetcher: fetcher}
 
-	rows, skipped, exhausted, _, err := fetchPage(context.Background(), nil, o, src)
+	rows, skipped, exhausted, _, _, err := fetchPage(context.Background(), nil, o, src)
 	if err != nil {
 		t.Fatalf("fetchPage: %v", err)
 	}
@@ -333,7 +333,7 @@ func TestFetchMergedFull_reportsDivergedDuplicates(t *testing.T) {
 		}
 		return []ResultRow{mk("MUTATED")}, nil
 	}
-	rows, _, skipped, diverged, err := FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
+	rows, _, skipped, diverged, _, err := FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
 		AllowGaps:      true,
 		ArchiveFetcher: divergeFetcher,
 	})
@@ -352,7 +352,7 @@ func TestFetchMergedFull_reportsDivergedDuplicates(t *testing.T) {
 	agreeFetcher := func(_ context.Context, _ Options, _ string) ([]ResultRow, error) {
 		return []ResultRow{mk("alice")}, nil
 	}
-	if _, _, _, diverged, err = FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
+	if _, _, _, diverged, _, err = FetchMergedFull(context.Background(), db, New(db), FetchMergedOptions{
 		AllowGaps:      true,
 		ArchiveFetcher: agreeFetcher,
 	}); err != nil {

--- a/internal/query/planner.go
+++ b/internal/query/planner.go
@@ -148,6 +148,95 @@ func Plan(ctx context.Context, db *sql.DB, dbName string, since, until *time.Tim
 	return plan, nil
 }
 
+// PlanBrowse builds the minimal QueryPlan for an UNBOUNDED read — no since
+// and no until, the console's default Events browse (#1353). Plan deliberately
+// returns nil there (no window, no hour-by-hour classification), which left
+// topNSatisfiedLive without a proof, so a newest-first page the live index
+// filled in milliseconds still opened every Parquet archive (on S3: a
+// per-request multi-file download) only to sort every archived row in below
+// the cutoff.
+//
+// What this plan asserts, and why it is correct by construction: rotation
+// archives a partition AS it drops it, so archives only ever hold hours OLDER
+// than the oldest live partition. When that holds — verified against the
+// scoped archive_state coverage, never assumed — every archived event sorts
+// strictly below any event the live partitions can serve, and the plan carries
+// ONE MySQLRange spanning the whole live partition span. topNSatisfiedLive
+// then proves a filled DESC page cannot gain from archives. A layout that
+// breaks the invariant (an archived hour at or above the oldest live hour —
+// a restored or hand-surgered index, or an archived-but-not-yet-dropped
+// partition after a rotate crash) yields a nil plan: fail open to the
+// slow-but-complete merged read.
+//
+// The single spanning range is sound even when the live hours have interior
+// holes: every archived hour is strictly below the live floor, so an hour
+// inside a hole holds no archived data either — nothing any tier could
+// contribute there. The span is about what archives CANNOT hold, not a claim
+// that every hour in it has data.
+//
+// GapHours is deliberately empty. An unbounded browse states no coverage
+// contract to enforce — before this function existed the plan was nil and no
+// gap was ever reported for it — and enumerating "gaps" across an index's
+// whole lifetime would put a permanent cry-wolf warning on every default
+// browse.
+//
+// Returns (nil, nil) when nothing is provable (nil db, no live partitions —
+// which also keeps SkipMySQL from misfiring on an all-archived index whose
+// p_future may still hold rows). Errors are the caller's to treat as "no
+// plan": this plan only ever ENABLES an optimization, so no fetch may fail
+// because it could not be built.
+func PlanBrowse(ctx context.Context, db *sql.DB, dbName string, scope ArchiveScope) (*QueryPlan, error) {
+	if db == nil || dbName == "" {
+		return nil, nil
+	}
+	liveHours, err := loadLivePartitionHours(ctx, db, dbName)
+	if err != nil {
+		return nil, fmt.Errorf("load partition info for browse planning: %w", err)
+	}
+	cov, err := loadArchiveCoverage(ctx, db, scope)
+	if err != nil {
+		if !isMissingTableErr(err) {
+			return nil, fmt.Errorf("load archive coverage for browse planning: %w", err)
+		}
+		cov = nil
+	}
+	return browsePlanFromHours(liveHours, expandArchiveHours(cov)), nil
+}
+
+// browsePlanFromHours is the pure core of PlanBrowse: liveHours are the live
+// partition hours, archivedHours the scoped archive coverage expanded to
+// content hours (expandArchiveHours, so a misfiled archive's real span counts,
+// not just its label). Nil when the archives-strictly-below-live invariant
+// does not hold — see PlanBrowse for the argument.
+func browsePlanFromHours(liveHours, archivedHours []time.Time) *QueryPlan {
+	if len(liveHours) == 0 {
+		return nil
+	}
+	oldestLive, newestLive := liveHours[0], liveHours[0]
+	for _, h := range liveHours[1:] {
+		if h.Before(oldestLive) {
+			oldestLive = h
+		}
+		if h.After(newestLive) {
+			newestLive = h
+		}
+	}
+	plan := &QueryPlan{OldestKnownHour: oldestLive}
+	for _, h := range archivedHours {
+		if !h.Before(oldestLive) {
+			// An archived hour at or above the live floor: the "archives are
+			// strictly older" invariant does not hold on this index, so no
+			// filled live page proves anything. Fail open.
+			return nil
+		}
+		if h.Before(plan.OldestKnownHour) {
+			plan.OldestKnownHour = h
+		}
+	}
+	plan.MySQLRanges = []TimeRange{{Start: oldestLive, End: newestLive.Add(time.Hour)}}
+	return plan
+}
+
 // buildPlan is the pure-logic core of the planner. It classifies each hour in
 // [rangeStart, rangeEnd) as live, archived, or gap, then builds a QueryPlan.
 // This function is extracted from Plan() for testability.

--- a/internal/query/planner_browse_test.go
+++ b/internal/query/planner_browse_test.go
@@ -1,0 +1,94 @@
+package query
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBrowsePlanFromHours is the decision table for the unbounded-browse plan
+// (#1353). The plan exists to hand topNSatisfiedLive a proof on the default
+// browse (no since/until), so every "nil" row here is a fail-open: the merged
+// live+archive read runs, slower but complete.
+func TestBrowsePlanFromHours(t *testing.T) {
+	h := func(daysAgo int, hour int) time.Time {
+		base := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+		return base.AddDate(0, 0, -daysAgo).Add(time.Duration(hour) * time.Hour)
+	}
+	live := []time.Time{h(0, 10), h(0, 11), h(0, 12)}
+
+	tests := []struct {
+		name      string
+		live      []time.Time
+		archived  []time.Time
+		wantStart time.Time // zero → want nil plan
+		wantEnd   time.Time
+		why       string
+	}{
+		{
+			name: "archives strictly below the live floor",
+			live: live, archived: []time.Time{h(2, 0), h(0, 9)},
+			wantStart: h(0, 10), wantEnd: h(0, 13),
+			why: "the rotation-boundary invariant holds, so one live range spans the live tier",
+		},
+		{
+			name: "no archives at all",
+			live: live, archived: nil,
+			wantStart: h(0, 10), wantEnd: h(0, 13),
+			why: "nothing registered can sit above the floor",
+		},
+		{
+			name: "live hours with an interior hole",
+			live: []time.Time{h(0, 8), h(0, 12)}, archived: []time.Time{h(0, 7)},
+			wantStart: h(0, 8), wantEnd: h(0, 13),
+			why: "every archived hour is below the floor, so the hole holds no archived data either — the span is about what archives CANNOT hold",
+		},
+		{
+			name: "archived hour equals the oldest live hour",
+			live: live, archived: []time.Time{h(0, 10)},
+			why: "at-or-above the floor breaks the strictly-older invariant (rotate crash between archive and drop, restored index) — fail open",
+		},
+		{
+			name: "archived hour interleaved inside the live span",
+			live: live, archived: []time.Time{h(0, 11)},
+			why: "an archived hour above the floor can outrank live rows on a DESC page",
+		},
+		{
+			name: "archived hour above the newest live hour",
+			live: live, archived: []time.Time{h(0, 20)},
+			why: "archives newer than every live partition would be silently dropped by a skip",
+		},
+		{
+			name: "no live partitions",
+			live: nil, archived: []time.Time{h(2, 0)},
+			why: "nothing provable — and an empty MySQLRanges plan would trip SkipMySQL past p_future rows",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := browsePlanFromHours(tt.live, tt.archived)
+			if tt.wantStart.IsZero() {
+				if got != nil {
+					t.Fatalf("browsePlanFromHours = %+v, want nil — %s", got, tt.why)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("browsePlanFromHours = nil, want a plan — %s", tt.why)
+			}
+			if len(got.GapHours) != 0 {
+				t.Errorf("browse plan enumerated GapHours %v; an unbounded browse states no coverage contract", got.GapHours)
+			}
+			if len(got.MySQLRanges) != 1 {
+				t.Fatalf("MySQLRanges = %v, want exactly one spanning range — topNSatisfiedLive requires it", got.MySQLRanges)
+			}
+			r := got.MySQLRanges[0]
+			if !r.Start.Equal(tt.wantStart) || !r.End.Equal(tt.wantEnd) {
+				t.Errorf("range = [%v, %v), want [%v, %v)", r.Start, r.End, tt.wantStart, tt.wantEnd)
+			}
+			if got.SkipMySQL() {
+				t.Error("browse plan claims SkipMySQL; the live fetch must always run on a browse")
+			}
+		})
+	}
+}

--- a/internal/query/topn_skip_test.go
+++ b/internal/query/topn_skip_test.go
@@ -155,7 +155,7 @@ func TestFetchPageSkipsArchivesOnFilledTopN(t *testing.T) {
 		},
 	}
 
-	rows, _, _, _, err := fetchPage(context.Background(), New(db), o, src)
+	rows, _, _, _, _, err := fetchPage(context.Background(), New(db), o, src)
 	if err != nil {
 		t.Fatalf("fetchPage: %v", err)
 	}


### PR DESCRIPTION
Closes #1353.

## Summary

On an archive-heavy source the default Events browse (newest first, no `since`/`until`) blocked its one `/api/events` fetch on the whole archive tier. The mechanics: `Plan()` needs a bounded window, so the default browse produced **no plan**, and the #1295 newest-first short-circuit (`topNSatisfiedLive`) — which already skips archives on *windowed* filled pages — never had its proof. Every default-browse page therefore opened every Parquet archive source (on S3, a per-request multi-file download + DuckDB scan) only to sort every archived row in **below** the page's cutoff.

**The fix is a proof, not a heuristic.** `query.PlanBrowse` builds the missing plan for the unbounded shape from index metadata alone (live partition hours + the *scoped* `archive_state` coverage, per #1232/#1345):

- Rotation archives a partition **as it drops it**, so archives only ever hold hours **older than the oldest live partition**. That invariant is *verified against the coverage rows, never assumed*: if any archived hour (label or #1037 content span) sits at or above the live floor — a restored index, a rotate crash between archive and drop, hand surgery — the plan is nil and the read **fails open** to the slow complete merge. Same for no live partitions (protects `p_future` rows from a `SkipMySQL` misfire) or unreadable metadata.
- With the invariant confirmed, one `MySQLRange` spanning the live tier hands `topNSatisfiedLive` its existing proof: a DESC page the live index **filled**, whose cutoff sits inside live coverage, cannot gain anything from strictly-older archives. Skipping them is correct by construction — nothing is missing from the page. The cutoff check still catches backfilled rows with pre-floor timestamps (fail open).
- The browse plan deliberately enumerates **no GapHours**: an unbounded browse states no coverage contract (pre-change it had a nil plan and no gap warning), and lifetime-wide "gaps" would put a cry-wolf banner on every browse.

**The skip is auditable, per the #1311/#1321 warnings contract.** `FetchMergedFull` (and the console's `fetchRestricted`) now return `archivesElided`; `/api/events` and `/api/recover` append a notice — *"Archived (rotated) hours were not searched for this page because they could not change it: … Nothing is missing from this page."* — worded as the completeness-preserving optimization it is, explicitly distinct from a profile/`--no-archive` **exclusion**, which keeps its own notice and can never claim elision (under `NoArchive` no sources are resolved, so the flag is structurally false).

**Decision table** (unprofiled session, archives registered):

| Shape | Behavior |
|---|---|
| Default browse, DESC, live fills the page | archives skipped, `archivesElided` notice in `warnings` |
| Default browse, live comes up **short** | archives read + merged, no elision claimed |
| `since`/`until` set (incl. until-only, ranges reaching archived hours) | existing windowed #1295 path, unchanged — filled page skips (archives still below the cutoff), short page reads archives; the skip now also carries the notice |
| Older pages (`before` cursor past the rotation boundary) | cutoff falls below the live floor → proof fails → archives read (unchanged #1297 behavior) |
| Archived hour at/above the live floor, no live partitions, planner/coverage error | no browse plan → fail open to the complete merge |
| Profiled session / `--no-archive` | untouched (#1321): archives **excluded**, exclusion notice, never the elision notice |

**Loading state** (`assets/app.js` + `style.css`): the Events list paints skeleton rows the moment the fetch starts — a blank list is never the busy rendering — and reveals a "Still working — reading history (archived hours can take a while)…" note past ~2s. The skeleton lives inside `#ev-rows`, so both the success path (`buildEventRows`) and the existing error path (`renderError`) sweep it away with their own `clear()`: a failed fetch can never leave a stuck skeleton. `prefers-reduced-motion` disables the pulse.

## Profiling

Fixture per the issue: 360,000 events across 72 hourly partitions on the local test MySQL (13306), then real `bintrail rotate --retain 3h --archive-dir …` → 69 hourly Parquet archives + `archive_state`, 15,000-event live remnant. Measured through the real `bintrail-console serve` binary with `curl -w %{time_total}`, 12 requests, default browse (`GET /api/events?order=DESC`).

| Configuration | p50 | p95 | Notes |
|---|---|---|---|
| Live-only floor (`--no-archive`) | 6.5 ms | 8.5 ms | lower bound |
| **Before**, local-disk archives | 93 ms | 97 ms | archive tier = ~93% of the request |
| **Before**, S3 archives (MinIO on loopback) | 259 ms | 288 ms | 69 S3 object reads per request; loopback hides real RTT — on WAN S3 this term scales to the issue's tens of seconds |
| **After**, local-disk archives | **8.4 ms** | **9.3 ms** | |
| **After**, S3 archives (MinIO) | **7.7 ms** | **8.0 ms** | **0 S3 reads per default-browse request** |

The ~1.5 ms over the live-only floor is the browse plan's two metadata queries (`information_schema.PARTITIONS` + scoped `archive_state` coverage) against the index DB. Time-filtered queries into archived hours still read the archives and were verified working on the same fixture.

## Testing

- **Unit — decision table**: `TestBrowsePlanFromHours` (archives below floor / no archives / interior live hole / archived == floor / interleaved / above newest live / no live partitions) and `TestFetchMergedFull_defaultBrowse` driving the real `FetchMergedFull` stack over sqlmock (filled page → skip + `archivesElided`, zero fetcher calls; short page → archives merged, no elision; `NoArchive` → never claims elision).
- **Integration** (`TestIntegrationEventsBrowseArchiveShortCircuit`, real MySQL + real `rotation.Perform` + real Parquet): **equivalence, not just speed** — the fast path's rows are compared event-by-event against the slow complete merge (unlimited ASC `FetchMerged` through `parquetquery.Fetch`, resorted newest-first); the audit notice asserted present on the skip, absent on the short page, and never shown to a profiled session (which keeps its #1321 exclusion notice and receives no archived rows). Fixture premises are asserted so drift fails loudly. Verified **real PASS lines** with the DB up (integration tests skip silently without it):
  - `--- PASS: TestIntegrationEventsBrowseArchiveShortCircuit` (3 subtests)
  - `--- PASS: TestIntegrationMergeDivergenceReachesResponseWarnings`, `--- PASS: TestIntegrationProfiledSessionDeclaresItsScope` (adjacent contracts unregressed)
- **Mutation check**: removing the fill-check from `topNSatisfiedLive` makes the integration test fail (short page wrongly skipping trips the equivalence path loudly); reverted and re-verified green.
- **Browser (headless Chromium/Playwright)** against the running console with `/api/events` delayed 3 s: skeleton rows visible while the fetch is in flight, slow-note hidden before ~2 s and revealed after, real rows replace the skeleton, elision notice rendered in `#ev-warnings`, and an aborted fetch renders the error with no stuck skeleton.
- `go build ./...`, `go test ./... -count=1`, `go vet ./...`, `go vet -tags integration ./...`, `gofmt -l` clean on all changed files; full `-tags integration` suites green for `internal/query`, `internal/console`, `internal/mcptools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
