### PR TITLE
Console Restore: loading modal for Generate undo SQL and table suggestions from the selected schema

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1960,6 +1960,20 @@ function setSelectWhenReady(form, name, value, cb) {
 
 let recoverBusyOpen = false; // one click = one generation (re-entry guard)
 
+// recoverBusyActive is the re-entry guard READ, and it self-heals: the shared
+// #modal slot has other occupants (Manage servers, the rotation dialog) that
+// replace its children without our teardown, so a set flag with no
+// .busy-modal actually in the slot is stale — honoring it would wedge every
+// future Generate/Preview click silently. The isConnected guards in
+// openRecoverBusy tear down on the next keystroke; this covers the click
+// path that arrives first.
+function recoverBusyActive() {
+  if (!recoverBusyOpen) return false;
+  if (document.querySelector("#modal .busy-modal")) return true;
+  recoverBusyOpen = false;
+  return false;
+}
+
 // recoverBusyFacts mirrors the context banner's facts: target, pk, window.
 function recoverBusyFacts(f) {
   const facts = [];
@@ -2011,6 +2025,17 @@ function openRecoverBusy(form, opts) {
   // form's buttons disabled. Tab is trapped inside the dialog.
   const onKey = (e) => {
     if (closed) return;
+    // The ⌘K palette stacks ABOVE this dialog in its own mount and handles
+    // its own keys (its Escape handler sits on the palette input, which this
+    // capture-phase listener would otherwise beat to the event) — while it is
+    // open, bail entirely: same check globalKeydown does.
+    const cmdk = document.getElementById("cmdk-mount");
+    if (cmdk && cmdk.firstChild) return;
+    // Another dialog clobbered the shared #modal slot (openServersModal /
+    // showRotationDialog replace its children without our teardown): the trap
+    // must dissolve, not keep intercepting Tab over a detached dialog and
+    // holding the form's buttons disabled.
+    if (!scrim.isConnected) { teardown(); return; }
     if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); cancel(); return; }
     if (e.key !== "Tab") return;
     const foci = $all("button, input, select, textarea, a[href]", panel).filter((n) => !n.disabled);
@@ -2043,11 +2068,21 @@ function openRecoverBusy(form, opts) {
     close(refocus) { if (teardown() && refocus) restoreFocus(); },
     showError(err) {
       if (closed) return;
+      const msg = String((err && err.message) || err);
+      if (!scrim.isConnected) {
+        // Another dialog clobbered the shared #modal slot mid-flight:
+        // rendering into the detached panel would be exactly the silently
+        // vanished failure this modal exists to prevent. Tear down and
+        // surface the error where it can be seen.
+        teardown();
+        toast(opts.errTitle + ": " + msg);
+        return;
+      }
       panel.setAttribute("aria-busy", "false");
       panel.classList.add("busy-failed");
       body.insertBefore(el("div", { class: "busy-error", role: "alert" },
         el("p", { class: "busy-error-title", text: opts.errTitle }),
-        el("p", { class: "busy-error-msg", text: String((err && err.message) || err) })), foot);
+        el("p", { class: "busy-error-msg", text: msg })), foot);
       cancelBtn.textContent = "Dismiss";
       cancelBtn.focus();
     },
@@ -2055,7 +2090,7 @@ function openRecoverBusy(form, opts) {
 }
 
 async function previewRecover(form) {
-  if (recoverBusyOpen) return; // shares the one-in-flight guard with Generate (#1363)
+  if (recoverBusyActive()) return; // shares the one-in-flight guard with Generate (#1363)
   const gen = serverGen;
   const container = $("#recover-preview", VIEW());
   const warns = $("#recover-warnings", VIEW());
@@ -2078,6 +2113,13 @@ async function previewRecover(form) {
   try {
     const data = await api("/api/events?" + new URLSearchParams(params).toString(), { signal: ctrl.signal });
     if (gen !== serverGen) { busy.close(false); return; }
+    if (!container || !container.isConnected) {
+      // The view was rebuilt mid-flight (palette navigation): don't render
+      // into detached nodes — close and say what happened.
+      busy.close(false);
+      toast("The page changed while previewing — run Preview rows again.");
+      return;
+    }
     clear(container);
     container.append(el("div", { class: "meta-line" }, el("b", { text: String(data.count) }), " affected event(s) · limit " + data.limit));
     const list = el("div", { class: "events" });
@@ -2103,15 +2145,21 @@ async function previewRecover(form) {
     renderWarnings(warns, notes);
     busy.close(true); // success: back to the button that started the preview
   } catch (err) {
-    // Cancel/ESC already closed the modal and restored the pre-click state.
+    // Cancel/ESC = a WITHDRAWN request: the modal is already closed and the
+    // page keeps its pre-click state, previous preview included.
     if (err && err.name === "AbortError") return;
     if (gen !== serverGen) { busy.close(false); return; }
+    // A FAILED preview must not leave the previous run's rows on screen as
+    // if they answered the current filters; the error renders in the modal.
+    // #recover-warnings is deliberately NOT cleared (#1311: server notices
+    // must survive a re-preview).
+    clear(container);
     busy.showError(err);
   }
 }
 
 async function generateUndo(form) {
-  if (recoverBusyOpen) return; // one click = one generation (#1363)
+  if (recoverBusyActive()) return; // one click = one generation (#1363)
   const gen = serverGen;
   const warns = $("#recover-warnings", VIEW());
   const out = $("#recover-out", VIEW());
@@ -2129,6 +2177,13 @@ async function generateUndo(form) {
   try {
     const data = await api("/api/recover", { method: "POST", body, signal: ctrl.signal });
     if (gen !== serverGen) { busy.close(false); return; }
+    if (!out || !out.isConnected) {
+      // The view was rebuilt mid-flight (palette navigation): don't render
+      // into detached nodes — close and say what happened.
+      busy.close(false);
+      toast("The page changed while generating — run Generate undo SQL again.");
+      return;
+    }
     renderWarnings(warns, data.warnings);
     lastSQL = data.sql || "";
     clear(out);
@@ -2169,12 +2224,18 @@ async function generateUndo(form) {
     const head = $("#sql-panel .code-head", out);
     if (head) head.focus();
   } catch (err) {
-    // Cancel/ESC already closed the modal and restored the pre-click state;
-    // the page below was never touched.
+    // Cancel/ESC = a WITHDRAWN request: the modal is already closed and the
+    // page keeps its pre-click state, previous result included.
     if (err && err.name === "AbortError") return;
     if (gen !== serverGen) { busy.close(false); return; }
-    // Errors render IN the modal (with a Dismiss), never as a silently
-    // vanished overlay — and the page keeps its pre-click state.
+    // A FAILED generation is different: the previous run's script must not
+    // stay on screen with Copy/Download live — those bytes answer a filter
+    // nobody named. Clear the result and the download buffer, then render
+    // the error IN the modal (with a Dismiss), never as a silently vanished
+    // overlay.
+    clear(warns);
+    clear(out);
+    lastSQL = "";
     busy.showError(err);
   }
 }
@@ -3816,8 +3877,11 @@ async function loadTables(form) {
   const hint = combo ? combo.parentElement.querySelector(".combo-hint") : null;
   // The schema the current combo value was entered under — read BEFORE the
   // fetch so a slow listing still knows whether this is a schema SWITCH.
+  // The marker only advances on a REAL selection: letting "— select —"
+  // overwrite it would launder A → "— select —" → B into a first selection
+  // and carry A's table silently into B.
   const prevSchema = combo ? (combo.dataset.schema || "") : "";
-  if (combo) combo.dataset.schema = schema;
+  if (combo && schema) combo.dataset.schema = schema;
   if (dl) clear(dl);
   if (hint) hint.textContent = "";
   if (!schema) return;
@@ -3832,8 +3896,10 @@ async function loadTables(form) {
     }
   } catch (err) {
     if (combo) combo.removeAttribute("aria-busy");
+    // Persistent, announced (aria-live) failure note — the toast alone lasts
+    // 2.2s. Set BEFORE the serverGen bail so no path strands "loading…".
+    if (hint) hint.textContent = "couldn't load suggestions — type the table name";
     if (gen !== serverGen) return;
-    if (hint) hint.textContent = "";
     if (tsel) tsel.append(opt("", "(error loading tables)"));
     // A failed listing leaves the combo as usable free text with its value
     // intact — we cannot know whether the value belongs to the new schema,
@@ -4966,6 +5032,13 @@ function globalKeydown(e) {
     const cmdk = document.getElementById("cmdk-mount");
     if (cmdk && cmdk.firstChild) return;
     const modalMount = document.getElementById("modal");
+    // The recover busy dialog owns its Escape (a capture-phase handler that
+    // also aborts the in-flight fetch, #1363) — never generically empty the
+    // mount over it. This branch is still reachable with that dialog open:
+    // cmdkKeydown closes the palette without stopping propagation, so the
+    // SAME Escape that closed the palette lands here with the cmdk check
+    // above already passing.
+    if (modalMount && modalMount.querySelector(".busy-modal")) return;
     if (modalMount && modalMount.firstChild) { e.preventDefault(); modalMount.replaceChildren(); }
     return;
   }

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -174,6 +174,9 @@ async function api(path, opts = {}) {
     method: opts.method || "GET",
     headers,
     body: opts.body ? JSON.stringify(opts.body) : undefined,
+    // AbortController support (#1363): callers that show a cancelable busy
+    // affordance pass a signal; an abort rejects with err.name "AbortError".
+    signal: opts.signal,
   });
   const text = await res.text();
   let data = null;
@@ -1310,6 +1313,23 @@ function fieldSelect(label, name, size, isSchema, isTable, options, anyLabel, re
     fieldLabel(label, required), sel);
 }
 
+// fieldTableCombo is an input + datalist combobox for a table name (#1364):
+// suggestions come from the selected schema's listing (loadTables fills the
+// datalist on schema change), but a hand-typed name still submits — recover
+// can legitimately target a dropped table whose events are indexed, and a
+// closed <select> would make that recovery impossible from the UI. The
+// combo-hint span is the brief busy note while a listing loads.
+let tableComboSeq = 0;
+function fieldTableCombo(label, name, size, placeholder) {
+  const listId = "table-combo-list-" + (++tableComboSeq);
+  return el("div", { class: "field field--" + size },
+    fieldLabel(label),
+    el("input", { class: "input table-combo", name, placeholder: placeholder || "",
+      list: listId, autocomplete: "off", spellcheck: "false" }),
+    el("datalist", { id: listId }),
+    el("span", { class: "combo-hint", "aria-live": "polite" }));
+}
+
 // ── date/time picker (calendar + clock) for Since/Until/At filter fields ────
 // event_timestamp round-trips through consoleTSFormat under the UTC location
 // config.Connect forces on every index-DB connection (internal/config), so
@@ -1865,7 +1885,10 @@ function renderRecover(params) {
   // Manual filter form
   const form = el("form", { class: "filters", id: "recover-form" });
   form.append(fieldSelect("Schema", "schema", "md", true, false, null, "— select —"));
-  form.append(fieldInput("Table", "table", "md", "orders"));
+  // Input + datalist, not a closed select (#1364): suggestions come from the
+  // selected schema, but recover legitimately targets dropped tables whose
+  // events are still indexed — a typed name must always submit.
+  form.append(fieldTableCombo("Table", "table", "md", "orders"));
   form.append(fieldInput("PK", "pk", "sm", "42 or 42|7"));
   form.append(fieldDateInput("Since (UTC)", "since", "md", "YYYY-MM-DD HH:MM:SS"));
   form.append(fieldDateInput("Until (UTC)", "until", "md", "YYYY-MM-DD HH:MM:SS"));
@@ -1921,7 +1944,118 @@ function setSelectWhenReady(form, name, value, cb) {
   }, 50);
 }
 
+// ── busy modal for the Restore actions (#1363) ───────────────────────────────
+//
+// Generate-undo (and Preview, which sits on the same latency) used to give no
+// feedback until the fetch returned — seconds, when the window reaches
+// archived hours — so a user who suspected the click didn't register clicked
+// again and queued a second generation. The modal opens the moment the button
+// is clicked: it states what is being generated (the same facts as the blue
+// context banner), animates with pure-CSS keyframes on the brand accent
+// (never the semantic insert/update/delete colors — those are data, not
+// decoration), collapses to a static note under prefers-reduced-motion (the
+// #1353 skeleton rule), blocks re-entry while open, and Cancel/ESC abort the
+// in-flight fetch via AbortController. Errors render IN the modal with the
+// server's own actionable text — never a silently-vanished overlay.
+
+let recoverBusyOpen = false; // one click = one generation (re-entry guard)
+
+// recoverBusyFacts mirrors the context banner's facts: target, pk, window.
+function recoverBusyFacts(f) {
+  const facts = [];
+  facts.push(["target", f.schema ? f.schema + (f.table ? "." + f.table : "") : "(all schemas)"]);
+  if (f.pk) facts.push(["pk", f.pk]);
+  if (f.since) facts.push(["since", f.since + " UTC"]);
+  if (f.until) facts.push(["until", f.until + " UTC"]);
+  return facts;
+}
+
+// openRecoverBusy opens the busy dialog and disables the form's action
+// buttons until it closes. Returns {close(refocus), showError(err)}; Cancel
+// and ESC run opts.onCancel (the fetch abort) and restore focus to the
+// element that had it. Accessibility: role="dialog", aria-busy while working,
+// focus trapped inside, focus restored on cancel/dismiss.
+function openRecoverBusy(form, opts) {
+  recoverBusyOpen = true;
+  const mount = document.getElementById("modal");
+  const trigger = document.activeElement;
+  const actions = $all(".filter-actions button", form);
+  actions.forEach((b) => { b.disabled = true; });
+
+  const scrim = el("div", { class: "modal-scrim show" });
+  const panel = el("div", { class: "modal busy-modal", role: "dialog", "aria-label": opts.title, "aria-busy": "true" });
+  panel.append(el("div", { class: "modal-head" }, el("h2", { class: "modal-title", text: opts.title })));
+  const body = el("div", { class: "modal-body" });
+  body.append(el("div", { class: "busy-anim", "aria-hidden": "true" }, el("span"), el("span"), el("span")));
+  // The reduced-motion arm: CSS swaps the animation for this static note.
+  body.append(el("p", { class: "busy-static", text: "Working — this closes when the result is ready." }));
+  const facts = el("div", { class: "busy-facts" });
+  (opts.facts || []).forEach(([k, v]) => facts.append(el("div", { class: "busy-fact" },
+    el("span", { class: "bf-k", text: k }), el("span", { class: "bf-v", text: v }))));
+  body.append(facts);
+  body.append(el("p", { class: "busy-note", text:
+    "Reading indexed changes — a window that reaches archived hours can take a few seconds." }));
+  const foot = el("div", { class: "modal-foot" });
+  const cancelBtn = el("button", { class: "btn", type: "button", text: "Cancel", onclick: () => cancel() });
+  foot.append(cancelBtn);
+  body.append(foot);
+  panel.append(body);
+  scrim.append(panel);
+  clear(mount);
+  mount.append(scrim);
+  cancelBtn.focus();
+
+  let closed = false;
+  // Capture phase, so this runs BEFORE globalKeydown's generic #modal-emptying
+  // Escape handler — closing that way would leave the fetch in flight and the
+  // form's buttons disabled. Tab is trapped inside the dialog.
+  const onKey = (e) => {
+    if (closed) return;
+    if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); cancel(); return; }
+    if (e.key !== "Tab") return;
+    const foci = $all("button, input, select, textarea, a[href]", panel).filter((n) => !n.disabled);
+    if (!foci.length) { e.preventDefault(); return; }
+    const first = foci[0], last = foci[foci.length - 1];
+    if (!panel.contains(document.activeElement)) { e.preventDefault(); first.focus(); }
+    else if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+    else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+  };
+  document.addEventListener("keydown", onKey, true);
+
+  const teardown = () => {
+    if (closed) return false;
+    closed = true;
+    document.removeEventListener("keydown", onKey, true);
+    scrim.remove();
+    actions.forEach((b) => { b.disabled = false; });
+    recoverBusyOpen = false;
+    return true;
+  };
+  const restoreFocus = () => {
+    if (trigger && document.contains(trigger) && typeof trigger.focus === "function") trigger.focus();
+  };
+  const cancel = () => {
+    if (!teardown()) return;
+    if (opts.onCancel) opts.onCancel();
+    restoreFocus();
+  };
+  return {
+    close(refocus) { if (teardown() && refocus) restoreFocus(); },
+    showError(err) {
+      if (closed) return;
+      panel.setAttribute("aria-busy", "false");
+      panel.classList.add("busy-failed");
+      body.insertBefore(el("div", { class: "busy-error", role: "alert" },
+        el("p", { class: "busy-error-title", text: opts.errTitle }),
+        el("p", { class: "busy-error-msg", text: String((err && err.message) || err) })), foot);
+      cancelBtn.textContent = "Dismiss";
+      cancelBtn.focus();
+    },
+  };
+}
+
 async function previewRecover(form) {
+  if (recoverBusyOpen) return; // shares the one-in-flight guard with Generate (#1363)
   const gen = serverGen;
   const container = $("#recover-preview", VIEW());
   const warns = $("#recover-warnings", VIEW());
@@ -1934,9 +2068,16 @@ async function previewRecover(form) {
   // there is no Go-to-JS constant-sharing mechanism in this codebase.
   params.limit = "1000";
   params.order = "desc";
+  const ctrl = new AbortController();
+  const busy = openRecoverBusy(form, {
+    title: "Previewing affected rows",
+    errTitle: "Couldn't preview the rows",
+    facts: recoverBusyFacts(params),
+    onCancel: () => ctrl.abort(),
+  });
   try {
-    const data = await api("/api/events?" + new URLSearchParams(params).toString());
-    if (gen !== serverGen) return;
+    const data = await api("/api/events?" + new URLSearchParams(params).toString(), { signal: ctrl.signal });
+    if (gen !== serverGen) { busy.close(false); return; }
     clear(container);
     container.append(el("div", { class: "meta-line" }, el("b", { text: String(data.count) }), " affected event(s) · limit " + data.limit));
     const list = el("div", { class: "events" });
@@ -1960,13 +2101,17 @@ async function previewRecover(form) {
       notes.push("Only the newest " + data.limit + " events are shown. The actual undo script may include more if you increase the limit.");
     }
     renderWarnings(warns, notes);
+    busy.close(true); // success: back to the button that started the preview
   } catch (err) {
-    if (gen !== serverGen) return;
-    renderError(container, err);
+    // Cancel/ESC already closed the modal and restored the pre-click state.
+    if (err && err.name === "AbortError") return;
+    if (gen !== serverGen) { busy.close(false); return; }
+    busy.showError(err);
   }
 }
 
 async function generateUndo(form) {
+  if (recoverBusyOpen) return; // one click = one generation (#1363)
   const gen = serverGen;
   const warns = $("#recover-warnings", VIEW());
   const out = $("#recover-out", VIEW());
@@ -1974,9 +2119,16 @@ async function generateUndo(form) {
   const body = {};
   ["schema", "table", "pk", "since", "until"].forEach((k) => { if (f[k] && f[k].trim()) body[k] = f[k].trim(); });
   if (!body.schema) { renderError(out, "Choose at least a schema to search."); return; }
+  const ctrl = new AbortController();
+  const busy = openRecoverBusy(form, {
+    title: "Generating undo SQL",
+    errTitle: "Couldn't generate the undo SQL",
+    facts: recoverBusyFacts(body),
+    onCancel: () => ctrl.abort(),
+  });
   try {
-    const data = await api("/api/recover", { method: "POST", body });
-    if (gen !== serverGen) return;
+    const data = await api("/api/recover", { method: "POST", body, signal: ctrl.signal });
+    if (gen !== serverGen) { busy.close(false); return; }
     renderWarnings(warns, data.warnings);
     lastSQL = data.sql || "";
     clear(out);
@@ -2011,15 +2163,27 @@ async function generateUndo(form) {
         (data.set_null_count || 0) + " SET NULL restore(s) · " + (data.key_restore_count || 0) + " FK restore(s)"
       : data.statement_count + " statement(s) from " + data.row_count + " event(s)";
     out.append(codePanel(lastSQL, meta));
+    // Success: close the busy dialog and land keyboard focus on the result —
+    // the reversal.sql panel header (#1363).
+    busy.close(false);
+    const head = $("#sql-panel .code-head", out);
+    if (head) head.focus();
   } catch (err) {
-    if (gen !== serverGen) return;
-    clear(warns); renderError(out, err);
+    // Cancel/ESC already closed the modal and restored the pre-click state;
+    // the page below was never touched.
+    if (err && err.name === "AbortError") return;
+    if (gen !== serverGen) { busy.close(false); return; }
+    // Errors render IN the modal (with a Dismiss), never as a silently
+    // vanished overlay — and the page keeps its pre-click state.
+    busy.showError(err);
   }
 }
 
 function codePanel(sql, metaLabel) {
   const panel = el("div", { class: "codepanel", id: "sql-panel" });
-  const head = el("div", { class: "code-head" });
+  // tabindex -1: programmatic focus target — the busy modal moves keyboard
+  // focus here when a generation succeeds (#1363).
+  const head = el("div", { class: "code-head", tabindex: "-1" });
   head.append(icon("file"));
   const lbl = el("span", { class: "lbl" }, el("b", { text: "reversal.sql" }), " · " + (metaLabel || "read-only preview"));
   head.append(lbl);
@@ -3638,26 +3802,61 @@ async function loadTables(form) {
   const gen = serverGen;
   const sel = form.querySelector(".schema-select");
   const tsel = form.querySelector(".table-select");
-  if (!tsel) return;
+  // A form carries either a closed table <select> (query-style filters, where
+  // "any" is meaningful) or a table-combo input+datalist (#1364, Restore —
+  // where a hand-typed dropped table must still submit).
+  const combo = form.querySelector(".table-combo");
+  if (!tsel && !combo) return;
   const schema = sel ? sel.value : "";
-  clear(tsel);
-  tsel.append(opt("", "— any —"));
+  if (tsel) {
+    clear(tsel);
+    tsel.append(opt("", "— any —"));
+  }
+  const dl = combo ? document.getElementById(combo.getAttribute("list")) : null;
+  const hint = combo ? combo.parentElement.querySelector(".combo-hint") : null;
+  // The schema the current combo value was entered under — read BEFORE the
+  // fetch so a slow listing still knows whether this is a schema SWITCH.
+  const prevSchema = combo ? (combo.dataset.schema || "") : "";
+  if (combo) combo.dataset.schema = schema;
+  if (dl) clear(dl);
+  if (hint) hint.textContent = "";
   if (!schema) return;
   let tables = tablesCache.get(schema);
   try {
     if (!tables) {
+      if (hint) hint.textContent = "loading tables…";
+      if (combo) combo.setAttribute("aria-busy", "true");
       const data = await api("/api/schemas?schema=" + encodeURIComponent(schema));
       tables = data.tables || [];
       if (gen === serverGen) tablesCache.set(schema, tables); // don't cache under a server we've since switched away from
     }
   } catch (err) {
+    if (combo) combo.removeAttribute("aria-busy");
     if (gen !== serverGen) return;
-    tsel.append(opt("", "(error loading tables)"));
+    if (hint) hint.textContent = "";
+    if (tsel) tsel.append(opt("", "(error loading tables)"));
+    // A failed listing leaves the combo as usable free text with its value
+    // intact — we cannot know whether the value belongs to the new schema,
+    // and a dead or emptied field would be worse than a stale suggestion.
     toast("failed to load tables: " + ((err && err.message) || err));
     return;
   }
+  if (combo) combo.removeAttribute("aria-busy");
   if (gen !== serverGen) return;
-  tables.forEach((t) => tsel.append(opt(t, t)));
+  if (hint) hint.textContent = "";
+  // A newer selection may have superseded this fetch (rapid schema switching):
+  // the last resolver must not repopulate under the wrong schema.
+  if ((sel ? sel.value : "") !== schema) return;
+  if (tsel) tables.forEach((t) => tsel.append(opt(t, t)));
+  if (dl) tables.forEach((t) => dl.append(opt(t, t)));
+  // Switching schema clears a stale table value that doesn't belong to the new
+  // schema (#1364) — but only on a SWITCH (previous schema non-empty and
+  // different): a name typed before the FIRST schema selection is the
+  // dropped-table flow and must survive. A value present in the new schema's
+  // own listing belongs there and is kept.
+  if (combo && prevSchema && prevSchema !== schema && combo.value && !tables.includes(combo.value)) {
+    combo.value = "";
+  }
 }
 
 function wireSchemaCascade(root) {

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -993,6 +993,59 @@ button { font-family: inherit; }
 .modal-foot { display: flex; gap: 10px; margin-top: 22px; align-items: center; }
 
 /* ============================================================
+   busy modal — Restore actions (#1363)
+   ============================================================ */
+/* Pure-CSS loading animation on the brand accent (--accent-a/--accent-b) —
+   the semantic insert/update/delete colors are data, never decoration.
+   Reduced-motion rule mirrors the #1353 event skeletons: the animation only
+   exists under no-preference; otherwise the static .busy-static note shows. */
+.busy-modal { max-width: 480px; text-align: center; }
+.busy-modal .modal-title { margin-bottom: 0; }
+.busy-anim { display: none; gap: 11px; justify-content: center; padding: 22px 0 4px; }
+.busy-anim span {
+  width: 12px; height: 12px; border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent-a), var(--accent-b));
+}
+.busy-static { display: block; color: var(--ink-2); font-size: 13.5px; margin: 16px 0 4px; }
+@media (prefers-reduced-motion: no-preference) {
+  .busy-anim { display: flex; }
+  .busy-anim span { animation: busypulse 1.05s ease-in-out infinite; }
+  .busy-anim span:nth-child(2) { animation-delay: .15s; }
+  .busy-anim span:nth-child(3) { animation-delay: .3s; }
+  .busy-static { display: none; }
+}
+@keyframes busypulse { 0%, 100% { transform: scale(.62); opacity: .4; } 50% { transform: none; opacity: 1; } }
+.busy-facts { margin: 14px auto 0; max-width: 340px; display: flex; flex-direction: column; gap: 6px; }
+.busy-fact { display: flex; gap: 14px; justify-content: space-between; align-items: baseline; }
+.busy-fact .bf-k {
+  color: var(--ink-3); font-family: var(--f-mono); font-size: 11px;
+  font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase;
+}
+.busy-fact .bf-v {
+  color: var(--ink); font-family: var(--f-mono); font-size: 12.5px;
+  word-break: break-all; text-align: right;
+}
+.busy-note { color: var(--ink-3); font-size: 12.5px; margin: 16px auto 0; max-width: 40ch; }
+/* Error state: the modal never silently vanishes — it re-renders as the
+   error surface, with the working chrome hidden and Cancel become Dismiss. */
+.busy-modal.busy-failed .busy-anim,
+.busy-modal.busy-failed .busy-static,
+.busy-modal.busy-failed .busy-note { display: none; }
+.busy-error {
+  margin: 16px 0 0; padding: 12px 14px; text-align: left;
+  background: var(--surface-2); border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+}
+.busy-error-title { margin: 0 0 6px; font-weight: 600; font-size: 13.5px; color: var(--ink); }
+.busy-error-msg { margin: 0; font-size: 13px; color: var(--ink-2); overflow-wrap: anywhere; }
+.busy-modal .modal-foot { justify-content: center; }
+/* Focus landing for the generated reversal.sql panel header (#1363). */
+.code-head:focus { outline: 2px solid var(--accent); outline-offset: -2px; }
+
+/* table combobox busy hint (#1364) */
+.combo-hint { display: block; margin-top: 4px; font-size: 11.5px; color: var(--ink-3); min-height: 15px; }
+
+/* ============================================================
    tweaks panel (vanilla)
    ============================================================ */
 #tweaks {

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1404,6 +1404,276 @@ try {
     ? ok("storage: baseline_trigger off → no button even with a destination")
     : bad("storage: baseline_trigger off → no button even with a destination", JSON.stringify(gates));
 
+  // Scenario 16 — Restore Table combobox (#1364). The Table field must be an
+  // input + datalist fed from /api/schemas?schema=… (the same endpoint the
+  // events table picker consumes): suggestions from the fixture's tables,
+  // swapped on a schema switch, a stale value cleared on switch — and still
+  // free text, because recover legitimately targets dropped tables whose
+  // events are indexed (that half is pinned in scenario 17's typed-submit leg).
+  await page.evaluate(() => navigate("recover"));
+  await page.waitForSelector("#recover-form", { timeout: 8000 });
+  await page.waitForFunction((FIX) => {
+    const f = document.getElementById("recover-form");
+    return f && Array.from(f.elements.schema.options).some((o) => o.value === FIX);
+  }, FIX, { timeout: 8000 });
+  const combo = await page.evaluate(async (FIX) => {
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    const f = document.getElementById("recover-form");
+    const input = f.elements.table;
+    const listId = input.getAttribute("list");
+    const dl = listId ? document.getElementById(listId) : null;
+    const read = () => (dl ? Array.from(dl.options).map((o) => o.value).sort() : []);
+    // Select the fixture schema through the REAL change path (what a user does).
+    f.elements.schema.value = FIX;
+    f.elements.schema.dispatchEvent(new Event("change"));
+    for (let i = 0; i < 80 && !read().length; i++) await sleep(50);
+    const tablesA = read();
+    // A value from the old schema, then a switch: suggestions must swap and
+    // the stale value must clear (never silently kept under the new schema).
+    input.value = "orders";
+    f.elements.schema.value = "e2estock";
+    f.elements.schema.dispatchEvent(new Event("change"));
+    for (let i = 0; i < 80 && (!read().length || read().join() === tablesA.join()); i++) await sleep(50);
+    const tablesB = read();
+    const clearedOnSwitch = input.value === "";
+    // Back to the fixture schema for the scenarios below.
+    f.elements.schema.value = FIX;
+    f.elements.schema.dispatchEvent(new Event("change"));
+    for (let i = 0; i < 80 && read().join() !== tablesA.join(); i++) await sleep(50);
+    return {
+      isInput: input.tagName === "INPUT",
+      hasList: !!dl,
+      hasHint: !!f.querySelector(".combo-hint"),
+      disabled: input.disabled,
+      tablesA, tablesB, clearedOnSwitch,
+    };
+  }, FIX);
+  (combo.isInput && combo.hasList)
+    ? ok("restore combo: Table is an input+datalist combobox, not a closed select")
+    : bad("restore combo: Table is an input+datalist combobox, not a closed select", JSON.stringify(combo));
+  combo.tablesA.join(",") === "child,orders,parent"
+    ? ok("restore combo: selecting a schema populates suggestions from its listing")
+    : bad("restore combo: selecting a schema populates suggestions from its listing", JSON.stringify(combo.tablesA));
+  combo.tablesB.join(",") === "inventory"
+    ? ok("restore combo: switching schemas swaps the suggestions")
+    : bad("restore combo: switching schemas swaps the suggestions", JSON.stringify(combo.tablesB));
+  combo.clearedOnSwitch
+    ? ok("restore combo: a stale table value is cleared on schema switch")
+    : bad("restore combo: a stale table value is cleared on schema switch", "kept the previous schema's table");
+  (!combo.disabled && combo.hasHint)
+    ? ok("restore combo: the field stays a usable free-text input with a busy-hint slot")
+    : bad("restore combo: the field stays a usable free-text input with a busy-hint slot", JSON.stringify(combo));
+
+  // Scenario 17 — Generate-undo busy modal (#1363). A slowed /api/recover must
+  // open the modal immediately (dialog semantics, facts stated, button
+  // disabled), block a second click, close on completion with focus on the
+  // reversal.sql header; Cancel and ESC must abort the fetch and restore the
+  // pre-click state; an error must render IN the modal, then dismiss cleanly.
+  // The stub honors AbortController like real fetch — which also proves api()
+  // passes the signal through: if it dropped it, the abort never rejects and
+  // the cancel legs below fail visibly.
+  const busyRun = await page.evaluate(async (FIX) => {
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    const f = document.getElementById("recover-form");
+    const genBtn = f.querySelector('button[type="submit"]');
+    const prevBtn = Array.from(f.querySelectorAll(".filter-actions button")).find((b) => b.textContent === "Preview rows");
+    const modalSel = () => document.querySelector("#modal .busy-modal");
+    const realFetch = window.fetch;
+    const calls = [];
+    let mode = "delay", delay = 800;
+    window.fetch = (p, o) => {
+      if (!(typeof p === "string" && p.startsWith("/api/recover"))) return realFetch(p, o);
+      calls.push(o && o.body ? String(o.body) : "");
+      if (mode === "error") {
+        return Promise.resolve(new Response('{"error":"the index server went away mid-read — check the connection and retry"}',
+          { status: 500, headers: { "Content-Type": "application/json" } }));
+      }
+      return new Promise((resolve, reject) => {
+        const t = setTimeout(() => resolve(realFetch(p, o)), delay);
+        if (o && o.signal) o.signal.addEventListener("abort", () => { clearTimeout(t); reject(new DOMException("Aborted", "AbortError")); });
+      });
+    };
+    try {
+      // A) slow generate: modal + facts + disabled button + second click inert.
+      f.elements.schema.value = FIX;
+      f.elements.table.value = "orders";
+      f.elements.pk.value = "1";
+      f.elements.since.value = ""; f.elements.until.value = "";
+      document.getElementById("recover-out").replaceChildren();
+      genBtn.focus(); genBtn.click();
+      await sleep(120);
+      const m = modalSel();
+      const open = {
+        present: !!m,
+        role: m ? m.getAttribute("role") : "",
+        busyAttr: m ? m.getAttribute("aria-busy") : "",
+        facts: m ? m.textContent : "",
+        btnDisabled: genBtn.disabled,
+        prevDisabled: prevBtn ? prevBtn.disabled : false,
+        focusInModal: m ? m.contains(document.activeElement) : false,
+      };
+      genBtn.click();    // disabled click — inert
+      f.requestSubmit(); // a keyboard/programmatic submit must hit the re-entry guard
+      await sleep(80);
+      const secondBlocked = calls.length === 1;
+      for (let i = 0; i < 100 && modalSel(); i++) await sleep(50);
+      const done = {
+        modalGone: !modalSel(),
+        panel: !!document.querySelector("#recover-out #sql-panel"),
+        calls: calls.length,
+        btnEnabled: !genBtn.disabled,
+        focusOnResult: !!document.activeElement && document.activeElement.classList.contains("code-head"),
+      };
+
+      // B) Cancel restores the pre-click state.
+      document.getElementById("recover-out").replaceChildren();
+      delay = 5000;
+      genBtn.focus(); genBtn.click();
+      await sleep(120);
+      const cbtn = Array.from((modalSel() || document.createElement("i")).querySelectorAll("button")).find((b) => b.textContent === "Cancel");
+      if (cbtn) cbtn.click();
+      await sleep(150);
+      const afterCancel = {
+        modalGone: !modalSel(),
+        noPanel: !document.querySelector("#recover-out #sql-panel"),
+        btnEnabled: !genBtn.disabled,
+        focusBack: document.activeElement === genBtn,
+        calls: calls.length, // 2: the canceled call fired once, never retried
+      };
+
+      // B2) ESC aborts the same way.
+      genBtn.focus(); genBtn.click();
+      await sleep(120);
+      const escOpened = !!modalSel();
+      document.activeElement.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+      await sleep(150);
+      const afterEsc = { opened: escOpened, modalGone: !modalSel(), btnEnabled: !genBtn.disabled, noPanel: !document.querySelector("#recover-out #sql-panel") };
+
+      // C) an error renders IN the modal, then Dismiss returns to pre-click state.
+      mode = "error";
+      genBtn.focus(); genBtn.click();
+      await sleep(200);
+      const em = modalSel();
+      const errShown = {
+        stillOpen: !!em,
+        busyAttr: em ? em.getAttribute("aria-busy") : "",
+        text: em ? em.textContent : "",
+      };
+      const dismiss = em ? Array.from(em.querySelectorAll("button")).find((b) => b.textContent === "Dismiss") : null;
+      if (dismiss) dismiss.click();
+      await sleep(80);
+      const afterErr = { modalGone: !modalSel(), noPanel: !document.querySelector("#recover-out #sql-panel"), btnEnabled: !genBtn.disabled };
+
+      // D) a hand-typed table NOT in the listing still submits (#1364) and
+      // reaches the backend — dropped tables with indexed events are a
+      // legitimate recover target.
+      mode = "delay"; delay = 0;
+      f.elements.table.value = "vanished_tbl";
+      f.elements.pk.value = "";
+      genBtn.focus(); genBtn.click();
+      for (let i = 0; i < 100 && modalSel(); i++) await sleep(50);
+      const typed = {
+        submitted: calls.some((c) => c.includes('"table":"vanished_tbl"')),
+        panel: !!document.querySelector("#recover-out #sql-panel"),
+      };
+
+      // E) Preview rows adopts the same busy mechanism (same latency source).
+      window.fetch = (p, o) => {
+        if (!(typeof p === "string" && p.startsWith("/api/events"))) return realFetch(p, o);
+        return new Promise((resolve, reject) => {
+          const t = setTimeout(() => resolve(realFetch(p, o)), 700);
+          if (o && o.signal) o.signal.addEventListener("abort", () => { clearTimeout(t); reject(new DOMException("Aborted", "AbortError")); });
+        });
+      };
+      f.elements.table.value = "orders";
+      f.elements.pk.value = "1";
+      prevBtn.focus(); prevBtn.click();
+      await sleep(120);
+      const pm = modalSel();
+      const previewBusy = { modalOpen: !!pm, title: pm ? pm.textContent : "" };
+      for (let i = 0; i < 100 && modalSel(); i++) await sleep(50);
+      const previewDone = {
+        modalGone: !modalSel(),
+        rendered: !!document.querySelector("#recover-preview .events"),
+        btnEnabled: !prevBtn.disabled,
+      };
+      return { open, secondBlocked, done, afterCancel, afterEsc, errShown, afterErr, typed, previewBusy, previewDone };
+    } finally {
+      window.fetch = realFetch;
+    }
+  }, FIX);
+  (busyRun.open.present && busyRun.open.role === "dialog" && busyRun.open.busyAttr === "true")
+    ? ok("busy modal: opens immediately as an aria-busy dialog")
+    : bad("busy modal: opens immediately as an aria-busy dialog", JSON.stringify(busyRun.open));
+  (busyRun.open.facts.includes(FIX + ".orders") && /pk/.test(busyRun.open.facts))
+    ? ok("busy modal: states what is being generated (target + pk)")
+    : bad("busy modal: states what is being generated (target + pk)", busyRun.open.facts.slice(0, 200));
+  (busyRun.open.btnDisabled && busyRun.open.prevDisabled)
+    ? ok("busy modal: the Restore action buttons are disabled while open")
+    : bad("busy modal: the Restore action buttons are disabled while open", JSON.stringify(busyRun.open));
+  busyRun.open.focusInModal
+    ? ok("busy modal: keyboard focus moves into the dialog")
+    : bad("busy modal: keyboard focus moves into the dialog", "focus stayed outside");
+  busyRun.secondBlocked
+    ? ok("busy modal: a second click/submit queues no second generation")
+    : bad("busy modal: a second click/submit queues no second generation", "a second /api/recover fired");
+  (busyRun.done.modalGone && busyRun.done.panel && busyRun.done.calls === 1)
+    ? ok("busy modal: closes on completion with the reversal panel rendered (one call total)")
+    : bad("busy modal: closes on completion with the reversal panel rendered (one call total)", JSON.stringify(busyRun.done));
+  (busyRun.done.btnEnabled && busyRun.done.focusOnResult)
+    ? ok("busy modal: success re-enables the button and focuses the reversal.sql header")
+    : bad("busy modal: success re-enables the button and focuses the reversal.sql header", JSON.stringify(busyRun.done));
+  (busyRun.afterCancel.modalGone && busyRun.afterCancel.noPanel && busyRun.afterCancel.btnEnabled && busyRun.afterCancel.calls === 2)
+    ? ok("busy modal: Cancel aborts the fetch and restores the pre-click state")
+    : bad("busy modal: Cancel aborts the fetch and restores the pre-click state", JSON.stringify(busyRun.afterCancel));
+  busyRun.afterCancel.focusBack
+    ? ok("busy modal: Cancel restores focus to the Generate button")
+    : bad("busy modal: Cancel restores focus to the Generate button", "focus elsewhere");
+  (busyRun.afterEsc.opened && busyRun.afterEsc.modalGone && busyRun.afterEsc.btnEnabled && busyRun.afterEsc.noPanel)
+    ? ok("busy modal: ESC aborts and restores like Cancel")
+    : bad("busy modal: ESC aborts and restores like Cancel", JSON.stringify(busyRun.afterEsc));
+  (busyRun.errShown.stillOpen && busyRun.errShown.busyAttr === "false" && /went away mid-read/.test(busyRun.errShown.text))
+    ? ok("busy modal: an error renders the server's actionable text IN the modal")
+    : bad("busy modal: an error renders the server's actionable text IN the modal", JSON.stringify(busyRun.errShown).slice(0, 300));
+  (busyRun.afterErr.modalGone && busyRun.afterErr.noPanel && busyRun.afterErr.btnEnabled)
+    ? ok("busy modal: Dismiss after an error returns to the pre-click state")
+    : bad("busy modal: Dismiss after an error returns to the pre-click state", JSON.stringify(busyRun.afterErr));
+  (busyRun.typed.submitted && busyRun.typed.panel)
+    ? ok("restore combo: a typed table not in the listing still submits end-to-end")
+    : bad("restore combo: a typed table not in the listing still submits end-to-end", JSON.stringify(busyRun.typed));
+  (busyRun.previewBusy.modalOpen && /Previewing affected rows/.test(busyRun.previewBusy.title))
+    ? ok("busy modal: Preview rows adopts the same busy affordance")
+    : bad("busy modal: Preview rows adopts the same busy affordance", JSON.stringify(busyRun.previewBusy).slice(0, 200));
+  (busyRun.previewDone.modalGone && busyRun.previewDone.rendered && busyRun.previewDone.btnEnabled)
+    ? ok("busy modal: preview closes on completion with the rows rendered")
+    : bad("busy modal: preview closes on completion with the rows rendered", JSON.stringify(busyRun.previewDone));
+
+  // Scenario 17b — the reduced-motion arm (#1363, same rule as the #1353
+  // skeletons): under prefers-reduced-motion the CSS animation is replaced by
+  // the static note; under no-preference the animation shows and the note
+  // hides. Driven through the REAL openRecoverBusy against emulated media.
+  const rmProbe = async () => page.evaluate(() => {
+    const busy = openRecoverBusy(document.getElementById("recover-form"),
+      { title: "probe", errTitle: "probe", facts: [], onCancel: () => {} });
+    const res = {
+      anim: getComputedStyle(document.querySelector("#modal .busy-anim")).display,
+      note: getComputedStyle(document.querySelector("#modal .busy-static")).display,
+    };
+    busy.close(false);
+    return res;
+  });
+  await page.emulateMedia({ reducedMotion: "no-preference" });
+  const rmOff = await rmProbe();
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  const rmOn = await rmProbe();
+  await page.emulateMedia({ reducedMotion: null });
+  (rmOff.anim === "flex" && rmOff.note === "none")
+    ? ok("busy modal: animation renders under no-preference (static note hidden)")
+    : bad("busy modal: animation renders under no-preference (static note hidden)", JSON.stringify(rmOff));
+  (rmOn.anim === "none" && rmOn.note === "block")
+    ? ok("busy modal: prefers-reduced-motion collapses the animation to the static note")
+    : bad("busy modal: prefers-reduced-motion collapses the animation to the static note", JSON.stringify(rmOn));
+
   // No uncaught JS errors over the whole run.
   jsErrors.length === 0 ? ok("no uncaught JS errors") : bad("no uncaught JS errors", JSON.stringify(jsErrors));
 } catch (err) {

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1423,55 +1423,125 @@ try {
     const listId = input.getAttribute("list");
     const dl = listId ? document.getElementById(listId) : null;
     const read = () => (dl ? Array.from(dl.options).map((o) => o.value).sort() : []);
-    // Select the fixture schema through the REAL change path (what a user does).
-    f.elements.schema.value = FIX;
-    f.elements.schema.dispatchEvent(new Event("change"));
-    for (let i = 0; i < 80 && !read().length; i++) await sleep(50);
+    const hintText = () => (f.querySelector(".combo-hint") || {}).textContent || "";
+    const waitFor = async (pred) => { for (let i = 0; i < 80 && !pred(); i++) await sleep(50); return pred(); };
+    const pick = (schema) => { f.elements.schema.value = schema; f.elements.schema.dispatchEvent(new Event("change")); };
+
+    // The dropped-table flow: a name typed BEFORE the first schema selection
+    // must survive that selection — clearing here would make the one recovery
+    // a closed <select> can't do impossible from this combobox too.
+    input.value = "preseeded_tbl";
+    pick(FIX);
+    await waitFor(() => read().length > 0);
     const tablesA = read();
-    // A value from the old schema, then a switch: suggestions must swap and
-    // the stale value must clear (never silently kept under the new schema).
-    input.value = "orders";
-    f.elements.schema.value = "e2estock";
-    f.elements.schema.dispatchEvent(new Event("change"));
-    for (let i = 0; i < 80 && (!read().length || read().join() === tablesA.join()); i++) await sleep(50);
+    const preseededKept = input.value === "preseeded_tbl";
+
+    // A value from the old schema not in the new listing: suggestions must
+    // swap and the stale value must clear (never silently kept).
+    input.value = "child";
+    pick("e2estock");
+    await waitFor(() => read().length > 0 && read().join() !== tablesA.join());
     const tablesB = read();
     const clearedOnSwitch = input.value === "";
-    // Back to the fixture schema for the scenarios below.
-    f.elements.schema.value = FIX;
-    f.elements.schema.dispatchEvent(new Event("change"));
-    for (let i = 0; i < 80 && read().join() !== tablesA.join(); i++) await sleep(50);
+
+    // The keep-arm: "orders" exists in BOTH schemas (shared fixture name), so
+    // switching must KEEP it — an unconditional clear-on-switch fails here.
+    pick(FIX);
+    await waitFor(() => read().join() === tablesA.join());
+    input.value = "orders";
+    pick("e2estock");
+    await waitFor(() => read().join() === tablesB.join());
+    const sharedKept = input.value === "orders";
+
+    // A → "— select —" → B must still clear: the empty option must not reset
+    // the switch marker and launder B into a "first selection".
+    pick(FIX);
+    await waitFor(() => read().join() === tablesA.join());
+    input.value = "parent";
+    pick("");
+    await sleep(120);
+    const keptOnEmpty = input.value === "parent"; // deselecting alone never clears
+    pick("e2estock");
+    await waitFor(() => read().join() === tablesB.join());
+    const clearedViaEmpty = input.value === "";
+
+    // A FAILED listing: value intact, field usable, aria-busy gone, and the
+    // persistent aria-live hint says to type the name (the toast is 2.2s).
+    const realFetch = window.fetch;
+    window.fetch = (p, o) => (typeof p === "string" && p.startsWith("/api/schemas")
+      ? Promise.resolve(new Response('{"error":"boom"}', { status: 500, headers: { "Content-Type": "application/json" } }))
+      : realFetch(p, o));
+    tablesCache.delete(FIX);
+    input.value = "typed_under_failure";
+    pick(FIX);
+    await waitFor(() => /type the table name/.test(hintText()));
+    const failed = {
+      valueKept: input.value === "typed_under_failure",
+      enabled: !input.disabled,
+      ariaBusyGone: !input.hasAttribute("aria-busy"),
+      hint: hintText(),
+    };
+    window.fetch = realFetch;
+    // ...and a submit still reaches the backend despite the failed listing.
+    document.getElementById("recover-out").replaceChildren();
+    f.elements.pk.value = "";
+    f.elements.since.value = ""; f.elements.until.value = "";
+    f.requestSubmit();
+    await waitFor(() => !!document.querySelector("#recover-out #sql-panel") && !document.querySelector("#modal .busy-modal"));
+    const failedSubmit = !!document.querySelector("#recover-out #sql-panel");
     return {
       isInput: input.tagName === "INPUT",
       hasList: !!dl,
       hasHint: !!f.querySelector(".combo-hint"),
       disabled: input.disabled,
-      tablesA, tablesB, clearedOnSwitch,
+      preseededKept, tablesA, tablesB, clearedOnSwitch, sharedKept,
+      keptOnEmpty, clearedViaEmpty, failed, failedSubmit,
     };
   }, FIX);
   (combo.isInput && combo.hasList)
     ? ok("restore combo: Table is an input+datalist combobox, not a closed select")
     : bad("restore combo: Table is an input+datalist combobox, not a closed select", JSON.stringify(combo));
+  combo.preseededKept
+    ? ok("restore combo: a name typed before the first schema selection survives it")
+    : bad("restore combo: a name typed before the first schema selection survives it", "first listing load cleared the typed value");
   combo.tablesA.join(",") === "child,orders,parent"
     ? ok("restore combo: selecting a schema populates suggestions from its listing")
     : bad("restore combo: selecting a schema populates suggestions from its listing", JSON.stringify(combo.tablesA));
-  combo.tablesB.join(",") === "inventory"
+  combo.tablesB.join(",") === "inventory,orders"
     ? ok("restore combo: switching schemas swaps the suggestions")
     : bad("restore combo: switching schemas swaps the suggestions", JSON.stringify(combo.tablesB));
   combo.clearedOnSwitch
     ? ok("restore combo: a stale table value is cleared on schema switch")
     : bad("restore combo: a stale table value is cleared on schema switch", "kept the previous schema's table");
-  (!combo.disabled && combo.hasHint)
-    ? ok("restore combo: the field stays a usable free-text input with a busy-hint slot")
-    : bad("restore combo: the field stays a usable free-text input with a busy-hint slot", JSON.stringify(combo));
+  combo.sharedKept
+    ? ok("restore combo: a value present in the NEW schema's listing survives the switch")
+    : bad("restore combo: a value present in the NEW schema's listing survives the switch", "cleared a value that belongs to the new schema");
+  (combo.keptOnEmpty && combo.clearedViaEmpty)
+    ? ok("restore combo: routing a switch through '— select —' still clears the stale value")
+    : bad("restore combo: routing a switch through '— select —' still clears the stale value", JSON.stringify({ keptOnEmpty: combo.keptOnEmpty, clearedViaEmpty: combo.clearedViaEmpty }));
+  (combo.failed.valueKept && combo.failed.enabled && combo.failed.ariaBusyGone)
+    ? ok("restore combo: a failed listing keeps the value and the field usable")
+    : bad("restore combo: a failed listing keeps the value and the field usable", JSON.stringify(combo.failed));
+  /type the table name/.test(combo.failed.hint)
+    ? ok("restore combo: a failed listing shows the persistent aria-live hint")
+    : bad("restore combo: a failed listing shows the persistent aria-live hint", JSON.stringify(combo.failed.hint));
+  combo.failedSubmit
+    ? ok("restore combo: a submit still reaches the backend after a failed listing")
+    : bad("restore combo: a submit still reaches the backend after a failed listing", "no reversal panel rendered");
+  !combo.disabled
+    ? ok("restore combo: the field is never disabled")
+    : bad("restore combo: the field is never disabled", "input.disabled");
 
   // Scenario 17 — Generate-undo busy modal (#1363). A slowed /api/recover must
   // open the modal immediately (dialog semantics, facts stated, button
   // disabled), block a second click, close on completion with focus on the
   // reversal.sql header; Cancel and ESC must abort the fetch and restore the
   // pre-click state; an error must render IN the modal, then dismiss cleanly.
-  // The stub honors AbortController like real fetch — which also proves api()
-  // passes the signal through: if it dropped it, the abort never rejects and
-  // the cancel legs below fail visibly.
+  // The stub honors AbortController like real fetch. That alone proves
+  // nothing — teardown is synchronous, so the modal closes either way; the
+  // wiring is proven by leg B sleeping PAST the stub's delay after Cancel:
+  // if api() dropped opts.signal, the un-aborted response lands, renders a
+  // panel and moves focus, and the post-delay assertions fail.
   const busyRun = await page.evaluate(async (FIX) => {
     const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
     const f = document.getElementById("recover-form");
@@ -1525,9 +1595,11 @@ try {
         focusOnResult: !!document.activeElement && document.activeElement.classList.contains("code-head"),
       };
 
-      // B) Cancel restores the pre-click state.
+      // B) Cancel restores the pre-click state — and the abort is PROVEN by
+      // sleeping past the stub's short delay afterwards: an un-aborted fetch
+      // resolves then, renders a panel and moves focus, failing below.
       document.getElementById("recover-out").replaceChildren();
-      delay = 5000;
+      delay = 600;
       genBtn.focus(); genBtn.click();
       await sleep(120);
       const cbtn = Array.from((modalSel() || document.createElement("i")).querySelectorAll("button")).find((b) => b.textContent === "Cancel");
@@ -1540,24 +1612,41 @@ try {
         focusBack: document.activeElement === genBtn,
         calls: calls.length, // 2: the canceled call fired once, never retried
       };
+      await sleep(900); // PAST the stub's delay
+      afterCancel.noPanelAfterDelay = !document.querySelector("#recover-out #sql-panel");
+      afterCancel.focusStillBack = document.activeElement === genBtn;
 
-      // B2) ESC aborts the same way.
+      // B2) ESC aborts the same way (same past-delay proof).
       genBtn.focus(); genBtn.click();
       await sleep(120);
       const escOpened = !!modalSel();
       document.activeElement.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
       await sleep(150);
       const afterEsc = { opened: escOpened, modalGone: !modalSel(), btnEnabled: !genBtn.disabled, noPanel: !document.querySelector("#recover-out #sql-panel") };
+      await sleep(900); // PAST the stub's delay
+      afterEsc.noPanelAfterDelay = !document.querySelector("#recover-out #sql-panel");
 
-      // C) an error renders IN the modal, then Dismiss returns to pre-click state.
+      // C) an error renders IN the modal — and a FAILED generation must not
+      // leave the PREVIOUS run's script on screen with Download live (those
+      // bytes answer a filter nobody named). Seed a successful result first,
+      // then fail the next generation and assert the stale panel and the
+      // download buffer are gone.
+      mode = "delay"; delay = 0;
+      genBtn.focus(); genBtn.click();
+      for (let i = 0; i < 100 && (modalSel() || !document.querySelector("#recover-out #sql-panel")); i++) await sleep(50);
+      const seeded = { panel: !!document.querySelector("#recover-out #sql-panel"), sql: lastSQL.length > 0 };
       mode = "error";
+      f.elements.pk.value = "2"; // a DIFFERENT filter than the seeded script answers
       genBtn.focus(); genBtn.click();
       await sleep(200);
       const em = modalSel();
       const errShown = {
+        seeded,
         stillOpen: !!em,
         busyAttr: em ? em.getAttribute("aria-busy") : "",
         text: em ? em.textContent : "",
+        stalePanelCleared: !document.querySelector("#recover-out #sql-panel"),
+        staleSQLCleared: lastSQL === "",
       };
       const dismiss = em ? Array.from(em.querySelectorAll("button")).find((b) => b.textContent === "Dismiss") : null;
       if (dismiss) dismiss.click();
@@ -1597,7 +1686,84 @@ try {
         rendered: !!document.querySelector("#recover-preview .events"),
         btnEnabled: !prevBtn.disabled,
       };
-      return { open, secondBlocked, done, afterCancel, afterEsc, errShown, afterErr, typed, previewBusy, previewDone };
+      window.fetch = (p, o) => {
+        if (!(typeof p === "string" && p.startsWith("/api/recover"))) return realFetch(p, o);
+        calls.push(o && o.body ? String(o.body) : "");
+        return new Promise((resolve, reject) => {
+          const t = setTimeout(() => resolve(realFetch(p, o)), delay);
+          if (o && o.signal) o.signal.addEventListener("abort", () => { clearTimeout(t); reject(new DOMException("Aborted", "AbortError")); });
+        });
+      };
+
+      // F) the ⌘K palette stacks ABOVE the dialog in its own mount and owns
+      // its keys: Escape with the palette open must close the palette ONLY —
+      // neither the modal's capture trap (which would beat the palette
+      // input's own handler to the event) nor globalKeydown's generic
+      // #modal-emptying fall-through (the same Escape that closed the
+      // palette bubbles on) may touch the busy dialog.
+      delay = 2000;
+      f.elements.table.value = "orders"; f.elements.pk.value = "1";
+      genBtn.focus(); genBtn.click();
+      await sleep(100);
+      const cmdkMount = document.getElementById("cmdk-mount");
+      document.activeElement.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true, cancelable: true }));
+      await sleep(100);
+      const paletteOpened = !!cmdkMount.firstChild;
+      document.activeElement.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+      await sleep(100);
+      const cmdkLeg = {
+        paletteOpened,
+        paletteClosed: !cmdkMount.firstChild,
+        modalSurvived: !!modalSel(),
+      };
+      document.activeElement.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+      await sleep(150);
+      cmdkLeg.canceledAfter = !modalSel();
+      cmdkLeg.btnEnabled = !genBtn.disabled;
+
+      // G) another dialog CLOBBERING the shared #modal slot (openServersModal
+      // replaces its children without our teardown) must dissolve the trap on
+      // the next keystroke: buttons re-enabled, re-entry flag reset, and the
+      // occupying dialog left alone.
+      delay = 1200;
+      document.getElementById("recover-out").replaceChildren();
+      genBtn.focus(); genBtn.click();
+      await sleep(100);
+      const clobberBefore = !!modalSel();
+      openServersModal();
+      for (let i = 0; i < 60 && !document.getElementById("servers-list"); i++) await sleep(50);
+      const busyGone = !modalSel();
+      // The click path can arrive before any keystroke: the re-entry guard
+      // must self-heal on read when the flag is set but no .busy-modal is in
+      // the slot.
+      const selfHealed = !recoverBusyActive() && !recoverBusyOpen;
+      document.activeElement.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true }));
+      await sleep(80);
+      const clobberLeg = {
+        before: clobberBefore,
+        busyGone,
+        selfHealed,
+        btnEnabled: !genBtn.disabled,
+        flagReset: !recoverBusyOpen,
+        serversIntact: !!document.getElementById("servers-list"),
+      };
+      closeServersModal();
+      // Let the orphaned (never-aborted) request land before the next leg.
+      for (let i = 0; i < 100 && !document.querySelector("#recover-out #sql-panel"); i++) await sleep(50);
+
+      // H) a server switch mid-flight closes the dialog and renders nothing.
+      delay = 700;
+      document.getElementById("recover-out").replaceChildren();
+      genBtn.focus(); genBtn.click();
+      await sleep(100);
+      serverGen++;
+      for (let i = 0; i < 60 && modalSel(); i++) await sleep(50);
+      const switchLeg = {
+        modalGone: !modalSel(),
+        noPanel: !document.querySelector("#recover-out #sql-panel"),
+        btnEnabled: !genBtn.disabled,
+      };
+      return { open, secondBlocked, done, afterCancel, afterEsc, errShown, afterErr, typed, previewBusy, previewDone, cmdkLeg, clobberLeg, switchLeg };
     } finally {
       window.fetch = realFetch;
     }
@@ -1626,15 +1792,21 @@ try {
   (busyRun.afterCancel.modalGone && busyRun.afterCancel.noPanel && busyRun.afterCancel.btnEnabled && busyRun.afterCancel.calls === 2)
     ? ok("busy modal: Cancel aborts the fetch and restores the pre-click state")
     : bad("busy modal: Cancel aborts the fetch and restores the pre-click state", JSON.stringify(busyRun.afterCancel));
+  (busyRun.afterCancel.noPanelAfterDelay && busyRun.afterCancel.focusStillBack)
+    ? ok("busy modal: the abort actually reaches the fetch (nothing renders after the stub's delay)")
+    : bad("busy modal: the abort actually reaches the fetch (nothing renders after the stub's delay)", JSON.stringify(busyRun.afterCancel));
   busyRun.afterCancel.focusBack
     ? ok("busy modal: Cancel restores focus to the Generate button")
     : bad("busy modal: Cancel restores focus to the Generate button", "focus elsewhere");
-  (busyRun.afterEsc.opened && busyRun.afterEsc.modalGone && busyRun.afterEsc.btnEnabled && busyRun.afterEsc.noPanel)
+  (busyRun.afterEsc.opened && busyRun.afterEsc.modalGone && busyRun.afterEsc.btnEnabled && busyRun.afterEsc.noPanel && busyRun.afterEsc.noPanelAfterDelay)
     ? ok("busy modal: ESC aborts and restores like Cancel")
     : bad("busy modal: ESC aborts and restores like Cancel", JSON.stringify(busyRun.afterEsc));
   (busyRun.errShown.stillOpen && busyRun.errShown.busyAttr === "false" && /went away mid-read/.test(busyRun.errShown.text))
     ? ok("busy modal: an error renders the server's actionable text IN the modal")
     : bad("busy modal: an error renders the server's actionable text IN the modal", JSON.stringify(busyRun.errShown).slice(0, 300));
+  (busyRun.errShown.seeded.panel && busyRun.errShown.seeded.sql && busyRun.errShown.stalePanelCleared && busyRun.errShown.staleSQLCleared)
+    ? ok("busy modal: a failed generation clears the previous script and its download buffer")
+    : bad("busy modal: a failed generation clears the previous script and its download buffer", JSON.stringify(busyRun.errShown).slice(0, 300));
   (busyRun.afterErr.modalGone && busyRun.afterErr.noPanel && busyRun.afterErr.btnEnabled)
     ? ok("busy modal: Dismiss after an error returns to the pre-click state")
     : bad("busy modal: Dismiss after an error returns to the pre-click state", JSON.stringify(busyRun.afterErr));
@@ -1647,6 +1819,24 @@ try {
   (busyRun.previewDone.modalGone && busyRun.previewDone.rendered && busyRun.previewDone.btnEnabled)
     ? ok("busy modal: preview closes on completion with the rows rendered")
     : bad("busy modal: preview closes on completion with the rows rendered", JSON.stringify(busyRun.previewDone));
+  (busyRun.cmdkLeg.paletteOpened && busyRun.cmdkLeg.paletteClosed && busyRun.cmdkLeg.modalSurvived)
+    ? ok("busy modal: Escape over the ⌘K palette closes the palette only — the dialog survives")
+    : bad("busy modal: Escape over the ⌘K palette closes the palette only — the dialog survives", JSON.stringify(busyRun.cmdkLeg));
+  (busyRun.cmdkLeg.canceledAfter && busyRun.cmdkLeg.btnEnabled)
+    ? ok("busy modal: the next Escape (palette closed) cancels the dialog as usual")
+    : bad("busy modal: the next Escape (palette closed) cancels the dialog as usual", JSON.stringify(busyRun.cmdkLeg));
+  (busyRun.clobberLeg.before && busyRun.clobberLeg.busyGone && busyRun.clobberLeg.serversIntact)
+    ? ok("busy modal: another dialog can claim the shared #modal slot (fixture precondition)")
+    : bad("busy modal: another dialog can claim the shared #modal slot (fixture precondition)", JSON.stringify(busyRun.clobberLeg));
+  (busyRun.clobberLeg.btnEnabled && busyRun.clobberLeg.flagReset)
+    ? ok("busy modal: a clobbered dialog dissolves its trap — buttons re-enabled, re-entry flag reset")
+    : bad("busy modal: a clobbered dialog dissolves its trap — buttons re-enabled, re-entry flag reset", JSON.stringify(busyRun.clobberLeg));
+  busyRun.clobberLeg.selfHealed
+    ? ok("busy modal: the re-entry guard self-heals on read after a clobber")
+    : bad("busy modal: the re-entry guard self-heals on read after a clobber", JSON.stringify(busyRun.clobberLeg));
+  (busyRun.switchLeg.modalGone && busyRun.switchLeg.noPanel && busyRun.switchLeg.btnEnabled)
+    ? ok("busy modal: a server switch mid-flight closes the dialog and renders nothing")
+    : bad("busy modal: a server switch mid-flight closes the dialog and renders nothing", JSON.stringify(busyRun.switchLeg));
 
   // Scenario 17b — the reduced-motion arm (#1363, same rule as the #1353
   // skeletons): under prefers-reduced-motion the CSS animation is replaced by

--- a/test/console-e2e/run.sh
+++ b/test/console-e2e/run.sh
@@ -99,7 +99,8 @@ INSERT INTO schema_snapshots (snapshot_id, snapshot_time, schema_name, table_nam
   (1,'$P_HOUR','$FIX_SCHEMA','parent','id',1,'PRI','int','NO'),
   (1,'$P_HOUR','$FIX_SCHEMA','child','id',1,'PRI','int','NO'),
   (1,'$P_HOUR','$FIX_SCHEMA','child','pid',2,'','int','YES'),
-  (1,'$P_HOUR','e2estock','inventory','id',1,'PRI','int','NO');
+  (1,'$P_HOUR','e2estock','inventory','id',1,'PRI','int','NO'),
+  (1,'$P_HOUR','e2estock','orders','id',1,'PRI','int','NO');
 INSERT INTO binlog_events (binlog_file, start_pos, end_pos, event_timestamp, connection_id, schema_name, table_name, event_type, pk_values, changed_columns, row_before, row_after, query_text, query_hash) VALUES
   ('binlog.000001',100,200,'$TS_INS',NULL,'$FIX_SCHEMA','orders',1,'3',NULL,NULL,'{"id":3,"status":"new","email":"c@example.com"}',NULL,NULL),
   ('binlog.000001',200,300,'$TS_UPD',777,'$FIX_SCHEMA','orders',2,'1','["status"]','{"id":1,"status":"new","email":"a@example.com"}','{"id":1,"status":"shipped","email":"a@example.com"}','UPDATE orders SET status = ''shipped'' /* e2e-canary-query-text */',SHA2('e2e-canary-query-text',256)),

--- a/test/console-e2e/run.sh
+++ b/test/console-e2e/run.sh
@@ -98,7 +98,8 @@ INSERT INTO schema_snapshots (snapshot_id, snapshot_time, schema_name, table_nam
   (1,'$P_HOUR','$FIX_SCHEMA','orders','email',3,'','varchar','YES'),
   (1,'$P_HOUR','$FIX_SCHEMA','parent','id',1,'PRI','int','NO'),
   (1,'$P_HOUR','$FIX_SCHEMA','child','id',1,'PRI','int','NO'),
-  (1,'$P_HOUR','$FIX_SCHEMA','child','pid',2,'','int','YES');
+  (1,'$P_HOUR','$FIX_SCHEMA','child','pid',2,'','int','YES'),
+  (1,'$P_HOUR','e2estock','inventory','id',1,'PRI','int','NO');
 INSERT INTO binlog_events (binlog_file, start_pos, end_pos, event_timestamp, connection_id, schema_name, table_name, event_type, pk_values, changed_columns, row_before, row_after, query_text, query_hash) VALUES
   ('binlog.000001',100,200,'$TS_INS',NULL,'$FIX_SCHEMA','orders',1,'3',NULL,NULL,'{"id":3,"status":"new","email":"c@example.com"}',NULL,NULL),
   ('binlog.000001',200,300,'$TS_UPD',777,'$FIX_SCHEMA','orders',2,'1','["status"]','{"id":1,"status":"new","email":"a@example.com"}','{"id":1,"status":"shipped","email":"a@example.com"}','UPDATE orders SET status = ''shipped'' /* e2e-canary-query-text */',SHA2('e2e-canary-query-text',256)),


### PR DESCRIPTION
## Summary

### #1363 — loading modal for Generate undo SQL

- Clicking **Generate undo SQL** (or **Preview rows**, which sits on the same latency) now opens a busy modal immediately, instead of the page sitting idle until `/api/recover` returns — seconds on an archive-reaching window.
- The modal states what is being generated (target `schema.table`, pk, since/until — the same facts as the blue context banner) over a **pure-CSS keyframe animation** on the brand accent tokens (`--accent-a`/`--accent-b`; the semantic insert/update/delete colors are data, never decoration).
- `prefers-reduced-motion` collapses the animation to a static progress note — the same rule the #1353 skeletons follow.
- While the modal is open the form's action buttons are disabled and a re-entry guard blocks programmatic submits: one click = one generation.
- **Cancel** and **ESC** abort the in-flight fetch (`AbortController`, threaded through `api()`) and restore the pre-click state, including focus on the triggering button.
- Errors render **in** the modal with the server's own actionable text and a Dismiss — the overlay never silently vanishes.
- On success the modal closes and keyboard focus moves to the `reversal.sql` panel header (`tabindex="-1"` on `.code-head`).
- A11y: `role="dialog"`, `aria-busy`, focus trapped while open (capture-phase key handling so the generic `#modal` Escape path can't strand the fetch), focus restored on cancel/dismiss.
- **Decision on Preview rows**: adopted — same mechanism, same guard, title "Previewing affected rows". It shares the exact latency source and the same double-click hazard.

### #1364 — Table suggestions from the selected schema

- The Restore **Table** field is now an input + `datalist` combobox populated from `GET /api/schemas?schema=X`, mirroring the existing consumer in `loadTables` (the events table picker) — same `tablesCache`, same session-visibility rules from #1326/#1337 for free.
- Deliberately **not** a closed `<select>`: a hand-typed table not in the listing still submits — recover legitimately targets dropped tables whose events are indexed.
- Switching schema refreshes the suggestions and clears a stale table value that doesn't belong to the new schema. A value present in the new schema's own listing is kept, and a name typed before the *first* schema selection (the dropped-table flow) survives.
- A failed or empty listing leaves the field as usable free text, never disabled; a brief "loading tables…" hint (`aria-live`) shows while the listing loads.
- Preview rows shares the field, so it is covered automatically.

## Testing

- `node --check internal/console/assets/app.js` clean; `go build ./...` and `go test ./... -count=1` green.
- console-e2e (Docker MySQL + headless Chromium): **189/189 passed** — 167 pre-change assertions all kept, 22 added:
  - slowed `/api/recover` → modal opens as an `aria-busy` dialog with the facts, buttons disabled, a second click/`requestSubmit` queues no second call, closes on completion with the reversal panel rendered and focused;
  - Cancel and ESC abort the stubbed fetch (the stub honors `AbortSignal`, which also proves `api()` passes the signal through) and restore the pre-click state;
  - a 500 renders its message in the modal, Dismiss returns to the pre-click state;
  - reduced-motion emulation (`page.emulateMedia`) swaps the animation for the static note, and back;
  - selecting the fixture schema populates the datalist (`child,orders,parent`), switching to the new `e2estock` fixture schema swaps it to `inventory` and clears the stale value, and a typed non-listed table submits end-to-end (request fired, panel rendered).
- Mutation-checked: with the re-entry guard removed and the schema-change clearing removed, the run fails exactly the two matching assertions (187/189) and returns green after revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round (consolidated)

- **Shared `#modal` clobbering (critical)**: the busy dialog now bails its capture-phase key handler while the ⌘K palette is open (the palette's own Escape handler sits on the cmdk input, which the capture listener would beat to the event); `globalKeydown`'s generic `#modal`-emptying Escape branch skips a mounted `.busy-modal` — required because `cmdkKeydown` closes the palette *without* stopping propagation, so the same Escape lands on the generic branch with the palette check already passing. A clobber by another dialog (`openServersModal`/rotation) dissolves the trap on the next keystroke (`scrim.isConnected` teardown: listener removed, buttons re-enabled, flag reset, occupying dialog untouched); the re-entry guard self-heals on read (`recoverBusyActive`); `showError` on a detached scrim tears down and toasts; the success paths check the output container is still connected (palette navigation mid-flight) and toast instead of rendering into detached nodes. A 401 mid-flight is covered without extra code: `handleUnauthorized` bumps `serverGen` synchronously before `api()` throws, so the catch always closes the modal — `showError` is unreachable on 401, and teardown (`scrim.remove()`) cannot touch the login gate's separate `#login-mount`.
- **Stale result on failure (critical)**: a failed generation now clears `#recover-out`, `#recover-warnings` and `lastSQL` before showing the error — the previous run's script can no longer sit on screen with Copy/Download live answering a filter nobody named. The failed preview clears the stale preview the same way (warnings deliberately kept there, per the #1311 rule). Cancel still preserves the pre-click state — a withdrawn request changes nothing — and the comments now say which is which.
- **Clear-on-switch hole**: the switch marker only advances on a real schema selection, so `A → "— select —" → B` no longer reads as a first selection and can't carry A's table into B.
- **Abort proven, not assumed**: the Cancel/ESC legs now sleep *past* the stub's delay — if `api()` dropped `opts.signal`, the un-aborted response renders a late panel and the assertions fail.
- **Listing-failure UX**: the persistent `aria-live` combo-hint now reads "couldn't load suggestions — type the table name" (the toast alone lasts 2.2 s), set before the `serverGen` bail so no path strands "loading…".
- **e2e: 189 → 203 assertions.** New legs: typed-before-first-selection survives; shared-name keep-arm (`orders` seeded in both fixture schemas); the `— select —` laundering path; failed listing keeps the value, shows the hint, and a submit still reaches the backend; abort proven past the stub delay; failed generation clears the seeded previous script; Escape over the open palette closes the palette only; `#modal` clobber dissolves the trap and self-heals the guard; server switch mid-flight closes the dialog and renders nothing.
- **Mutation-checked** (two batched runs, each mutation with a dedicated failing assertion): dropping the cmdk bail, the `globalKeydown` busy-modal guard, the `isConnected` teardown, the self-heal, `api()`'s signal pass-through, or the clear-on-error each turns its test red; suite green again after revert.
