### PR TITLE
telemetry: beacon from every long-running daemon, with per-daemon wiring guards

### DIFF
--- a/cliapp/daemon_beacon_test.go
+++ b/cliapp/daemon_beacon_test.go
@@ -45,6 +45,41 @@ func TestStreamDaemonWiringEmitsBeacon(t *testing.T) {
 	}
 }
 
+// TestUpDelegationNamesBeaconUp pins the docs' "up beacons" claim, which
+// rides on runUpStream delegating to runStream WITH the up command itself:
+// the shared call site names the beacon via cmd.Name(), so invoked as `up` it
+// must say "up", not "stream". Hardcode the name in runStream — or break the
+// delegation's cmd pass-through — and this fails.
+func TestUpDelegationNamesBeaconUp(t *testing.T) {
+	c, bodies := telemetrytest.CollectingClient(t)
+	defer tel.SetClientForTest(c)()
+
+	addr, sever := telemetrytest.HangingTCPAddr(t)
+	origIndex, origSource := strmIndexDSN, strmSourceDSN
+	defer func() { strmIndexDSN, strmSourceDSN = origIndex, origSource }()
+	// As in production `up`, the strm* globals carry the DSNs by the time
+	// runStream runs (populateStreamFlags has copied them).
+	strmIndexDSN = "root:x@tcp(" + addr + ")/bintrail_index"
+	strmSourceDSN = "root:x@tcp(" + addr + ")/ignored"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	upCmd.SetContext(ctx)
+
+	done := make(chan error, 1)
+	go func() { done <- runStream(upCmd, nil) }()
+
+	telemetrytest.WaitForBeacon(t, bodies, "up")
+
+	cancel()
+	sever()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("runStream did not return after cancel — daemon shutdown would hang")
+	}
+}
+
 // TestAgentDaemonWiringEmitsBeacon keeps `bintrail agent` alive through its
 // channel reconnect backoff (a connection-refused endpoint, a few attempts)
 // while the shortened daemon tick fires.

--- a/cliapp/daemon_beacon_test.go
+++ b/cliapp/daemon_beacon_test.go
@@ -1,0 +1,91 @@
+package cliapp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/telemetry/telemetrytest"
+)
+
+// These are the WIRING guards for #1362: each drives the REAL daemon run
+// function and passes only once a real daemon_beacon carrying that daemon's
+// command name is delivered end to end. Delete the daemon's
+// `go tel.Client().RunDaemon(ctx, cmd.Name())` line and the matching test
+// fails — the loop itself is pinned by internal/telemetry's own daemon tests.
+
+// TestStreamDaemonWiringEmitsBeacon holds `bintrail stream` alive in its very
+// first index dial (a TCP endpoint that accepts and never answers, so the
+// driver's handshake read blocks) while the shortened daemon tick fires.
+func TestStreamDaemonWiringEmitsBeacon(t *testing.T) {
+	c, bodies := telemetrytest.CollectingClient(t)
+	defer tel.SetClientForTest(c)()
+
+	addr, sever := telemetrytest.HangingTCPAddr(t)
+	origIndex, origSource := strmIndexDSN, strmSourceDSN
+	defer func() { strmIndexDSN, strmSourceDSN = origIndex, origSource }()
+	strmIndexDSN = "root:x@tcp(" + addr + ")/bintrail_index"
+	strmSourceDSN = "root:x@tcp(" + addr + ")/ignored"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	streamCmd.SetContext(ctx)
+
+	done := make(chan error, 1)
+	go func() { done <- runStream(streamCmd, nil) }()
+
+	telemetrytest.WaitForBeacon(t, bodies, "stream")
+
+	cancel()
+	sever()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("runStream did not return after cancel — daemon shutdown would hang")
+	}
+}
+
+// TestAgentDaemonWiringEmitsBeacon keeps `bintrail agent` alive through its
+// channel reconnect backoff (a connection-refused endpoint, a few attempts)
+// while the shortened daemon tick fires.
+func TestAgentDaemonWiringEmitsBeacon(t *testing.T) {
+	c, bodies := telemetrytest.CollectingClient(t)
+	defer tel.SetClientForTest(c)()
+
+	origEndpoint, origAPIKey := agtEndpoint, agtAPIKey
+	origIndex, origSource := agtIndexDSN, agtSourceDSN
+	origArchiveDir := agtArchiveDir
+	origAttempts := agtMaxReconnectAttempts
+	defer func() {
+		agtEndpoint, agtAPIKey = origEndpoint, origAPIKey
+		agtIndexDSN, agtSourceDSN = origIndex, origSource
+		agtArchiveDir = origArchiveDir
+		agtMaxReconnectAttempts = origAttempts
+	}()
+	// Port 1 refuses instantly; the reconnect backoff between attempts keeps
+	// the daemon alive well past the shortened tick, and the bounded attempt
+	// count means the run function returns on its own even without a signal.
+	agtEndpoint = "ws://127.0.0.1:1/v1/agent"
+	agtAPIKey = "wiring-test"
+	agtIndexDSN, agtSourceDSN = "", ""
+	// An archive dir satisfies the at-least-one-data-source validation with
+	// no pre-launch connection (the flag is recorded, not scanned, here).
+	agtArchiveDir = t.TempDir()
+	agtMaxReconnectAttempts = 4
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	agentCmd.SetContext(ctx)
+
+	done := make(chan error, 1)
+	go func() { done <- runAgent(agentCmd, nil) }()
+
+	telemetrytest.WaitForBeacon(t, bodies, "agent")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("runAgent did not return after cancel — daemon shutdown would hang")
+	}
+}

--- a/cmd/bintrail-pg/daemon_beacon_test.go
+++ b/cmd/bintrail-pg/daemon_beacon_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/telemetry/telemetrytest"
+)
+
+// TestPGStreamDaemonWiringEmitsBeacon is the #1362 wiring guard for
+// `bintrail-pg stream`: it drives the REAL runPGStream and passes only once a
+// real daemon_beacon carrying its command name is delivered. The daemon is
+// held alive in its very first connection — pgstreamrun.One dials the MySQL
+// index before it ever touches PostgreSQL, and the hanging endpoint accepts
+// without answering, so the handshake read blocks while the shortened daemon
+// tick fires. Delete the `go tel.Client().RunDaemon(...)` line and this fails.
+func TestPGStreamDaemonWiringEmitsBeacon(t *testing.T) {
+	c, bodies := telemetrytest.CollectingClient(t)
+	defer tel.SetClientForTest(c)()
+
+	// pgStreamConfigFromFlags fills EMPTY flag vars from BINTRAIL_PG_*; make
+	// sure a developer shell's values cannot leak into the run.
+	for _, v := range []string{"BINTRAIL_PG_REPL_DSN", "BINTRAIL_PG_QUERY_DSN",
+		"BINTRAIL_PG_SLOT", "BINTRAIL_PG_PUBLICATION", "BINTRAIL_PG_START_LSN"} {
+		t.Setenv(v, "")
+	}
+
+	addr, sever := telemetrytest.HangingTCPAddr(t)
+	origIndex, origRepl, origQuery := pgIndexDSN, pgReplDSN, pgQueryDSN
+	origSlot, origPub, origServerID := pgSlot, pgPublication, pgServerID
+	defer func() {
+		pgIndexDSN, pgReplDSN, pgQueryDSN = origIndex, origRepl, origQuery
+		pgSlot, pgPublication, pgServerID = origSlot, origPub, origServerID
+	}()
+	pgIndexDSN = "root:x@tcp(" + addr + ")/bintrail_index"
+	pgReplDSN = "postgres://u:p@127.0.0.1:1/db?replication=database"
+	pgQueryDSN = "postgres://u:p@127.0.0.1:1/db"
+	pgSlot, pgPublication, pgServerID = "wiring", "wiring", 1
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	streamCmd.SetContext(ctx)
+
+	done := make(chan error, 1)
+	go func() { done <- runPGStream(streamCmd, nil) }()
+
+	telemetrytest.WaitForBeacon(t, bodies, "stream")
+
+	cancel()
+	sever()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("runPGStream did not return after cancel — daemon shutdown would hang")
+	}
+}

--- a/cmd/bintrail-pg/flashback.go
+++ b/cmd/bintrail-pg/flashback.go
@@ -170,6 +170,12 @@ func runFlashback(cmd *cobra.Command, args []string) error {
 		listener.Close()
 	}()
 
+	// Usage telemetry for a months-lived process (#1362): Init's drain runs
+	// once, at startup, so without this loop a daemon's beacons would spool
+	// and age out undelivered. Own goroutine — never on a client connection's
+	// path. Same seam as the MySQL shim, via this binary's own hook.
+	go tel.Client().RunDaemon(ctx, cmd.Name())
+
 	cfg := pgshim.Config{
 		IndexDB: db,
 		ShimConfig: shim.Config{

--- a/cmd/bintrail-pg/flashback_beacon_integration_test.go
+++ b/cmd/bintrail-pg/flashback_beacon_integration_test.go
@@ -1,0 +1,57 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/telemetry/telemetrytest"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestIntegrationFlashbackDaemonWiringEmitsBeacon is the #1362 wiring guard
+// for `bintrail-pg flashback`, the PostgreSQL-wire time-travel daemon: it
+// drives the REAL runFlashback against the integration MySQL index (the
+// daemon pings and migrates the index before it listens, so this cannot be a
+// unit test; no live PostgreSQL is involved — the engine is index-only) and
+// passes only once a real daemon_beacon carrying "flashback" is delivered end
+// to end. Delete its `go tel.Client().RunDaemon(...)` line and this fails.
+func TestIntegrationFlashbackDaemonWiringEmitsBeacon(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	c, bodies := telemetrytest.CollectingClient(t)
+	defer tel.SetClientForTest(c)()
+
+	cfgPath := filepath.Join(t.TempDir(), "shim.yaml")
+	shimYAML := "tenants:\n  - mysql_user: app\n    mysql_password: secret\n"
+	if err := os.WriteFile(cfgPath, []byte(shimYAML), 0o600); err != nil {
+		t.Fatalf("write shim.yaml: %v", err)
+	}
+
+	origListen, origIndexDSN, origConfig := fbListen, fbIndexDSN, fbShimConfig
+	defer func() { fbListen, fbIndexDSN, fbShimConfig = origListen, origIndexDSN, origConfig }()
+	fbListen = "127.0.0.1:0"
+	fbIndexDSN = testutil.IntegrationDSN(dbName)
+	fbShimConfig = cfgPath
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	flashbackCmd.SetContext(ctx)
+
+	done := make(chan error, 1)
+	go func() { done <- runFlashback(flashbackCmd, nil) }()
+
+	telemetrytest.WaitForBeacon(t, bodies, "flashback")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("runFlashback did not return after cancel — daemon shutdown would hang")
+	}
+}

--- a/consoleapp/daemon_beacon_integration_test.go
+++ b/consoleapp/daemon_beacon_integration_test.go
@@ -8,25 +8,26 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dbtrail/dbtrail/internal/rotation"
 	"github.com/dbtrail/dbtrail/internal/telemetry/telemetrytest"
 	"github.com/dbtrail/dbtrail/internal/testutil"
 )
 
 // The #1362 wiring guards for BOTH `bintrail-console watch` run paths. Each
-// drives the real run function against the integration MySQL index and passes
-// only once a real daemon_beacon carrying "watch" is delivered end to end —
-// delete either path's `go tel.Client().RunDaemon(...)` line and the matching
-// test fails. Both paths connect to the index BEFORE the telemetry launch, so
-// these cannot be unit tests.
+// drives runWatch itself — the registered entrypoint, including its
+// preflight/init phases and the source-less vs source-ful dispatch — against
+// the integration MySQL index, and passes only once a real daemon_beacon
+// carrying "watch" is delivered end to end. Delete either path's
+// `go tel.Client().RunDaemon(...)` line and the matching test fails. Both
+// paths connect to the index BEFORE the telemetry launch, so these cannot be
+// unit tests.
 
-// watchWiringSetup prepares the shared pieces: a real index DB, cleared env,
-// the collecting client injected into the hook, and saved/restored watch
+// watchWiringSetup prepares the shared pieces: a real (empty) index database
+// — runWatch's own init phase creates the tables, as in production — cleared
+// env, the collecting client injected into the hook, and saved/restored watch
 // flag globals.
 func watchWiringSetup(t *testing.T) (bodies func() []string) {
 	t.Helper()
-	db, dbName := testutil.CreateTestDB(t)
-	testutil.InitIndexTables(t, db)
+	_, dbName := testutil.CreateTestDB(t)
 
 	c, collected := telemetrytest.CollectingClient(t)
 	restoreClient := tel.SetClientForTest(c)
@@ -47,14 +48,6 @@ func watchWiringSetup(t *testing.T) (bodies func() []string) {
 	upConsoleListen = "127.0.0.1:0"
 	upConsoleToken = "wiring-test-token"
 	upConsoleServersFile = filepath.Join(t.TempDir(), "servers.yaml")
-
-	// runWatch normally parses this before dispatching to the run path under
-	// test; mirror it with the flag defaults.
-	var err error
-	upRotationCfg, err = rotation.ParseSettings(upRotateRetain, upRotateInterval, upRotateAddFuture, false)
-	if err != nil {
-		t.Fatalf("parse default rotation settings: %v", err)
-	}
 	return collected
 }
 
@@ -66,7 +59,7 @@ func TestIntegrationWatchConsoleOnlyDaemonWiringEmitsBeacon(t *testing.T) {
 	watchCmd.SetContext(ctx)
 
 	done := make(chan error, 1)
-	go func() { done <- runUpConsoleOnly(watchCmd) }()
+	go func() { done <- runWatch(watchCmd, nil) }()
 
 	telemetrytest.WaitForBeacon(t, bodies, "watch")
 
@@ -74,10 +67,10 @@ func TestIntegrationWatchConsoleOnlyDaemonWiringEmitsBeacon(t *testing.T) {
 	select {
 	case err := <-done:
 		if err != nil {
-			t.Errorf("runUpConsoleOnly returned an error on clean shutdown: %v", err)
+			t.Errorf("runWatch returned an error on clean shutdown: %v", err)
 		}
 	case <-time.After(60 * time.Second):
-		t.Fatal("runUpConsoleOnly did not return after cancel — daemon shutdown would hang")
+		t.Fatal("runWatch did not return after cancel — daemon shutdown would hang")
 	}
 }
 
@@ -85,22 +78,25 @@ func TestIntegrationWatchConsoleOnlyDaemonWiringEmitsBeacon(t *testing.T) {
 // path. The source DSN points at a hanging TCP endpoint so the main stream
 // blocks in its source dial — the daemon stays alive past the shortened tick
 // regardless of the test host's binlog configuration, and severing the
-// endpoint lets the stream fail out and the daemon drain.
+// endpoint lets the stream fail out and the daemon drain. The preflight is
+// skipped the way an operator would (--skip-doctor): doctor would block on
+// the deliberately-unresponsive source.
 func TestIntegrationWatchStreamDaemonWiringEmitsBeacon(t *testing.T) {
 	bodies := watchWiringSetup(t)
 
 	addr, sever := telemetrytest.HangingTCPAddr(t)
 	upSourceDSN = "root:x@tcp(" + addr + ")/ignored"
-	origServerID := upServerID
-	t.Cleanup(func() { upServerID = origServerID })
+	origServerID, origSkipDoctor := upServerID, upSkipDoctor
+	t.Cleanup(func() { upServerID, upSkipDoctor = origServerID, origSkipDoctor })
 	upServerID = 54321
+	upSkipDoctor = true
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	watchCmd.SetContext(ctx)
 
 	done := make(chan error, 1)
-	go func() { done <- runUpStreamWithConsole(watchCmd, nil) }()
+	go func() { done <- runWatch(watchCmd, nil) }()
 
 	telemetrytest.WaitForBeacon(t, bodies, "watch")
 
@@ -109,6 +105,6 @@ func TestIntegrationWatchStreamDaemonWiringEmitsBeacon(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(60 * time.Second):
-		t.Fatal("runUpStreamWithConsole did not return after cancel — daemon shutdown would hang")
+		t.Fatal("runWatch did not return after cancel — daemon shutdown would hang")
 	}
 }

--- a/consoleapp/daemon_beacon_integration_test.go
+++ b/consoleapp/daemon_beacon_integration_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+
+package consoleapp
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/rotation"
+	"github.com/dbtrail/dbtrail/internal/telemetry/telemetrytest"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// The #1362 wiring guards for BOTH `bintrail-console watch` run paths. Each
+// drives the real run function against the integration MySQL index and passes
+// only once a real daemon_beacon carrying "watch" is delivered end to end —
+// delete either path's `go tel.Client().RunDaemon(...)` line and the matching
+// test fails. Both paths connect to the index BEFORE the telemetry launch, so
+// these cannot be unit tests.
+
+// watchWiringSetup prepares the shared pieces: a real index DB, cleared env,
+// the collecting client injected into the hook, and saved/restored watch
+// flag globals.
+func watchWiringSetup(t *testing.T) (bodies func() []string) {
+	t.Helper()
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	c, collected := telemetrytest.CollectingClient(t)
+	restoreClient := tel.SetClientForTest(c)
+	t.Cleanup(restoreClient)
+	clearConsoleEnv(t)
+
+	origIndex, origSource := upIndexDSN, upSourceDSN
+	origListen, origToken, origServers := upConsoleListen, upConsoleToken, upConsoleServersFile
+	origRotation := upRotationCfg
+	t.Cleanup(func() {
+		upIndexDSN, upSourceDSN = origIndex, origSource
+		upConsoleListen, upConsoleToken, upConsoleServersFile = origListen, origToken, origServers
+		upRotationCfg = origRotation
+	})
+
+	upIndexDSN = testutil.IntegrationDSN(dbName)
+	upSourceDSN = ""
+	upConsoleListen = "127.0.0.1:0"
+	upConsoleToken = "wiring-test-token"
+	upConsoleServersFile = filepath.Join(t.TempDir(), "servers.yaml")
+
+	// runWatch normally parses this before dispatching to the run path under
+	// test; mirror it with the flag defaults.
+	var err error
+	upRotationCfg, err = rotation.ParseSettings(upRotateRetain, upRotateInterval, upRotateAddFuture, false)
+	if err != nil {
+		t.Fatalf("parse default rotation settings: %v", err)
+	}
+	return collected
+}
+
+func TestIntegrationWatchConsoleOnlyDaemonWiringEmitsBeacon(t *testing.T) {
+	bodies := watchWiringSetup(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watchCmd.SetContext(ctx)
+
+	done := make(chan error, 1)
+	go func() { done <- runUpConsoleOnly(watchCmd) }()
+
+	telemetrytest.WaitForBeacon(t, bodies, "watch")
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("runUpConsoleOnly returned an error on clean shutdown: %v", err)
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("runUpConsoleOnly did not return after cancel — daemon shutdown would hang")
+	}
+}
+
+// TestIntegrationWatchStreamDaemonWiringEmitsBeacon covers the source-ful
+// path. The source DSN points at a hanging TCP endpoint so the main stream
+// blocks in its source dial — the daemon stays alive past the shortened tick
+// regardless of the test host's binlog configuration, and severing the
+// endpoint lets the stream fail out and the daemon drain.
+func TestIntegrationWatchStreamDaemonWiringEmitsBeacon(t *testing.T) {
+	bodies := watchWiringSetup(t)
+
+	addr, sever := telemetrytest.HangingTCPAddr(t)
+	upSourceDSN = "root:x@tcp(" + addr + ")/ignored"
+	origServerID := upServerID
+	t.Cleanup(func() { upServerID = origServerID })
+	upServerID = 54321
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watchCmd.SetContext(ctx)
+
+	done := make(chan error, 1)
+	go func() { done <- runUpStreamWithConsole(watchCmd, nil) }()
+
+	telemetrytest.WaitForBeacon(t, bodies, "watch")
+
+	cancel()
+	sever()
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatal("runUpStreamWithConsole did not return after cancel — daemon shutdown would hang")
+	}
+}

--- a/consoleapp/daemon_beacon_test.go
+++ b/consoleapp/daemon_beacon_test.go
@@ -1,0 +1,95 @@
+package consoleapp
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/telemetry/telemetrytest"
+)
+
+// clearConsoleEnv pins every environment variable the serve/watch env
+// fallbacks read to empty (empty means "unset" to those fallbacks, and a
+// present-but-empty var also stops the env-file loader from filling it), so a
+// developer shell or ~/.config/bintrail/config.env cannot steer a wiring
+// test. HOME is pointed at a temp dir for the same reason — the default
+// registry/auth paths live under it.
+func clearConsoleEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	for _, v := range []string{
+		"BINTRAIL_INDEX_DSN",
+		"BINTRAIL_CONSOLE_LISTEN", "BINTRAIL_CONSOLE_TOKEN",
+		"BINTRAIL_CONSOLE_BASELINE_DIR", "BINTRAIL_CONSOLE_BASELINE_S3",
+		"BINTRAIL_CONSOLE_BASELINE_RETAIN", "BINTRAIL_BASELINE_REFRESH_INTERVAL",
+		"BINTRAIL_CONSOLE_SERVERS", "BINTRAIL_CONSOLE_AUTH",
+		"BINTRAIL_CONSOLE_TLS_CERT", "BINTRAIL_CONSOLE_TLS_KEY",
+		"BINTRAIL_CONSOLE_ALLOWED_HOSTS", "BINTRAIL_CONSOLE_ALLOW_SETUP",
+		"BINTRAIL_CONSOLE_FLASHBACK_LISTEN", "BINTRAIL_CONSOLE_ARCHIVE_STAGING",
+		"BINTRAIL_CONSOLE_BASELINE_TRIGGER", "BINTRAIL_CONSOLE_BASELINE_STAGING",
+		"BINTRAIL_CONSOLE_BASELINE_POINT_CONSISTENT",
+		"BINTRAIL_CONSOLE_VERIFY_TRIGGER", "BINTRAIL_CONSOLE_VERIFY_INTERVAL",
+		"BINTRAIL_CONSOLE_VERIFY_TABLES", "BINTRAIL_CONSOLE_NOTIFY_WEBHOOK",
+	} {
+		t.Setenv(v, "")
+	}
+}
+
+// TestServeDaemonWiringEmitsBeacon is the #1362 wiring guard for
+// `bintrail-console serve`: it drives the REAL runServe against a
+// registry-only configuration (registry servers connect lazily, so no MySQL
+// is needed) and passes only once a real daemon_beacon carrying "serve" is
+// delivered end to end. Delete serve's `go tel.Client().RunDaemon(...)` line
+// and this fails — the loop itself is pinned by internal/telemetry's tests.
+func TestServeDaemonWiringEmitsBeacon(t *testing.T) {
+	c, bodies := telemetrytest.CollectingClient(t)
+	defer tel.SetClientForTest(c)()
+	clearConsoleEnv(t)
+
+	serversPath := filepath.Join(t.TempDir(), "servers.yaml")
+	reg, err := console.LoadRegistry(serversPath)
+	if err != nil {
+		t.Fatalf("load empty registry: %v", err)
+	}
+	if _, err := reg.Add(console.ServerEntry{
+		Name: "wiring-test",
+		DSN:  "root:x@tcp(127.0.0.1:9)/bintrail_index", // lazy — never dialed
+	}); err != nil {
+		t.Fatalf("seed registry: %v", err)
+	}
+
+	origIndex, origListen, origToken := conIndexDSN, conListen, conToken
+	origServers, origProfile := conServersFile, conProfile
+	origBaselineDir, origBaselineS3 := conBaselineDir, conBaselineS3
+	defer func() {
+		conIndexDSN, conListen, conToken = origIndex, origListen, origToken
+		conServersFile, conProfile = origServers, origProfile
+		conBaselineDir, conBaselineS3 = origBaselineDir, origBaselineS3
+	}()
+	conIndexDSN = ""
+	conListen = "127.0.0.1:0"
+	conToken = "wiring-test-token"
+	conServersFile = serversPath
+	conProfile, conBaselineDir, conBaselineS3 = "", "", ""
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	serveCmd.SetContext(ctx)
+
+	done := make(chan error, 1)
+	go func() { done <- runServe(serveCmd, nil) }()
+
+	telemetrytest.WaitForBeacon(t, bodies, "serve")
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("runServe returned an error on clean shutdown: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("runServe did not return after cancel — daemon shutdown would hang")
+	}
+}

--- a/consoleapp/serve.go
+++ b/consoleapp/serve.go
@@ -254,6 +254,14 @@ func runServe(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	// Usage telemetry for a months-lived process (#1362): Init's drain runs
+	// once, at startup, so without this loop a daemon's beacons would spool
+	// and age out undelivered. Own goroutine — never on a request path. serve
+	// is as long-lived as `watch`; a read-only console counts toward daily
+	// active daemons like any other daemon, and the beacon carries nothing a
+	// command event doesn't (no run_id, one per UTC day).
+	go tel.Client().RunDaemon(ctx, cmd.Name())
+
 	printConsoleBanner(srv, "Bintrail console (read-only) is running. Open:")
 	slog.Info("console listening", "addr", conListen, "no_archive", conNoArchive || conProfile != "")
 

--- a/consoleapp/serve.go
+++ b/consoleapp/serve.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/indexer"
 	"github.com/dbtrail/dbtrail/internal/query"
+	"github.com/dbtrail/dbtrail/internal/telemetry"
 )
 
 var serveCmd = &cobra.Command{
@@ -221,9 +222,14 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	srv, err := console.New(console.Config{
-		DB:            db,
-		DBName:        dbName,
-		BootDSN:       conIndexDSN,
+		DB:      db,
+		DBName:  dbName,
+		BootDSN: conIndexDSN,
+		// The consent-only adapter (serveTelemetry): serve beacons (#1362), so
+		// the UI opt-out toggle must stop THIS running process and the state
+		// endpoint must report the live decision — while console actions stay
+		// unrecorded, per TELEMETRY.md.
+		Telemetry:     serveTelemetry{},
 		Registry:      registry,
 		Listen:        conListen,
 		Token:         conToken,
@@ -298,3 +304,23 @@ func printConsoleBanner(srv *console.Server, headline string) {
 		fmt.Fprintln(os.Stderr)
 	}
 }
+
+// serveTelemetry adapts the process's live telemetry client for the read-only
+// console. It delegates the CONSENT surface — Enabled, Decision,
+// SetRuntimeConsent — so the UI opt-out toggle stops a running serve's daily
+// beacon immediately (not just on the next start), and so the telemetry state
+// endpoint reports the LIVE decision, including a --telemetry launch flag
+// (which the POST handler's 409 override guard keys on). Without this, serve
+// would keep beaconing after the operator opted out, while GET /api/telemetry
+// claimed reporting was off.
+//
+// It deliberately does NOT delegate RecordDaemonCommand: TELEMETRY.md
+// promises the read-only serve records no console-action events, so actions
+// return a nil *Span (inert by contract). Wiring tel.Client() directly, the
+// way `watch` does, would silently break that promise.
+type serveTelemetry struct{}
+
+func (serveTelemetry) Enabled() bool                              { return tel.Client().Enabled() }
+func (serveTelemetry) Decision() telemetry.Decision               { return tel.Client().Decision() }
+func (serveTelemetry) SetRuntimeConsent(enabled bool)             { tel.Client().SetRuntimeConsent(enabled) }
+func (serveTelemetry) RecordDaemonCommand(string) *telemetry.Span { return nil }

--- a/consoleapp/serve_telemetry_test.go
+++ b/consoleapp/serve_telemetry_test.go
@@ -1,0 +1,162 @@
+package consoleapp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/console"
+	"github.com/dbtrail/dbtrail/internal/telemetry/telemetrytest"
+)
+
+// TestServeTelemetryOptOutStopsBeacons pins the consent surface serve's
+// beacon rides on (#1362 review), through the REAL runServe: serve wires the
+// consent-only adapter (serveTelemetry) into the console, so the UI opt-out
+// must (a) flip the LIVE client — the very next tick delivers nothing, not
+// just the next start — and (b) never let GET /api/telemetry claim reporting
+// is off while the client is enabled and beaconing (the old nil-controller
+// fallback did exactly that). Delete runServe's `Telemetry:` wiring or break
+// the adapter's delegation and this fails.
+func TestServeTelemetryOptOutStopsBeacons(t *testing.T) {
+	c, bodies := telemetrytest.CollectingClient(t)
+	defer tel.SetClientForTest(c)()
+	// HOME→temp (inside): the opt-out handler persists the machine-wide
+	// choice and purges the default spool under the config dir.
+	clearConsoleEnv(t)
+
+	serversPath := filepath.Join(t.TempDir(), "servers.yaml")
+	reg, err := console.LoadRegistry(serversPath)
+	if err != nil {
+		t.Fatalf("load empty registry: %v", err)
+	}
+	if _, err := reg.Add(console.ServerEntry{
+		Name: "consent-test",
+		DSN:  "root:x@tcp(127.0.0.1:9)/bintrail_index", // lazy — never dialed
+	}); err != nil {
+		t.Fatalf("seed registry: %v", err)
+	}
+
+	// Reserve a port so the test can talk to the daemon runServe starts
+	// (":0" would leave the bound port unknowable from out here).
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	listen := l.Addr().String()
+	l.Close()
+	baseURL := "http://" + listen
+
+	origIndex, origListen, origToken := conIndexDSN, conListen, conToken
+	origServers, origProfile := conServersFile, conProfile
+	origBaselineDir, origBaselineS3 := conBaselineDir, conBaselineS3
+	defer func() {
+		conIndexDSN, conListen, conToken = origIndex, origListen, origToken
+		conServersFile, conProfile = origServers, origProfile
+		conBaselineDir, conBaselineS3 = origBaselineDir, origBaselineS3
+	}()
+	conIndexDSN = ""
+	conListen = listen
+	conToken = "consent-test-token"
+	conServersFile = serversPath
+	conProfile, conBaselineDir, conBaselineS3 = "", "", ""
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	serveCmd.SetContext(ctx)
+
+	done := make(chan error, 1)
+	go func() { done <- runServe(serveCmd, nil) }()
+	defer func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(30 * time.Second):
+			t.Error("runServe did not return after cancel")
+		}
+	}()
+
+	do := func(method, body string) (*http.Response, error) {
+		var buf *bytes.Buffer
+		if body == "" {
+			buf = bytes.NewBuffer(nil)
+		} else {
+			buf = bytes.NewBufferString(body)
+		}
+		req, err := http.NewRequest(method, baseURL+"/api/telemetry", buf)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer consent-test-token")
+		return http.DefaultClient.Do(req)
+	}
+
+	type stateDTO struct {
+		Reporting bool `json:"reporting"`
+		Consent   bool `json:"consent"`
+	}
+	getState := func() stateDTO {
+		t.Helper()
+		resp, err := do(http.MethodGet, "")
+		if err != nil {
+			t.Fatalf("GET /api/telemetry: %v", err)
+		}
+		defer resp.Body.Close()
+		var st stateDTO
+		if err := json.NewDecoder(resp.Body).Decode(&st); err != nil {
+			t.Fatalf("decode state: %v", err)
+		}
+		return st
+	}
+
+	// Wait for the daemon to serve.
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		if resp, err := do(http.MethodGet, ""); err == nil {
+			resp.Body.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("serve never started answering /api/telemetry")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// While the live client is enabled, the state endpoint must say so — the
+	// nil-controller fallback used to report reporting:false while the loop
+	// delivered beacons.
+	if st := getState(); !st.Reporting {
+		t.Fatalf("state claims reporting:false while the live client is enabled and beaconing: %+v", st)
+	}
+
+	// Prove the loop is live, then opt out through the console.
+	telemetrytest.WaitForBeacon(t, bodies, "serve")
+
+	resp, err := do(http.MethodPost, `{"enabled":false}`)
+	if err != nil {
+		t.Fatalf("POST /api/telemetry: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /api/telemetry: status %d, want 200", resp.StatusCode)
+	}
+	if c.Enabled() {
+		t.Fatal("opt-out did not reach the live client — serve would keep beaconing after the operator said no")
+	}
+
+	// The next ticks must deliver nothing new. Contention can only mean FEWER
+	// ticks fire, so this cannot false-fail.
+	delivered := len(bodies())
+	time.Sleep(300 * time.Millisecond) // ~12 shortened ticks
+	if n := len(bodies()); n != delivered {
+		t.Fatalf("beacons kept flowing after opt-out: %d deliveries grew to %d", delivered, n)
+	}
+
+	if st := getState(); st.Reporting || st.Consent {
+		t.Fatalf("state does not reflect the opt-out: %+v", st)
+	}
+}

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -159,10 +159,12 @@ no cookie, and no account identifier**.
 
 ### Daemons
 
-Long-running commands (`stream`, `agent`, `up`, `watch`, `bintrail-console
-serve`, `bintrail shim`) send at most **one beacon per UTC day**, and the
-first only after they have been running for an hour. A finer cadence would reconstruct your uptime and maintenance windows; a
-beacon at startup would mean a crash-looping daemon emitted one per restart.
+Long-running commands (`stream`, `agent`, `up`, `watch`,
+`bintrail-console serve`, `bintrail shim`, `bintrail-pg stream`,
+`bintrail-pg flashback`) send at most **one beacon per UTC day**, and the
+first only after they have been running for an hour. A finer cadence would
+reconstruct your uptime and maintenance windows; a beacon at startup would
+mean a crash-looping daemon emitted one per restart.
 
 Beacons carry no `run_id`.
 
@@ -240,7 +242,7 @@ binary — cannot emit telemetry.
 | Surface | Reports? | |
 |---|---|---|
 | `bintrail`, `bintrail-pg` commands | Yes, by default | |
-| Daemons (`stream`, `agent`, `up`, `watch`, `bintrail-console serve`, `bintrail shim`) | Yes, one beacon per day | `watch` also records the console actions below |
+| Daemons (`stream`, `agent`, `up`, `watch`, `bintrail-console serve`, `bintrail shim`, `bintrail-pg stream`, `bintrail-pg flashback`) | Yes, one beacon per day | `watch` also records the console actions below |
 | **Demo image** (`ghcr.io/dbtrail/bintrail-demo`) | **Never** | Hard-disabled in the image and in its entrypoint, and asserted by its smoke test. An evaluation image must not phone home from a laptop |
 | **MCP server** (`bintrail-mcp`) | **Never** | Invoked by an AI agent inside an editor or chat session — no human is present to consent and no terminal exists for a notice. It cannot link the telemetry package at all |
 | **Web console UI** (under `watch`) | A deliberate-action event, server-side | See below. No JavaScript beacon, ever — the frontend has no third-party dependencies and makes no telemetry request; the event is recorded by the server it already talks to |
@@ -347,6 +349,7 @@ statements of fact rather than intent.
 | `TestRootHookIsNotShadowed` (×3 binaries) | Instrumentation cannot be silently lost from part of the command tree |
 | `TestMCPServerIsTelemetryFree` | The MCP server cannot link the telemetry package |
 | `TestRunDaemonDoesNotBeaconBeforeFirstTick` | A crash-looping daemon emits nothing |
+| Per-daemon wiring guards (`*DaemonWiringEmitsBeacon`, one per call site across `stream`, `agent`, `up`, both `watch` paths, `serve`, `shim`, `bintrail-pg stream`, `bintrail-pg flashback`) | Every daemon this document says beacons actually starts the beacon loop — each test drives the real run function and fails if its launch line is deleted |
 | `TestBeaconCarriesNoRunID` | Daemon beacons carry no identifier |
 | `TestRecordDaemonCommandOmitsRunID` | A console action inside a daemon records no `run_id` — no per-install timeline |
 | `TestRecordActionUsesFixedName` | The console action name is a fixed constant, never derived from the request |

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -159,9 +159,9 @@ no cookie, and no account identifier**.
 
 ### Daemons
 
-Long-running commands (`stream`, `agent`, `up`, `watch`) send at most **one
-beacon per UTC day**, and the first only after they have been running for an
-hour. A finer cadence would reconstruct your uptime and maintenance windows; a
+Long-running commands (`stream`, `agent`, `up`, `watch`, `bintrail-console
+serve`, `bintrail shim`) send at most **one beacon per UTC day**, and the
+first only after they have been running for an hour. A finer cadence would reconstruct your uptime and maintenance windows; a
 beacon at startup would mean a crash-looping daemon emitted one per restart.
 
 Beacons carry no `run_id`.
@@ -240,8 +240,7 @@ binary — cannot emit telemetry.
 | Surface | Reports? | |
 |---|---|---|
 | `bintrail`, `bintrail-pg` commands | Yes, by default | |
-| Daemons (`stream`, `agent`, `up`, `watch`) | Yes, one beacon per day | `watch` also records the console actions below |
-| `bintrail-console serve`, `bintrail shim` | Command events only | They record like any command; they do not beacon |
+| Daemons (`stream`, `agent`, `up`, `watch`, `bintrail-console serve`, `bintrail shim`) | Yes, one beacon per day | `watch` also records the console actions below |
 | **Demo image** (`ghcr.io/dbtrail/bintrail-demo`) | **Never** | Hard-disabled in the image and in its entrypoint, and asserted by its smoke test. An evaluation image must not phone home from a laptop |
 | **MCP server** (`bintrail-mcp`) | **Never** | Invoked by an AI agent inside an editor or chat session — no human is present to consent and no terminal exists for a notice. It cannot link the telemetry package at all |
 | **Web console UI** (under `watch`) | A deliberate-action event, server-side | See below. No JavaScript beacon, ever — the frontend has no third-party dependencies and makes no telemetry request; the event is recorded by the server it already talks to |
@@ -261,8 +260,10 @@ value can reach the wire; the closed allowlist still applies. Crucially, because
 the console lives in a months-long daemon that holds a single `run_id`, these
 events are recorded **without any `run_id`** (like beacons), so they cannot be
 stitched into a per-install activity timeline. They are day-granularity usage
-counts, nothing more. The read-only `bintrail-console serve` wires no telemetry
-client and records no console actions.
+counts, nothing more. The read-only `bintrail-console serve` wires no
+console-action client and records none of these events; like every other
+long-running daemon it still emits the daily liveness beacon, which carries
+nothing a command event doesn't.
 
 ## Cloned machines — the honest caveat
 

--- a/internal/cli/shim.go
+++ b/internal/cli/shim.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"net"
-	"os"
 	"os/signal"
 	"strings"
 	"sync"
@@ -279,10 +278,12 @@ func runShim(cmd *cobra.Command, args []string) error {
 		"tenants_with_default_schema", len(userSchemas),
 	)
 
-	// Derive from the cobra context (context.Background under a normal
-	// Execute) so an embedding caller — or a wiring test — can stop the
-	// daemon by cancelling it, exactly like every other long-running command.
-	ctx, cancel := context.WithCancel(cmd.Context())
+	// SIGINT/SIGTERM or parent-context cancellation (an embedding caller, a
+	// wiring test) → ctx done → close listener → accept loop returns. The
+	// signal-bound context is the sibling daemons' pattern (`serve`,
+	// bintrail-pg flashback), and NotifyContext un-registers the handler when
+	// runShim returns.
+	ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
 	// Usage telemetry for a months-lived process (#1362): Init's drain runs
@@ -293,18 +294,9 @@ func runShim(cmd *cobra.Command, args []string) error {
 	// hook publishes the client it resolved at Start.
 	go processClient.RunDaemon(ctx, cmd.Name())
 
-	// SIGINT / SIGTERM → cancel ctx → close listener → accept loop returns.
-	// Parent-context cancellation closes the listener the same way, or a
-	// cancelled daemon would sit blocked in Accept forever.
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		select {
-		case <-sigs:
-			slog.Info("shim shutting down")
-			cancel()
-		case <-ctx.Done():
-		}
+		<-ctx.Done()
+		slog.Info("shim shutting down")
 		listener.Close()
 	}()
 

--- a/internal/cli/shim.go
+++ b/internal/cli/shim.go
@@ -279,16 +279,32 @@ func runShim(cmd *cobra.Command, args []string) error {
 		"tenants_with_default_schema", len(userSchemas),
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	// Derive from the cobra context (context.Background under a normal
+	// Execute) so an embedding caller — or a wiring test — can stop the
+	// daemon by cancelling it, exactly like every other long-running command.
+	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
+	// Usage telemetry for a months-lived process (#1362): Init's drain runs
+	// once, at startup, so without this loop a daemon's beacons would spool
+	// and age out undelivered. Own goroutine — never on a client connection's
+	// path. The client arrives through the package seam (processClient): shim
+	// is the one daemon implemented in this shared package, and each binary's
+	// hook publishes the client it resolved at Start.
+	go processClient.RunDaemon(ctx, cmd.Name())
+
 	// SIGINT / SIGTERM → cancel ctx → close listener → accept loop returns.
+	// Parent-context cancellation closes the listener the same way, or a
+	// cancelled daemon would sit blocked in Accept forever.
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		<-sigs
-		slog.Info("shim shutting down")
-		cancel()
+		select {
+		case <-sigs:
+			slog.Info("shim shutting down")
+			cancel()
+		case <-ctx.Done():
+		}
 		listener.Close()
 	}()
 

--- a/internal/cli/shim_beacon_integration_test.go
+++ b/internal/cli/shim_beacon_integration_test.go
@@ -1,0 +1,69 @@
+//go:build integration
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/telemetry/telemetrytest"
+	"github.com/dbtrail/dbtrail/internal/testutil"
+)
+
+// TestIntegrationShimDaemonWiringEmitsBeacon is the #1362 wiring guard for
+// `bintrail shim`: it drives the REAL runShim against the integration MySQL
+// index (the shim pings and migrates the index before it ever listens, so
+// this cannot be a unit test) and passes only once a real daemon_beacon
+// carrying "shim" is delivered end to end. Delete shim's
+// `go processClient.RunDaemon(...)` line and this fails — the loop itself is
+// pinned by internal/telemetry's own daemon tests.
+//
+// The client is injected through the same package seam production uses: the
+// binary's TelemetryHook publishes its resolved client via SetClientForTest /
+// Start, and runShim picks it up from processClient.
+func TestIntegrationShimDaemonWiringEmitsBeacon(t *testing.T) {
+	db, dbName := testutil.CreateTestDB(t)
+	testutil.InitIndexTables(t, db)
+
+	c, bodies := telemetrytest.CollectingClient(t)
+	defer (&TelemetryHook{}).SetClientForTest(c)()
+
+	cfgPath := filepath.Join(t.TempDir(), "shim.yaml")
+	shimYAML := "tenants:\n  - mysql_user: app\n    mysql_password: secret\n"
+	if err := os.WriteFile(cfgPath, []byte(shimYAML), 0o600); err != nil {
+		t.Fatalf("write shim.yaml: %v", err)
+	}
+
+	origListen, origIndexDSN := shListen, shIndexDSN
+	origConfig, origNoArchive := shShimConfig, shNoArchive
+	defer func() {
+		shListen, shIndexDSN = origListen, origIndexDSN
+		shShimConfig, shNoArchive = origConfig, origNoArchive
+	}()
+	shListen = "127.0.0.1:0"
+	shIndexDSN = testutil.IntegrationDSN(dbName)
+	shShimConfig = cfgPath
+	shNoArchive = true
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	shimCmd.SetContext(ctx)
+
+	done := make(chan error, 1)
+	go func() { done <- runShim(shimCmd, nil) }()
+
+	telemetrytest.WaitForBeacon(t, bodies, "shim")
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("runShim returned an error on clean shutdown: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("runShim did not return after cancel — daemon shutdown would hang")
+	}
+}

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -35,6 +35,15 @@ type TelemetryHook struct {
 	span   *telemetry.Span
 }
 
+// processClient is the telemetry client Start resolved for THIS process.
+// Published at package level because long-running commands implemented in this
+// package (shim) need the daemon beacon loop (telemetry.Client.RunDaemon) but
+// cannot reach the binary's hook variable — cliapp, consoleapp and
+// cmd/bintrail-pg each hold their own. One process, one Start, one client, so
+// a package-level publication is exact. Nil (an exempt command, or Start never
+// ran) is safe: every telemetry.Client method tolerates a nil receiver.
+var processClient *telemetry.Client
+
 // Start resolves consent and begins recording the command about to run, unless
 // the command is one of the exempt trees (see uninstrumented).
 func (h *TelemetryHook) Start(cmd *cobra.Command) {
@@ -42,7 +51,20 @@ func (h *TelemetryHook) Start(cmd *cobra.Command) {
 		return
 	}
 	h.client = telemetry.Init(telemetry.Config{Flag: telemetryFlagValue(cmd)})
+	processClient = h.client
 	h.span = h.client.RecordCommand(commandPath(cmd))
+}
+
+// SetClientForTest injects a resolved client into the hook and the package
+// seam, returning a restore func. Test support ONLY (the ext.ResetForTest
+// pattern): the per-daemon wiring tests (#1362) drive a REAL daemon run
+// function — runStream, runServe, runShim, … — and need an observable client
+// in place of the one Start would resolve from the live environment.
+// Production code resolves the client exclusively through Start.
+func (h *TelemetryHook) SetClientForTest(c *telemetry.Client) (restore func()) {
+	prevHook, prevProcess := h.client, processClient
+	h.client, processClient = c, c
+	return func() { h.client, processClient = prevHook, prevProcess }
 }
 
 // uninstrumented reports whether cmd belongs to a tree that must not be

--- a/internal/cli/telemetry_seam_test.go
+++ b/internal/cli/telemetry_seam_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestStartPublishesProcessClient guards the one production hop between a
+// binary's TelemetryHook and the daemon commands implemented in this package:
+// Start must publish the client it resolved into the processClient seam, or
+// shim's (and any future in-package daemon's) RunDaemon launch would run on a
+// nil client forever — beacons silently gone, nothing failing. The wiring
+// tests inject via SetClientForTest and so would never notice.
+//
+// It also fences the #1061 hazard this file's own comment names: a subcommand
+// that grows its own PersistentPreRunE stops Start from running at all, and
+// with it this publication.
+func TestStartPublishesProcessClient(t *testing.T) {
+	prevProcess := processClient
+	t.Cleanup(func() { processClient = prevProcess })
+	processClient = nil
+
+	root := &cobra.Command{Use: "bintrail"}
+	root.PersistentFlags().String("telemetry", "", "")
+	child := &cobra.Command{Use: "shim"}
+	root.AddCommand(child)
+
+	var h TelemetryHook
+	h.Start(child)
+
+	if h.Client() == nil {
+		t.Fatal("Start resolved no client")
+	}
+	if processClient != h.Client() {
+		t.Fatal("Start did not publish its client to processClient — shim's daemon telemetry loop would never see it")
+	}
+}

--- a/internal/console/server.go
+++ b/internal/console/server.go
@@ -506,8 +506,10 @@ func (s *Server) buildHandler() http.Handler {
 	api.HandleFunc("GET /api/storage", s.handleStorageInfo)
 	api.HandleFunc("GET /api/profiles", s.handleProfiles)
 	// Usage-telemetry opt-out: read the machine-wide state, and toggle it (a
-	// local config write, not a data write). Available on any console; the UI
-	// surfaces it on the watch daemon that actually beacons.
+	// local config write, not a data write). Every console daemon beacons
+	// (#1362), so every embedding binary wires a live TelemetryController —
+	// watch the full client, serve a consent-only adapter — and the toggle
+	// stops the running process's beacons immediately.
 	api.HandleFunc("GET /api/telemetry", s.handleTelemetryGet)
 	api.HandleFunc("POST /api/telemetry", s.handleTelemetrySet)
 	// Server management: CRUD over the local registry file (never a DB write)

--- a/internal/console/telemetry_api.go
+++ b/internal/console/telemetry_api.go
@@ -9,11 +9,13 @@ import (
 	"github.com/dbtrail/dbtrail/internal/telemetry"
 )
 
-// TelemetryController is the live usage-telemetry client a long-running console
-// (`bintrail-console watch`) wires in, so the UI opt-out toggle takes effect on
-// the running process immediately instead of only on the next start. Satisfied
-// by *telemetry.Client. nil on the read-only console, where the toggle still
-// persists the machine-wide choice to the consent file.
+// TelemetryController is the live usage-telemetry surface a long-running
+// console wires in, so the UI opt-out toggle takes effect on the running
+// process immediately instead of only on the next start. `watch` wires
+// *telemetry.Client directly; the read-only `serve` wires a consent-only
+// adapter whose RecordDaemonCommand returns nil, because it beacons (#1362)
+// but must not record console actions. nil means no live process to control —
+// the toggle still persists the machine-wide choice to the consent file.
 type TelemetryController interface {
 	Enabled() bool
 	Decision() telemetry.Decision
@@ -30,8 +32,9 @@ type TelemetryController interface {
 // ("recover", "reconstruct", …) — never derived from the request, path params,
 // query, or body — so nothing about the operator's data (schemas, tables, PKs,
 // row values) can reach the wire. A 5xx becomes an internal-error event; every
-// other status is a plain run. No telemetry client (the read-only `serve`
-// binary) means the handler is called untouched.
+// other status is a plain run. No telemetry client — or serve's consent-only
+// controller, whose RecordDaemonCommand returns a nil (inert) span — means
+// the handler runs effectively untouched.
 func (s *Server) recordAction(action string, h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if s.telemetry == nil {

--- a/internal/telemetry/consent.go
+++ b/internal/telemetry/consent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 )
@@ -42,6 +43,11 @@ var ciEnvVars = []string{
 	"CI", "GITHUB_ACTIONS", "TF_BUILD", "TRAVIS",
 	"CIRCLECI", "JENKINS_URL", "BUILDKITE", "GITLAB_CI",
 }
+
+// CIEnvVars returns a copy of the CI marker variables IsCI checks. Exposed for
+// the telemetrytest helpers, which neutralize them so the daemon wiring tests
+// behave identically on a laptop and in CI.
+func CIEnvVars() []string { return slices.Clone(ciEnvVars) }
 
 // IsCI reports whether the process looks like it is running in CI.
 func IsCI() bool {

--- a/internal/telemetry/daemon_test.go
+++ b/internal/telemetry/daemon_test.go
@@ -15,9 +15,7 @@ import (
 // withDaemonTick shortens the daemon loop for the duration of a test.
 func withDaemonTick(t *testing.T, d time.Duration) {
 	t.Helper()
-	prev := daemonTick
-	daemonTick = d
-	t.Cleanup(func() { daemonTick = prev })
+	t.Cleanup(ShortenDaemonTickForTest(d))
 }
 
 func TestRunDaemonStopsOnContextCancel(t *testing.T) {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -273,9 +273,24 @@ func (c *Client) drainOnce() {
 // accumulated. Beacons are capped at one per UTC day regardless, so this
 // governs delivery latency rather than beacon frequency.
 //
-// A var rather than a const so tests can shorten it; nothing in production
-// writes it.
-var daemonTick = time.Hour
+// Mutable so tests can shorten it; nothing in production writes it. Stored
+// atomically because the per-daemon WIRING tests (#1362) live in OTHER
+// packages and restore the tick while the RunDaemon goroutine their daemon
+// started may still be winding down — with a plain var that restore would be
+// a data race.
+var daemonTick atomic.Int64
+
+func init() { daemonTick.Store(int64(time.Hour)) }
+
+// ShortenDaemonTickForTest overrides the daemon loop's tick and returns a
+// restore func. Test support ONLY (the ext.ResetForTest pattern): it exists so
+// the per-daemon wiring tests in cliapp/consoleapp/cmd/bintrail-pg/internal/cli
+// can drive a REAL daemon run function and observe a beacon without waiting an
+// hour. Production code never calls it.
+func ShortenDaemonTickForTest(d time.Duration) (restore func()) {
+	prev := daemonTick.Swap(int64(d))
+	return func() { daemonTick.Store(prev) }
+}
 
 // RunDaemon keeps telemetry alive for a long-running process. Run it in its own
 // goroutine; it returns when ctx is done.
@@ -312,7 +327,7 @@ func (c *Client) RunDaemon(ctx context.Context, daemon string) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(daemonTick):
+		case <-time.After(time.Duration(daemonTick.Load())):
 		}
 		if !c.Enabled() {
 			continue // consent off right now; a runtime opt-in resumes us

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -305,12 +305,27 @@ func ShortenDaemonTickForTest(d time.Duration) (restore func()) {
 // beaconed on start would emit one per restart, bounded only by the spool cap.
 // Waiting an hour means a crash loop never beacons at all, and "alive for at
 // least an hour" is the more honest liveness signal anyway.
+//
+// One beacon per PROCESS: the daily cap lives on the Client and is blind to
+// the daemon name, so a process must run exactly ONE RunDaemon loop — a
+// second loop under a different name would race it for the single daily slot
+// and corrupt both series. That is why the supervised per-source streams
+// under `watch` deliberately do NOT beacon as "stream": the process already
+// beacons as "watch".
+//
+// Wired daemons (keep in sync with docs/TELEMETRY.md "Which surfaces
+// report"): stream, agent, up (delegates to runStream), watch (both run
+// paths), bintrail-console serve, bintrail shim, bintrail-pg stream, and
+// bintrail-pg flashback. A new long-running daemon must start this loop AND
+// add a wiring guard test (see internal/telemetry/telemetrytest) — nothing
+// fails on its own when the launch line is missing.
 func (c *Client) RunDaemon(ctx context.Context, daemon string) {
 	// Exit only when this build/environment can NEVER report — an inert build
 	// must not spin a ticker forever. A daemon that is merely consent-off keeps
 	// the loop so a runtime opt-in (the console toggle) resumes beaconing
 	// without a restart; Beacon and drainOnce no-op while consent is off.
 	if !c.canEverReport() {
+		debugf("daemon %q: telemetry can never report in this build/environment; loop not started", daemon)
 		return
 	}
 	defer func() {
@@ -332,8 +347,19 @@ func (c *Client) RunDaemon(ctx context.Context, daemon string) {
 		if !c.Enabled() {
 			continue // consent off right now; a runtime opt-in resumes us
 		}
-		c.Beacon(daemon)
-		c.drainOnce()
+		// Per-tick recovery: a panic in one tick's beacon or drain must cost
+		// that tick, not every future beacon of a months-lived process (the
+		// outer recover alone would end the loop for good, signalled only at
+		// debug level).
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					debugf("daemon telemetry tick panicked")
+				}
+			}()
+			c.Beacon(daemon)
+			c.drainOnce()
+		}()
 	}
 }
 

--- a/internal/telemetry/telemetrytest/telemetrytest.go
+++ b/internal/telemetry/telemetrytest/telemetrytest.go
@@ -1,0 +1,143 @@
+// Package telemetrytest provides shared helpers for the per-daemon telemetry
+// WIRING tests (#1362) — the guards that drive a REAL daemon run function
+// (runStream, runServe, runShim, …) and fail when that daemon's
+// `go client.RunDaemon(ctx, name)` line is deleted.
+//
+// The telemetry package's own tests already pin the loop itself (RunDaemon
+// beacons once per UTC day and drains what it spooled); what rots is the
+// one-line launch inside each daemon. These helpers make that launch cheap to
+// observe: an enabled client delivering to an in-process endpoint, a shortened
+// daemon tick, and a poll that only succeeds once a real `daemon_beacon`
+// carrying the daemon's command name has been delivered end to end.
+package telemetrytest
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dbtrail/dbtrail/internal/telemetry"
+)
+
+// ClearReportingEnv neutralizes every environment variable that could
+// suppress consent — DO_NOT_TRACK, BINTRAIL_TELEMETRY, and the CI markers —
+// so a wiring test behaves identically on a laptop and in CI. (These vars can
+// only ever turn telemetry OFF, so clearing them enables nothing beyond the
+// test client's own temp-dir consent default.)
+func ClearReportingEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv(telemetry.EnvVar, "")
+	for _, v := range telemetry.CIEnvVars() {
+		t.Setenv(v, "")
+	}
+}
+
+// CollectingClient returns an ENABLED telemetry client that spools to a temp
+// dir and delivers to an in-process endpoint, plus an accessor for every
+// NDJSON body delivered so far. It also shortens the daemon tick (restored on
+// cleanup) so a wired daemon's first beacon arrives within milliseconds of
+// RunDaemon starting instead of after an hour.
+func CollectingClient(t *testing.T) (c *telemetry.Client, bodies func() []string) {
+	t.Helper()
+	ClearReportingEnv(t)
+	t.Cleanup(telemetry.ShortenDaemonTickForTest(25 * time.Millisecond))
+
+	var mu sync.Mutex
+	var got []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		got = append(got, string(b))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	interactive := false
+	c = telemetry.Init(telemetry.Config{
+		Dir:         t.TempDir(),
+		Endpoint:    srv.URL,
+		Stderr:      io.Discard,
+		Interactive: &interactive,
+	})
+	if !c.Enabled() {
+		t.Fatal("test telemetry client is not enabled — the wiring test could never observe a beacon")
+	}
+	c.WaitStartupDrain()
+	return c, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.Clone(got)
+	}
+}
+
+// WaitForBeacon polls until a delivered payload carries a `daemon_beacon`
+// event for the given sanitized command name, failing the test after a
+// generous deadline. It can only pass if the daemon's run path started
+// telemetry.Client.RunDaemon with that name — delete the wiring line and this
+// fails.
+func WaitForBeacon(t *testing.T, bodies func() []string, command string) {
+	t.Helper()
+	wantType := `"event_type":"daemon_beacon"`
+	wantCmd := `"command":"` + command + `"`
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, b := range bodies() {
+			for line := range strings.SplitSeq(b, "\n") {
+				if strings.Contains(line, wantType) && strings.Contains(line, wantCmd) {
+					return
+				}
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("no daemon_beacon for command %q was delivered — the daemon does not start the telemetry loop (RunDaemon wiring deleted?); delivered payloads: %q",
+		command, bodies())
+}
+
+// HangingTCPAddr returns the host:port of a listener that accepts connections
+// and never writes a byte, plus a func that severs the listener and every
+// accepted connection. Pointing a daemon's startup DSN at it holds the daemon
+// alive in its first dial long enough for the (shortened) daemon tick to
+// fire; severing lets the daemon fail out and return. Severing is also
+// registered as a cleanup, so a failing test cannot leak a blocked daemon.
+func HangingTCPAddr(t *testing.T) (addr string, sever func()) {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for hanging TCP endpoint: %v", err)
+	}
+	var mu sync.Mutex
+	var conns []net.Conn
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			conns = append(conns, c)
+			mu.Unlock()
+		}
+	}()
+	var once sync.Once
+	sever = func() {
+		once.Do(func() {
+			l.Close()
+			mu.Lock()
+			defer mu.Unlock()
+			for _, c := range conns {
+				c.Close()
+			}
+		})
+	}
+	t.Cleanup(sever)
+	return l.Addr().String(), sever
+}


### PR DESCRIPTION
## Summary

Closes #1362.

**What the grep missed.** The issue's `grep '\.Beacon('` found zero call sites because #1067 moved the call one layer down: `telemetry.Client.RunDaemon` (started with `go tel.Client().RunDaemon(ctx, cmd.Name())`) beacons AND drains on every tick, and `stream`, `agent`, both `watch` run paths, and `bintrail-pg stream` have run it since 2026-07-21. The `watch` "flush loop" the issue quotes *is* that loop — line 320 of telemetry.go is `c.Beacon(daemon)`. So most of the wiring already existed; this PR closes what was genuinely open.

**The serve/shim decision: include both.** They were documented as "they do not beacon" with no recorded rationale. Both are months-lived daemons; a fleet of read-only consoles or shims is real install base that read as zero. The beacon carries nothing a command event doesn't (no `run_id`, one per UTC day, same consent gates), so read-only-ness is not a privacy distinction. Plumbing was cheap and consistent with `watch`:

- `bintrail-console serve` — one line after its signal context; the hook in `consoleapp` already resolves the client.
- `bintrail shim` — the client now reaches `internal/cli` through a package seam (`processClient`, published by `TelemetryHook.Start`), since shim is implemented in the shared command package and cannot see any binary's hook variable. Both binaries that register shim (`bintrail`, `bintrail-pg`) cover it automatically. `runShim` also now derives its context from `cmd.Context()` and closes its listener on parent cancellation — cobra-honest, and the seam the wiring test shuts the daemon down through.

**Deliberately NOT wired: `Beacon` in `internal/streamrun`'s checkpoint ticker.** The once-per-UTC-day cap is per-**client**, not per daemon name. Inside a `watch` process, a supervised per-source stream calling `Beacon("stream")` would race the process's `Beacon("watch")` for the single daily slot — whichever fires first suppresses the other, corrupting both series. The beacon counts *processes*: standalone `bintrail stream` beacons as `stream` (via `runStream`'s existing `RunDaemon`), and a `watch` supervising N sources beacons once as `watch`. `up` is covered because it delegates to `runStream`.

**Flush delivery (the "same bug one layer down" check).** No daemon only-spools: `RunDaemon` itself calls `drainOnce()` after `Beacon()` on every tick, in-process, in every daemon that runs it — the flush loop never lived only in `watch`. Short CLI runs additionally drain at `Init` (startup, adopting aged claims) and wait a bounded moment at `Shutdown`. With serve and shim wired, every daemon that emits a beacon also delivers it; nothing waits for "the next CLI run" except events from a process killed mid-drain, whose spool claim a later run adopts by design.

**Docs.** `TELEMETRY.md`'s "Which surfaces report" table and daemon section now include serve and shim; the console-actions paragraph still (truthfully) says serve wires no console-action client. Wire format, consent gates, and the payload table are untouched.

## Testing

Per the issue, the guards test the **wiring**, not the function — one test per call site, each driving the REAL run function (`runStream`, `runAgent`, `runPGStream`, `runServe`, `runUpConsoleOnly`, `runUpStreamWithConsole`, `runShim`) with an enabled client delivering to an in-process endpoint and a shortened daemon tick (`telemetry.ShortenDaemonTickForTest`; `daemonTick` became atomic so restore isn't a data race). A test passes only once a real `daemon_beacon` carrying that daemon's sanitized command name is delivered end to end. Daemons that would fail fast on a bad DSN are held alive in their first dial by a TCP endpoint that accepts and never answers (`telemetrytest.HangingTCPAddr`). Shared helpers: `internal/telemetry/telemetrytest`.

- Unit (no DB): `stream`, `agent`, `bintrail-pg stream`, `serve` — all PASS.
- Integration (MySQL 8.0 at 127.0.0.1:13306; PASS lines verified, not skips): `watch` console-only, `watch` source-ful, `shim` — all PASS.
- **Mutation check, per site**: commenting out each of the eight `RunDaemon` launches makes exactly that daemon's test fail (8/8 KILLED, verified individually); plus the review-round guards below (11/11 total).
- `go build ./...`, `go vet ./...`, `go vet -tags integration ./...` clean; `gofmt -l` clean on touched files; full `go test ./... -count=1` green; `go test -tags integration -count=1` green for every touched package (`internal/telemetry`, `internal/cli`, `cliapp`, `consoleapp`, `cmd/bintrail-pg`); `-race` green on the same packages, wiring tests included.


## Review round (3-agent review, one consolidated fix commit)

- **serve consent (critical)**: runServe built its console without `Config.Telemetry`, so with serve beaconing, the UI opt-out purged the spool but flipped nothing live (the loop kept delivering), `GET /api/telemetry` reported `reporting:false` while beaconing, and a `--telemetry` launch flag never tripped the 409 override guard. Fixed with `serveTelemetry`, a consent-only adapter (Enabled/Decision/SetRuntimeConsent delegate to the live client; `RecordDaemonCommand` returns a nil span) — NOT the full client, which would have started recording console actions and falsified TELEMETRY.md. The flag reaches the override guard via the live client's `Decision`. Guard: `TestServeTelemetryOptOutStopsBeacons` drives the REAL runServe on a reserved port — asserts the state endpoint never claims reporting-off while the client beacons, opts out over the API, and proves the live client flips and the next ~12 ticks deliver nothing.
- **`bintrail-pg flashback`** — the eighth months-lived daemon — now runs the loop (same seam as the MySQL shim) with its own wiring guard; TELEMETRY.md daemon lists include it.
- **Start→processClient seam**: `TestStartPublishesProcessClient` runs the real hook and fails if Start stops publishing the client shim's loop depends on (the wiring guards inject via `SetClientForTest` and would never notice); also fences the #1061 shadowed-hook hazard for that path.
- **watch guards now drive `runWatch` itself** (preflight/init phases + dispatch included), not the per-path internals; the fixture's hand-mirrored rotation parse is gone. The source-ful test uses `--skip-doctor`, as an operator would against the deliberately-unresponsive source.
- Smaller: `RunDaemon` recovers per tick (one drain panic no longer ends beaconing for a months-lived process), debug-logs the never-report early return, and documents the one-beacon-per-PROCESS contract with the enumerated wired-daemon list; shim's signal handling became `signal.NotifyContext` (sibling pattern, shutdown logged on parent-cancel too); a tiny test pins that `up`'s delegated beacon says `"up"`; TELEMETRY.md gains the wiring guards in its verification table and loses a broken line-wrap.
- **Mutation evidence, cumulative (11/11 KILLED)**: the 8 `RunDaemon` launches (stream, agent, pg stream, serve, watch×2, shim, flashback), the `processClient` publication, runServe's `Telemetry:` wiring line, and the adapter's `SetRuntimeConsent` delegation — each deletion fails exactly its guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
