### PR TITLE
console: every rendered time states its timezone — UTC everywhere, declared

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -709,13 +709,63 @@ function setActiveNav(route) {
   $all(".nav-item").forEach((a) => a.classList.toggle("active", a.dataset.route === route));
 }
 
+// ── Timezone discipline (#1354) ──────────────────────────────────────────────
+// Every time this console renders is UTC — the zone the wire speaks
+// (consoleTSFormat / status.TSFmt) and the zone the Since/Until/At filters and
+// `--since`/`--until`/`AS OF` parse. So the DISPLAYED text of a data timestamp
+// is the exact wire string (copy-pasteable into those inputs unchanged), and
+// the zone is DECLARED next to it instead of suffixed onto every row: a
+// section-level chip or "(UTC)" label, plus a hover tooltip carrying the
+// viewer's local equivalent. Freshness/metadata stamps ("as of …", "created …")
+// are not paste targets, so those carry an inline " UTC" label directly.
+// Never render an unlabeled browser-local time.
+
+// utcLocalTitle builds the hover tooltip for a UTC stamp: it names the zone of
+// the displayed value and gives the viewer's local equivalent. "" for
+// non-stamps ("—", empty), so callers can set title unconditionally.
+function utcLocalTitle(stamp) {
+  const m = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})/.exec(String(stamp || ""));
+  if (!m) return "";
+  const t = new Date(m[1] + "T" + m[2] + "Z");
+  if (isNaN(t)) return "";
+  return "UTC — in your local time: " + t.toLocaleString();
+}
+
+// tsSpan renders one data timestamp: exact wire text, local-time tooltip.
+function tsSpan(cls, stamp) {
+  return el("span", { class: cls, text: stamp, title: utcLocalTitle(stamp) || null });
+}
+
+// utcLabel normalizes a wire timestamp (RFC3339 "…T…Z" or the bare
+// "YYYY-MM-DD HH:MM:SS" UTC form) into the labeled display shape
+// "YYYY-MM-DD HH:MM:SS UTC", for prose and freshness lines that are read, not
+// copy-pasted. Non-stamps pass through unlabeled — never label a value as UTC
+// unless it parses as one.
+function utcLabel(stamp) {
+  const m = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})(?:\.\d+)?(?:Z)?$/.exec(String(stamp || ""));
+  return m ? m[1] + " " + m[2] + " UTC" : String(stamp || "");
+}
+
+// tzChip is the section-level zone declaration: a small "UTC" chip for the
+// head of a card/panel whose body renders bare timestamps.
+function tzChip() {
+  return el("span", { class: "tz-chip", text: "UTC",
+    title: "All times in this section are UTC — copy-paste ready for the Since/Until/At filters. Hover a timestamp for your local time." });
+}
+
+// nowClock is the freshness clock ("as of …"). UTC and labeled, NOT
+// toLocaleTimeString: it sits beside data timestamps that are all UTC, and an
+// unlabeled browser-local clock made the same instant appear hours apart on
+// one page (#1354).
+function nowClock() { return new Date().toISOString().slice(11, 19) + " UTC"; }
+
 // ── Overview ─────────────────────────────────────────────────────────────────
 
 // covLast is the payload the visible coverage card was built from, so a FAILED
 // refresh can re-render the same numbers instead of blanking them — and label
 // them stale, which is the part that keeps that honest. One Overview is on
 // screen at a time, so one slot is enough.
-let covLast = null; // { data, at } — `at` is the local clock time of the fetch
+let covLast = null; // { data, at } — `at` is the UTC clock time of the fetch
 
 // covRefresh builds the card's refresh control: a fetch-time stamp plus the
 // button. `stamp` is {at, error} — a refresh that failed keeps the previous
@@ -769,8 +819,6 @@ async function refreshCovCard(btn) {
   card.replaceWith(covCard(next, { at: covLast.at }));
 }
 
-function nowClock() { return new Date().toLocaleTimeString(); }
-
 // covCard renders the live RPO statement (#1194). The window's upper edge is
 // the last INDEXED event on purpose — "restorable up to now" with a dead
 // stream would be false assurance; the lag chip is what says "now". Degrades
@@ -779,6 +827,7 @@ function covCard(c, stamp) {
   const card = el("section", { class: "ov-panel cov-card" });
   card.append(el("div", { class: "ov-panel-head" },
     el("h2", { class: "ov-panel-title", text: "Restore coverage" }),
+    tzChip(),
     covRefresh(stamp)));
   const cont = c.continuity || "unknown";
   const bad = cont === "gap_lost" || cont === "unavailable";
@@ -791,11 +840,11 @@ function covCard(c, stamp) {
   } else if (!c.delta_from) {
     // Unknown floor: don't assert a bounded window whose start we don't know.
     card.append(el("p", { class: "cov-line" },
-      "Restorable up to ", el("b", { text: c.delta_to }), "; the window start could not be determined."));
+      "Restorable up to ", el("b", { text: c.delta_to, title: utcLocalTitle(c.delta_to) || null }), "; the window start could not be determined."));
   } else {
     card.append(el("p", { class: "cov-line" },
-      "Any point between ", el("b", { text: c.delta_from }),
-      " and ", el("b", { text: c.delta_to }), " is restorable."));
+      "Any point between ", el("b", { text: c.delta_from, title: utcLocalTitle(c.delta_from) || null }),
+      " and ", el("b", { text: c.delta_to, title: utcLocalTitle(c.delta_to) || null }), " is restorable."));
   }
   const chips = el("div", { class: "cov-chips" });
   // Freshness (#1227) is what makes the lag number readable, so it decides the
@@ -844,7 +893,9 @@ function covCard(c, stamp) {
       card.append(el("p", { class: "cov-line warn", text: "Full-table coverage could not be evaluated — check the daemon log." }));
     }
     if (c.full_table_from) {
-      card.append(el("p", { class: "cov-line", text: "Full-table restore for tables with a baseline: any point from " + c.full_table_from + " onwards." }));
+      card.append(el("p", { class: "cov-line" },
+        "Full-table restore for tables with a baseline: any point from ",
+        el("b", { text: c.full_table_from, title: utcLocalTitle(c.full_table_from) || null }), " onwards."));
     }
     if (c.broken_tables && c.broken_tables.length) {
       card.append(el("p", { class: "cov-line bad", text: "Not fully restorable (newest baseline predates coverage): " + c.broken_tables.join(", ") + " — take a fresh baseline." }));
@@ -920,6 +971,7 @@ function ovFrame() {
   f.recentPanel = el("section", { class: "ov-panel" });
   f.recentPanel.append(el("div", { class: "ov-panel-head" },
     el("h2", { class: "ov-panel-title", text: "Recent changes" }),
+    tzChip(),
     el("a", { class: "btn btn-sm btn-ghost", href: "/events",
       onclick: (e) => { e.preventDefault(); navigate("events"); }, text: "Browse all events ›" })));
   f.recentBody = el("div", { class: "ov-evlist" });
@@ -972,7 +1024,7 @@ function fillOvEvents(f, eventsData, err) {
   const events = (eventsData && eventsData.events) || [];
   const latest = (events[0] && events[0].event_timestamp) || "—";
   const wide = el("div", { class: "ov-stat" },
-    el("div", { class: "ov-stat-v small", text: latest }),
+    el("div", { class: "ov-stat-v small", text: latest, title: utcLocalTitle(latest) || null }),
     el("div", { class: "ov-stat-k", text: "most recent change" }),
     el("div", { class: "ov-stat-scope", text: "point in time (UTC)" }));
   f.statLatest.replaceWith(f.statLatest = wide);
@@ -1000,8 +1052,10 @@ function fillOvActivity(f, activity) {
   const deletes = activity ? activity.deletes : null;
   const tableCount = activity ? activity.tables : null;
   const refreshed = (activity && activity.refreshed_at) || "";
-  // Tiles carry the compact time-of-day stamp; the footer carries the full one.
-  const asofShort = refreshed ? " · as of " + (refreshed.length > 11 ? refreshed.slice(11) : refreshed) : "";
+  // Tiles carry the compact time-of-day stamp; the footer carries the full
+  // one. Both are labeled: the freshness clock beside them (nowClock) says
+  // "UTC", and an unlabeled sibling would read as a different zone (#1354).
+  const asofShort = refreshed ? " · as of " + (refreshed.length > 11 ? refreshed.slice(11) : refreshed) + " UTC" : "";
   // The window scope printed on every window-scoped tile. "partial" is not
   // decoration: the server sets complete=false when the counts are knowably a
   // floor, and a narrower number under a wider label is the bug this page is
@@ -1022,7 +1076,7 @@ function fillOvActivity(f, activity) {
   });
 
   if (refreshed) {
-    f.tablesHead.append(el("span", { class: "cov-asof", text: "as of " + refreshed }));
+    f.tablesHead.append(el("span", { class: "cov-asof", text: "as of " + utcLabel(refreshed) }));
   }
   clear(f.tablesBody);
   const tables = (activity && activity.top_tables || []).map((t) => ({
@@ -1038,8 +1092,10 @@ function fillOvActivity(f, activity) {
   // far wider one — the same class of mismatch as the tiles' (#1300).
   clear(f.tablesFoot);
   f.tablesFoot.append(
-    el("span", { text: "window" }), " ",
-    el("b", { text: activity ? activity.since : "—" }), " → ", el("b", { text: activity ? activity.until : "—" }),
+    el("span", { text: "window (UTC)" }), " ",
+    el("b", { text: activity ? activity.since : "—", title: activity ? utcLocalTitle(activity.since) || null : null }),
+    " → ",
+    el("b", { text: activity ? activity.until : "—", title: activity ? utcLocalTitle(activity.until) || null : null }),
     el("span", { text: activity ? " · " + winScope : "" }));
 }
 
@@ -1115,7 +1171,7 @@ function colsSummary(cols, highlight) {
 function ovEventRow(e) {
   const row = el("div", { class: "ov-ev",
     onclick: () => navigate("events", { q: "pk:" + e.pk_values }) });
-  row.append(el("span", { class: "ov-ev-time", text: e.event_timestamp }));
+  row.append(tsSpan("ov-ev-time", e.event_timestamp));
   row.append(badge(e.event_type));
   const tbl = el("span", { class: "ov-ev-tbl", text: e.schema_name + "." + e.table_name + " " });
   tbl.append(el("span", { class: "ov-ev-pk", text: "#" + e.pk_values }));
@@ -1218,7 +1274,7 @@ function renderEvents(params) {
   // events list
   const list = el("div", { class: "events", id: "events-list" });
   const head = el("div", { class: "ev-head" });
-  ["time", "table", "type", "pk", "changed columns"].forEach((h) => head.append(el("span", { text: h })));
+  ["time (UTC)", "table", "type", "pk", "changed columns"].forEach((h) => head.append(el("span", { text: h })));
   list.append(head);
   list.append(el("div", { id: "ev-rows" }));
   v.append(list);
@@ -1687,7 +1743,7 @@ function buildEventRows(container, events, scopeNote) {
   events.forEach((e, i) => {
     const row = el("div", { class: "ev-row", "data-ev": i, tabindex: "0", role: "button", "aria-expanded": "false" });
     row.append(icon("caret", "ev-caret"));
-    row.append(el("span", { class: "ev-time", text: e.event_timestamp }));
+    row.append(tsSpan("ev-time", e.event_timestamp));
     row.append(el("span", { class: "ev-table", text: e.schema_name + "." + e.table_name }));
     row.append(el("span", {}, badge(e.event_type)));
     row.append(el("span", { class: "ev-pk", text: e.pk_values }));
@@ -1799,7 +1855,7 @@ function renderRecover(params) {
     banner.append(el("div", { class: "ctx-main" },
       el("span", { class: "ctx-eyebrow", text: "Reverting this row to before this point" }),
       el("span", { class: "ctx-title", text: ctx.schema + "." + ctx.table + " · pk " + ctx.pk }),
-      el("span", { class: "ctx-detail", text: "undoing changes up to " + ctx.type + " at " + ctx.time })));
+      el("span", { class: "ctx-detail", text: "undoing changes up to " + ctx.type + " at " + ctx.time + " UTC" })));
     banner.append(el("span", { class: "spacer" }));
     banner.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Clear",
       onclick: () => { pendingRecover = null; navigate("recover"); } }));
@@ -1885,7 +1941,7 @@ async function previewRecover(form) {
     container.append(el("div", { class: "meta-line" }, el("b", { text: String(data.count) }), " affected event(s) · limit " + data.limit));
     const list = el("div", { class: "events" });
     const head = el("div", { class: "ev-head" });
-    ["time", "table", "type", "pk", "changed columns"].forEach((h) => head.append(el("span", { text: h })));
+    ["time (UTC)", "table", "type", "pk", "changed columns"].forEach((h) => head.append(el("span", { text: h })));
     list.append(head);
     const rows = el("div");
     buildEventRows(rows, data.events || []);
@@ -2081,7 +2137,7 @@ function aimUndoAtInstant(form, at) {
   form.elements.until.value = "";
   previewRecover(form);
   form.scrollIntoView({ behavior: "smooth", block: "start" });
-  toast("Undo window set to everything after " + at);
+  toast("Undo window set to everything after " + at + " UTC");
 }
 
 // restoreToStateAction is the bridge that makes the two halves one errand:
@@ -2102,7 +2158,7 @@ function restoreToStateAction(form, data) {
   if (!data.found) return row;
   row.append(el("button", {
     class: "btn btn-primary", type: "button", text: "Restore to this state",
-    title: "Reverse every change after " + data.at + ", leaving the row exactly as shown",
+    title: "Reverse every change after " + data.at + " UTC, leaving the row exactly as shown",
     onclick: () => aimUndoAtInstant(form, data.at),
   }));
   row.append(el("span", { class: "state-actions-note", text:
@@ -2198,13 +2254,14 @@ async function runReconstruct(form, history) {
 function reconstructMeta(data, label) {
   return el("div", { class: "meta-line" },
     el("b", { text: data.schema + "." + data.table + " pk=" + data.pk }),
-    " · " + label + " · baseline " + data.baseline_time + " · " + data.event_count + " event(s)");
+    " · " + label + " · baseline " + data.baseline_time + " · " + data.event_count + " event(s)",
+    tzChip());
 }
 
 function renderStateAt(container, data) {
   container.append(reconstructMeta(data, "as of " + data.at));
   if (!data.found) { container.append(el("div", { class: "deleted-note", text: "No row with this primary key existed at or before the selected time." })); return; }
-  if (data.deleted) { container.append(el("div", { class: "deleted-note", text: "Row was deleted as of " + data.at + "." })); return; }
+  if (data.deleted) { container.append(el("div", { class: "deleted-note", text: "Row was deleted as of " + data.at + " UTC." })); return; }
   container.append(stateTable(data.state || {}));
 }
 
@@ -2229,7 +2286,7 @@ function renderTimeline(container, data) {
     node.append(el("span", { class: "tl-dot " + kind }));
     const head = el("div", { class: "tl-head" });
     head.append(el("span", { class: "badge " + (e.source === "baseline" ? "b-baseline" : badgeClass(e.source)), text: e.source }));
-    head.append(el("span", { class: "tl-time", text: e.time }));
+    head.append(tsSpan("tl-time", e.time));
     node.append(head);
 
     const body = el("div", { class: "tl-body" });
@@ -2258,13 +2315,13 @@ function renderTimeline(container, data) {
     const acts = el("div", { class: "tl-actions" });
     acts.append(el("button", {
       class: "btn btn-sm tl-use", type: "button", text: "Use this moment",
-      title: "Set the At field above to " + e.time,
+      title: "Set the At field above to " + e.time + " UTC",
       onclick: () => useTimelineInstant(e.time),
     }));
     if (e.source !== "baseline") {
       acts.append(el("button", {
         class: "btn btn-sm tl-restore", type: "button", text: "Restore to this state",
-        title: "Reverse every change after " + e.time + ", leaving the row as shown here",
+        title: "Reverse every change after " + e.time + " UTC, leaving the row as shown here",
         onclick: () => {
           const form = document.getElementById("recover-form");
           if (form) aimUndoAtInstant(form, e.time);
@@ -2316,8 +2373,8 @@ async function renderStatus() {
     ["partitions", (data.partitions || []).length],
   ]));
   cards.append(statusCard("Coverage", [
-    ["earliest event", cov.earliest_event],
-    ["latest event", cov.latest_event],
+    ["earliest event (UTC)", cov.earliest_event],
+    ["latest event (UTC)", cov.latest_event],
     ["total events", cov.total_events],
     ["schema changes", cov.schema_changes],
   ]));
@@ -2385,7 +2442,7 @@ function continuityBox(stream, pg) {
     lost.append(el("div", { text: stream.gap_lost.detail ||
       (pg ? "The replication slot PostgreSQL was using got invalidated. To keep capturing changes, create a new baseline and start over."
           : "A gap in the binlog can't be filled — some history is permanently missing. To keep capturing changes, create a new baseline and start over.") }));
-    lost.append(el("div", { text: "Detected: " + stream.gap_lost.at }));
+    lost.append(el("div", { text: "Detected: " + utcLabel(stream.gap_lost.at) }));
     return lost;
   }
   if (stream.continuity && stream.continuity.status === "ok") {
@@ -2433,10 +2490,10 @@ function captureHealthBox(stream) {
       : "⚠ Capture incomplete — some changes were not indexed" }));
   const reasons = Object.keys(h.skipped || {}).sort().join(", ");
   box.append(el("div", { text: h.total_skipped + " event(s) were read from the stream but not indexed" +
-    (reasons ? " (" + reasons + ")" : "") + (h.last_skip_at ? "; last " + h.last_skip_at : "") +
+    (reasons ? " (" + reasons + ")" : "") + (h.last_skip_at ? "; last " + utcLabel(h.last_skip_at) : "") +
     ". Those changes are missing from the index for good." +
-    (acked && h.acknowledged_at ? " Acknowledged " + h.acknowledged_at + "; anything skipped after that count raises this again." : "") +
-    (!acked && historic && h.snapshot_at ? " The schema snapshot in force since " + h.snapshot_at + " has recorded none." : "") }));
+    (acked && h.acknowledged_at ? " Acknowledged " + utcLabel(h.acknowledged_at) + "; anything skipped after that count raises this again." : "") +
+    (!acked && historic && h.snapshot_at ? " The schema snapshot in force since " + utcLabel(h.snapshot_at) + " has recorded none." : "") }));
   // Cause, remedy and scope come from the backend (status.ExplainCaptureSkips),
   // the same strings `bintrail status` prints — the console must not re-author
   // this advice in JavaScript, because the half that drifts is always the half
@@ -2990,7 +3047,7 @@ function baselineSummaryCard(b, cur) {
   const snaps = b.snapshots || [];
   kvRow(card, "source", b.source);
   kvRow(card, "snapshots", String(snaps.length) + (b.truncated ? "+" : ""));
-  kvRow(card, "latest", snaps.length ? snaps[0].time : "none yet");
+  kvRow(card, "latest (UTC)", snaps.length ? snaps[0].time : "none yet");
   if (snaps.length) kvRow(card, "age", formatAge(snaps[0].age_hours));
   kvRow(card, "time-travel", b.reconstruct ? "enabled" : "off (archives disabled)");
   return card;
@@ -3046,11 +3103,13 @@ function archivingPanel(servers, serversErr) {
 // baselineRefreshNote renders the last automatic refresh for the selected
 // server.
 function baselineRefreshNote(rf) {
-  const when = rf.finished_at || rf.since || "";
+  // finished_at/since are RFC3339 UTC on the wire; utcLabel renders them in
+  // the console's labeled shape ("YYYY-MM-DD HH:MM:SS UTC", #1354).
+  const when = utcLabel(rf.finished_at || rf.since || "");
   let text;
   switch (rf.state) {
     case "running":
-      text = "Automatic refresh running" + (rf.since ? " since " + rf.since : "") + "…";
+      text = "Automatic refresh running" + (rf.since ? " since " + utcLabel(rf.since) : "") + "…";
       break;
     case "succeeded":
       text = "Automatic refresh: " + (rf.tables || 0) + " table(s) refreshed" + (when ? " at " + when : "") + ".";
@@ -3073,7 +3132,8 @@ function baselinesPanel(b, servers) {
   let owner = cur ? serverLabel(cur) : "";
   if (!owner && b && !b.error && b.configured) owner = "daemon (--baseline-dir / --baseline-s3)";
   const head = el("div", { class: "ov-panel-head" },
-    el("h2", { class: "ov-panel-title", text: "Baseline snapshots" + (owner ? " — " + owner : "") }));
+    el("h2", { class: "ov-panel-title", text: "Baseline snapshots" + (owner ? " — " + owner : "") }),
+    tzChip());
   // Create-baseline action: only when the daemon opted in (capsCache.baseline_trigger),
   // a real server is selected, and it has a baseline destination configured (else the
   // endpoint 400s). The endpoint still re-validates the source DSN server-side.
@@ -3120,7 +3180,7 @@ function baselinesPanel(b, servers) {
     }
     b.snapshots.forEach((sn, idx) => {
       const row = el("div", { class: "stg-row" });
-      row.append(el("span", { class: "stg-name mono", text: sn.time }));
+      row.append(tsSpan("stg-name mono", sn.time));
       row.append(el("span", { class: "stg-dest", text:
         (sn.tables || []).length + " table(s)" + (sn.binlog_file ? " · " + sn.binlog_file + ":" + sn.binlog_pos : "") }));
       if (idx === 0 && sn.staleness && sn.staleness !== "ok") {
@@ -3354,7 +3414,7 @@ async function loadVerifyHistory(id, box) {
     if (r.state === "skipped") outcome = "skipped — " + (r.skip_reason || "");
     else if (r.state === "failed") outcome = "failed — " + (r.last_error || "unknown error");
     else outcome = s.match + " match · " + s.mismatch + " mismatch · " + s.inconclusive + " inconclusive · " + s.error + " error";
-    const when = (r.finished_at || r.since || "").replace("T", " ").replace("Z", " UTC");
+    const when = utcLabel(r.finished_at || r.since || "");
     const row = el("div", { class: "stg-row" });
     row.append(
       el("span", { class: "stg-age", text: when }),
@@ -3757,7 +3817,7 @@ function mcpTokenCard(tok, minted) {
   if (tok.managed) {
     if (!minted) {
       card.append(el("p", { class: "stg-hint", text:
-        "A managed token is active" + (tok.created_at ? " (created " + tok.created_at + ")" : "") +
+        "A managed token is active" + (tok.created_at ? " (created " + utcLabel(tok.created_at) + ")" : "") +
         ". Its value is not stored and cannot be re-displayed — rotate to get a fresh one." }));
     }
     if (tok.read_only) {

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1544,6 +1544,18 @@ button { font-family: inherit; }
 .cov-refresh { display: flex; align-items: center; gap: 8px; }
 .cov-asof { font-family: var(--f-mono); font-size: 11px; color: var(--ink-4); }
 .cov-asof.bad { color: var(--delete); }
+
+/* Section-level timezone declaration (#1354): a small "UTC" chip on the head
+   of any card/panel whose body renders bare timestamps. The rows keep the
+   exact wire text (copy-pasteable into the Since/Until/At filters, which
+   parse UTC); the chip states the zone once per section. In the flex panel
+   heads margin-right:auto keeps it grouped with the title while buttons stay
+   right; in non-flex contexts (meta lines) the auto margin is inert. */
+.tz-chip {
+  font-size: 10px; color: var(--ink-4); letter-spacing: .05em;
+  border: 1px solid var(--line); border-radius: 5px; padding: 1px 5px;
+  margin-left: 8px; margin-right: auto; cursor: default; white-space: nowrap;
+}
 .cov-refresh-btn {
   display: flex; align-items: center; justify-content: center;
   width: 26px; height: 26px; padding: 0;

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -866,6 +866,26 @@ try {
   evr.leakedKeys === 0 ? ok("events: no query_text/query_hash keys in the wire events") : bad("events: no query_text/query_hash keys in the wire events", `${evr.leakedKeys} event(s) carry them`);
   evr.connId === 777 ? ok("events: connection_id passes through (#701 D1)") : bad("events: connection_id passes through (#701 D1)", `connection_id=${JSON.stringify(evr.connId)}`);
 
+  // Scenario 12tz — timezone discipline on Events (#1354): the column header
+  // declares the zone once, and each row keeps the EXACT wire text — so it
+  // copy-pastes into Since/Until/At unchanged — with the viewer's local
+  // equivalent as a hover tooltip. Never an unlabeled browser-local render.
+  const evtz = await page.evaluate(() => {
+    const head = document.querySelector(".ev-head span");
+    const t = document.querySelector("#ev-rows .ev-time");
+    return {
+      headCol: head ? head.textContent : "",
+      text: t ? t.textContent : "",
+      title: t ? t.getAttribute("title") || "" : "",
+    };
+  });
+  evtz.headCol === "time (UTC)"
+    ? ok("events: the time column declares UTC")
+    : bad("events: the time column declares UTC", JSON.stringify(evtz));
+  (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(evtz.text) && evtz.title.startsWith("UTC — in your local time:"))
+    ? ok("events: rows keep exact UTC text with a local-time tooltip")
+    : bad("events: rows keep exact UTC text with a local-time tooltip", JSON.stringify(evtz));
+
   // Scenario 12b — the export path (#970): drive the REAL JSON/CSV buttons and
   // capture the blobs downloadBlob mints. Export is over the on-screen
   // redacted DTOs — so it must stay query_text-free WITH connection_id, and
@@ -1224,10 +1244,15 @@ try {
   // turns a missing scope into a driver timeout that aborts the rest of the run
   // instead of one legible failure.
   await page.waitForFunction(() => document.querySelectorAll(".ov-stat").length === 4, { timeout: 10000 });
+  // The coverage card fills independently (#1352); its freshness clock is part
+  // of what this scenario pins, so wait for that fill too.
+  await page.waitForFunction(() => !!document.querySelector(".cov-card .cov-asof"), { timeout: 10000 });
   const ovLive = await page.evaluate(() => ({
     scopes: Array.from(document.querySelectorAll(".ov-stat")).map((n) => (n.querySelector(".ov-stat-scope") || {}).textContent || ""),
     win: (document.querySelector(".ov-coverage") || {}).textContent || "",
     warns: Array.from(document.querySelectorAll(".warn-item")).map((n) => n.textContent),
+    asof: (document.querySelector(".cov-card .cov-asof") || {}).textContent || "",
+    tzChips: document.querySelectorAll(".tz-chip").length,
   }));
   ovLive.scopes.every((s) => s.trim() !== "")
     ? ok("overview (live): every rendered tile carries a scope line")
@@ -1239,12 +1264,23 @@ try {
     : bad("overview (live): the window tiles carry a real window from /api/activity", JSON.stringify(ovLive));
   // The aggregate is a server-side materialization (#1352): its freshness must
   // be rendered with its numbers, or a stale count reads as live.
-  (ovLive.scopes.filter((s) => / · as of \d{2}:\d{2}:\d{2}/.test(s)).length === 2)
-    ? ok("overview (live): the window tiles disclose the aggregate's refresh time")
-    : bad("overview (live): the window tiles disclose the aggregate's refresh time", JSON.stringify(ovLive));
-  (/window\s+\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/.test(ovLive.win) && !ovLive.warns.some((w) => /window counts could not be loaded/.test(w)))
-    ? ok("overview (live): the window line states the aggregate's own bounds")
-    : bad("overview (live): the window line states the aggregate's own bounds", JSON.stringify(ovLive));
+  (ovLive.scopes.filter((s) => / · as of \d{2}:\d{2}:\d{2} UTC/.test(s)).length === 2)
+    ? ok("overview (live): the window tiles disclose the aggregate's refresh time, labeled UTC")
+    : bad("overview (live): the window tiles disclose the aggregate's refresh time, labeled UTC", JSON.stringify(ovLive));
+  (/window \(UTC\)\s+\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/.test(ovLive.win) && !ovLive.warns.some((w) => /window counts could not be loaded/.test(w)))
+    ? ok("overview (live): the window line states the aggregate's own bounds and their zone")
+    : bad("overview (live): the window line states the aggregate's own bounds and their zone", JSON.stringify(ovLive));
+  // Timezone discipline (#1354): the freshness clock is the labeled UTC clock
+  // — nowClock() was toLocaleTimeString(), which put an unlabeled browser-local
+  // time directly above data timestamps that are all UTC, so the same instant
+  // read hours apart on one page. And the sections that render bare data
+  // timestamps each carry a UTC chip.
+  /as of \d{2}:\d{2}:\d{2} UTC$/.test(ovLive.asof)
+    ? ok("overview (live): the freshness clock is UTC and says so")
+    : bad("overview (live): the freshness clock is UTC and says so", JSON.stringify(ovLive.asof));
+  (ovLive.tzChips >= 2)
+    ? ok("overview (live): timestamp-bearing sections carry a UTC chip")
+    : bad("overview (live): timestamp-bearing sections carry a UTC chip", `tz chips: ${ovLive.tzChips}`);
 
   // Scenario 15 — Overview scope honesty (#686 + #1300): fixture-drive the REAL
   // buildOverview and pin that (a) every tile states its OWN scope, (b) the
@@ -1301,7 +1337,7 @@ try {
   (ov.full.tiles.length === 4 && ov.full.tiles.every((t) => t.scope.trim() !== ""))
     ? ok("overview: every tile states its own scope")
     : bad("overview: every tile states its own scope", JSON.stringify(ov.full.tiles));
-  (tileBy(ov.full.tiles, "deletes").v === "17" && tileBy(ov.full.tiles, "deletes").scope.includes("live retention") && tileBy(ov.full.tiles, "deletes").scope.includes("as of 09:00:00"))
+  (tileBy(ov.full.tiles, "deletes").v === "17" && tileBy(ov.full.tiles, "deletes").scope.includes("live retention") && tileBy(ov.full.tiles, "deletes").scope.includes("as of 09:00:00 UTC"))
     ? ok("overview: the deletes tile is the server aggregate, labelled with its window and freshness")
     : bad("overview: the deletes tile is the server aggregate, labelled with its window and freshness", JSON.stringify(tileBy(ov.full.tiles, "deletes")));
   (tileBy(ov.full.tiles, "tables touched").v === "5" && tileBy(ov.full.tiles, "tables touched").scope.includes("live retention"))


### PR DESCRIPTION
## Summary

Fixes #1354 — the console rendered times in two zones and labeled almost none of them: every data timestamp was bare UTC while the "as of" freshness clock (`nowClock()`) was unlabeled browser-local `toLocaleTimeString()`, so the same instant appeared hours apart on one page. This applies the ratified rule: **everything renders in UTC with the zone declared**, and browser-local appears only as a hover tooltip — the displayed value stays copy-pasteable into `Since`/`Until`/`At` (and `--since`/`--until`/`AS OF`), which are UTC surfaces.

### Helpers (app.js, one "timezone discipline" section)

- `nowClock()` — now the labeled UTC clock (`"19:07:25 UTC"`), was `toLocaleTimeString()`.
- `utcLocalTitle(stamp)` — tooltip text `"UTC — in your local time: …"`; `""` for non-stamps so it can be set unconditionally.
- `tsSpan(cls, stamp)` — a data timestamp: exact wire text + local-time tooltip.
- `utcLabel(stamp)` — normalizes bare (`consoleTSFormat`) or RFC3339 wire stamps to `"YYYY-MM-DD HH:MM:SS UTC"` for prose/freshness lines; non-stamps pass through unlabeled.
- `tzChip()` — the section-level `UTC` chip (new `.tz-chip` CSS) for heads of cards whose bodies render bare timestamps.

### Render sites fixed (before → after)

| Surface | Before | After |
|---|---|---|
| Freshness clock (coverage card "as of", refresh-failed chip) | unlabeled browser-local | `as of 19:07:25 UTC` (UTC) |
| Overview activity tiles `· as of HH:MM:SS` (#1352 stamps) | unlabeled | `· as of HH:MM:SS UTC` |
| Activity-by-table head `as of <full>` | unlabeled | `as of <full> UTC` via `utcLabel` |
| Overview window footer `window <since> → <until>` | unlabeled | `window (UTC)` + local tooltips on both bounds |
| Restore-coverage bounds (`Any point between X and Y`, `Restorable up to`, `Full-table … from`) | bare | `UTC` chip on the card head + local tooltips on each stamp |
| Recent-changes rows (`ov-ev-time`) | bare | `UTC` chip on the panel head + per-row local tooltip |
| "most recent change" tile | scope already said `point in time (UTC)` | + local tooltip on the value |
| Events list + recover preview column header | `time` | `time (UTC)`; rows get local tooltips (`tsSpan`), text unchanged |
| Recover context banner `undoing changes up to UPDATE at <t>` | unlabeled | `… at <t> UTC` |
| Reconstruct meta line (`as of <at> · baseline <t>`) | unlabeled | + `UTC` chip on the line (covers state view, deleted note, timeline) |
| Deleted note `Row was deleted as of <at>.` | unlabeled | `… as of <at> UTC.` |
| Timeline `tl-time` + "Use this moment"/"Restore to this state" titles | bare | local tooltip on the time; titles say `<t> UTC` |
| Status coverage card | `earliest event` / `latest event` | `earliest event (UTC)` / `latest event (UTC)` |
| Continuity box `Detected: <at>` | bare | `Detected: <at> UTC` |
| Capture-skip record (`last`, `Acknowledged`, `snapshot in force since`) | bare | all through `utcLabel` |
| Storage baselines summary `latest` | bare | `latest (UTC)` |
| Baseline snapshots panel rows | bare | `UTC` chip on the head + per-row local tooltip |
| Automatic-refresh note (`at`/`since`, RFC3339 `Z`) | raw RFC3339 | `utcLabel` → `… UTC` |
| Verify history `when` | ad-hoc `.replace("Z", " UTC")` | same output via shared `utcLabel` |
| MCP token `created <RFC3339>` | raw RFC3339 | `utcLabel` → `… UTC` |
| Toast `Undo window set to everything after <t>` | unlabeled | `… <t> UTC` |

Deliberately untouched: relative ages (`checked 5s ago`, `3 h ago` — zone-free), the SQL panel results (DuckDB values arrive as RFC3339 with an explicit `Z`/offset), the date pickers (already labeled `(UTC)` + `dt-tz` chip), and extension-view bodies (provider-authored content; the rule for core surfaces is now uniform around them). Wire formats are untouched — this is rendering only.

## Testing

- `test/console-e2e/run.sh` — full headless-Chromium suite against a live daemon: **167/167 pass**, including six new/strengthened timezone guards:
  - the freshness clock matches `as of \d{2}:\d{2}:\d{2} UTC` (a `toLocaleTimeString` regression fails this in any non-UTC environment),
  - the activity tiles' as-of stamps are asserted **with** the ` UTC` label (both live and fixture-driven arms),
  - the window line asserts `window (UTC)` before its bounds,
  - the Events column header is `time (UTC)`,
  - event rows keep exact `YYYY-MM-DD HH:MM:SS` text (copy-paste contract) with a `UTC — in your local time:` tooltip,
  - timestamp-bearing overview sections carry the `.tz-chip`.
  The existing bridge assertions (`Restore to this state` = at+1s, timeline `Use this moment` fills the At field verbatim) still pass — proof the displayed values stayed byte-identical wire text.
- `node --check` on `app.js` and `console_e2e.mjs`.
- `go build ./...`, `go vet ./...`, `go test ./... -count=1` (51 packages ok; no Go files changed — assets re-embed automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
