### PR TITLE
console: run verify Explain on the daemon and show it working

### DIFF
--- a/consoleapp/verify.go
+++ b/consoleapp/verify.go
@@ -69,12 +69,17 @@ type explainJob struct {
 	err    error
 }
 
-// maxCachedExplains bounds the cache. Explanations carry rendered text and up
-// to the engine's per-table diff cap, so they are not free; a run's mismatch
-// list is the realistic upper bound on distinct keys and this sits above it.
-// Overflow drops the whole cache rather than guessing which entry matters —
-// a dropped entry costs one recomputation, and a stale-eviction policy here
-// would be more machinery than the payload deserves.
+// maxCachedExplains bounds the FINISHED entries only. Explanations carry
+// rendered text and up to the engine's per-table diff cap, so they are not
+// free; a run's mismatch list is the realistic upper bound on distinct keys
+// and this sits above it. Overflow drops every finished entry rather than
+// guessing which one matters — a dropped entry costs one recomputation.
+//
+// In-flight entries are deliberately NOT capped: evicting one would abandon
+// work still running and make the next poll start it again, which is the
+// pile-up this cache exists to prevent. Concurrent drill-downs are therefore
+// bounded by callers, not here — the same as before this cache existed, when
+// every request ran its own reconstruction with no dedup at all.
 const maxCachedExplains = 16
 
 func explainKey(serverID, schema, table string) string {
@@ -164,8 +169,8 @@ func (s *verifySupervisor) begin(req console.VerifyRequest, trigger string) (str
 	// A new run invalidates this server's cached drill-downs: each belongs to
 	// the BaselinePair of the run that produced its verdict, so serving one
 	// afterwards would explain a mismatch the displayed results no longer
-	// claim. In-flight entries go too — their goroutine finds the key gone
-	// and drops the result.
+	// claim. In-flight entries go too — finishExplain sees its
+	// job is no longer the one under that key and drops the result.
 	for k := range s.explains {
 		if strings.HasPrefix(k, req.ServerID+"|") {
 			delete(s.explains, k)
@@ -252,21 +257,58 @@ func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.Ver
 			}
 		}
 	}
-	s.explains[key] = &explainJob{}
+	job := &explainJob{}
+	s.explains[key] = job
 	s.mu.Unlock()
 
 	go func() {
+		// A panic here must NEVER take down the daemon: this background
+		// goroutine shares the process with the stream and console under
+		// `watch`, so a panic in the reconstruct/DuckDB path would stop
+		// CAPTURE over a drill-down click. Mirrors run's guard below.
+		// finishExplain also closes the job, so the recover cannot leave a
+		// key stuck "running" forever.
+		defer func() {
+			if r := recover(); r != nil {
+				s.finishExplain(key, job, nil, fmt.Errorf("internal error: %v", r))
+			}
+		}()
 		res, err := s.explainNow(indexDSN, noArchive, schema, table, pair)
-		s.mu.Lock()
-		// Gone means a newer run (or an eviction) invalidated this key while
-		// the work ran: the result belongs to a verdict nobody is showing any
-		// more, so drop it rather than serve it.
-		if ej, ok := s.explains[key]; ok {
-			ej.result, ej.err, ej.done = res, err, true
-		}
-		s.mu.Unlock()
+		s.finishExplain(key, job, res, err)
 	}()
 	return nil, console.ErrExplainRunning
+}
+
+// finishExplain publishes a drill-down result to the job that requested it.
+//
+// The identity check is the load-bearing part: comparing only the KEY would
+// let a superseded goroutine write its result into a LATER job that happens to
+// reuse the same key, so the operator would be shown a diff computed against a
+// different BaselinePair than the verdict on screen — the exact hazard begin's
+// invalidation loop exists to prevent, reintroduced from the other end. On a
+// forensics surface that is wrong evidence, not merely stale UI.
+//
+// Every outcome is logged, because the response is NOT a reliable delivery
+// path: a poll only sees this result if the operator is still waiting and the
+// key survived. A failure nobody was polling for would otherwise exist
+// nowhere at all, and the daemon log is the surface that outlives the modal.
+func (s *verifySupervisor) finishExplain(key string, job *explainJob, res *console.VerifyExplanation, err error) {
+	s.mu.Lock()
+	cur, ok := s.explains[key]
+	live := ok && cur == job
+	if live {
+		cur.result, cur.err, cur.done = res, err, true
+	}
+	s.mu.Unlock()
+
+	switch {
+	case err != nil && live:
+		slog.Error("verify: drill-down failed", "key", key, "error", err)
+	case err != nil:
+		slog.Error("verify: drill-down failed after being superseded", "key", key, "error", err)
+	case !live:
+		slog.Warn("verify: discarding a drill-down whose request was superseded", "key", key)
+	}
 }
 
 // explainNow performs the reconstruction and row-level diff. It is the old

--- a/consoleapp/verify.go
+++ b/consoleapp/verify.go
@@ -46,6 +46,39 @@ type verifySupervisor struct {
 
 	mu   sync.Mutex
 	jobs map[string]*verifyJob
+	// explains caches the on-demand drill-downs, keyed serverID|schema|table.
+	// Guarded by mu like jobs. Cleared for a server when a new run begins:
+	// an explanation belongs to the BaselinePair of the run that produced the
+	// verdict, so serving one across runs would explain a mismatch nobody is
+	// looking at any more.
+	explains map[string]*explainJob
+}
+
+// explainJob is one table's drill-down: in flight, or finished with a result
+// or an error. Written by the goroutine Explain starts, read by later polls —
+// every field under verifySupervisor.mu.
+//
+// The error is KEPT rather than discarded so a failed reconstruction reports
+// its reason on the next poll instead of silently restarting forever (the
+// poller would otherwise see "running" for as long as the operator waits).
+// Reading a finished job CONSUMES it, so a retry re-runs rather than
+// re-serving a stale failure.
+type explainJob struct {
+	done   bool
+	result *console.VerifyExplanation
+	err    error
+}
+
+// maxCachedExplains bounds the cache. Explanations carry rendered text and up
+// to the engine's per-table diff cap, so they are not free; a run's mismatch
+// list is the realistic upper bound on distinct keys and this sits above it.
+// Overflow drops the whole cache rather than guessing which entry matters —
+// a dropped entry costs one recomputation, and a stale-eviction policy here
+// would be more machinery than the payload deserves.
+const maxCachedExplains = 16
+
+func explainKey(serverID, schema, table string) string {
+	return serverID + "|" + schema + "." + table
 }
 
 // verifyJob is the mutable per-server job state: the pollable status PLUS the
@@ -83,7 +116,11 @@ type verifyJob struct {
 // history and onFinish may be nil (runs are then not recorded / not
 // observed); both are fixed at construction on purpose — see their fields.
 func newVerifySupervisor(ctx context.Context, history *console.VerifyHistory, onFinish func(console.VerifyRunRecord)) *verifySupervisor {
-	return &verifySupervisor{ctx: ctx, history: history, onFinish: onFinish, jobs: make(map[string]*verifyJob)}
+	return &verifySupervisor{
+		ctx: ctx, history: history, onFinish: onFinish,
+		jobs:     make(map[string]*verifyJob),
+		explains: make(map[string]*explainJob),
+	}
 }
 
 // Trigger starts a verify run in the background; returns
@@ -124,6 +161,16 @@ func (s *verifySupervisor) begin(req console.VerifyRequest, trigger string) (str
 	if baselineSrc == "" {
 		baselineSrc = req.BaselineS3
 	}
+	// A new run invalidates this server's cached drill-downs: each belongs to
+	// the BaselinePair of the run that produced its verdict, so serving one
+	// afterwards would explain a mismatch the displayed results no longer
+	// claim. In-flight entries go too — their goroutine finds the key gone
+	// and drops the result.
+	for k := range s.explains {
+		if strings.HasPrefix(k, req.ServerID+"|") {
+			delete(s.explains, k)
+		}
+	}
 	s.jobs[req.ServerID] = &verifyJob{
 		status:     console.VerifyStatus{State: console.VerifyStateRunning, Mode: req.Mode, Since: nowStamp()},
 		mode:       req.Mode,
@@ -154,12 +201,31 @@ func (s *verifySupervisor) Status(serverID string) console.VerifyStatus {
 // comment). It opens its own short-lived index connection: the triggering
 // run's connection is already closed by the time an operator clicks Explain.
 func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.VerifyExplanation, error) {
+	key := explainKey(serverID, schema, table)
+
 	// Copy everything needed out of the job under the SAME critical section:
 	// j.pairs is a plain map, mutated by cachePair from the run's goroutine
 	// while a run is still in flight (mismatches on later tables cache in
 	// after earlier ones have already been polled/explained) — reading it
 	// after releasing the lock would race that write.
 	s.mu.Lock()
+	if ej, ok := s.explains[key]; ok {
+		if !ej.done {
+			// Already computing: report that instead of starting a second
+			// reconstruction of the same table. This is the re-entry guard —
+			// without it every poll tick would launch another minutes-long
+			// DuckDB job on a shared daemon.
+			s.mu.Unlock()
+			return nil, console.ErrExplainRunning
+		}
+		// Finished entries are CONSUMED on read: a retry after a failure
+		// re-runs the work instead of replaying the old error forever, and a
+		// delivered result stops holding its rendered text.
+		delete(s.explains, key)
+		s.mu.Unlock()
+		return ej.result, ej.err
+	}
+
 	j, ok := s.jobs[serverID]
 	var (
 		indexDSN  string
@@ -171,11 +237,43 @@ func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.Ver
 		indexDSN, noArchive = j.indexDSN, j.noArchive
 		pair, pairOK = j.pairs[schema+"."+table]
 	}
-	s.mu.Unlock()
 	if !pairOK {
+		s.mu.Unlock()
 		return nil, console.ErrExplainUnavailable
 	}
+	if len(s.explains) >= maxCachedExplains {
+		// Evict only FINISHED entries: dropping an in-flight one would throw
+		// away work that is still running and make the next poll start it
+		// again, which on a big table is exactly the pile-up this cache
+		// exists to prevent.
+		for k, ej := range s.explains {
+			if ej.done {
+				delete(s.explains, k)
+			}
+		}
+	}
+	s.explains[key] = &explainJob{}
+	s.mu.Unlock()
 
+	go func() {
+		res, err := s.explainNow(indexDSN, noArchive, schema, table, pair)
+		s.mu.Lock()
+		// Gone means a newer run (or an eviction) invalidated this key while
+		// the work ran: the result belongs to a verdict nobody is showing any
+		// more, so drop it rather than serve it.
+		if ej, ok := s.explains[key]; ok {
+			ej.result, ej.err, ej.done = res, err, true
+		}
+		s.mu.Unlock()
+	}()
+	return nil, console.ErrExplainRunning
+}
+
+// explainNow performs the reconstruction and row-level diff. It is the old
+// synchronous body of Explain, called on the goroutine Explain starts; it
+// takes everything it needs by value so it holds no lock and touches no
+// supervisor state.
+func (s *verifySupervisor) explainNow(indexDSN string, noArchive bool, schema, table string, pair verify.BaselinePair) (*console.VerifyExplanation, error) {
 	db, err := config.Connect(indexDSN)
 	if err != nil {
 		return nil, fmt.Errorf("connect index: %w", err)

--- a/consoleapp/verify.go
+++ b/consoleapp/verify.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -344,14 +345,34 @@ func (s *verifySupervisor) finishExplain(key string, job *explainJob, res *conso
 		job.cancel()
 	}
 
+	level, msg := explainLogVerdict(err, live)
+	slog.Log(context.Background(), level, msg, "key", key, "error", err)
+}
+
+// explainLogVerdict decides how a finished drill-down is reported. Split out
+// as a pure function so the policy is assertable: the levels are the whole
+// point of the logging, and a level chosen inside finishExplain could only be
+// tested by capturing global slog output.
+//
+// Cancellation is deliberately NOT an error. A canceled drill-down is one WE
+// abandoned — a new run purged it, or the daemon is shutting down — so
+// reporting it at Error would emit a failure line on every --verify-interval
+// tick that overlaps an open drill-down, and bury the failures this logging
+// exists to surface. Same reasoning as status's refusal to grade an
+// unattributable baseline as broken: a log that cries wolf is worse than one
+// that says less.
+func explainLogVerdict(err error, live bool) (slog.Level, string) {
 	switch {
+	case errors.Is(err, context.Canceled):
+		return slog.LevelDebug, "verify: drill-down canceled"
 	case err != nil && live:
-		slog.Error("verify: drill-down failed", "key", key, "error", err)
+		return slog.LevelError, "verify: drill-down failed"
 	case err != nil:
-		slog.Error("verify: drill-down failed after being superseded", "key", key, "error", err)
+		return slog.LevelError, "verify: drill-down failed after being superseded"
 	case !live:
-		slog.Warn("verify: discarding a drill-down whose request was superseded", "key", key)
+		return slog.LevelWarn, "verify: discarding a drill-down whose request was superseded"
 	}
+	return slog.LevelDebug, "verify: drill-down delivered"
 }
 
 // explainNow performs the reconstruction and row-level diff. It is the old

--- a/consoleapp/verify.go
+++ b/consoleapp/verify.go
@@ -44,13 +44,21 @@ type verifySupervisor struct {
 	// notification hook). Set only at construction, so no run can race it.
 	onFinish func(console.VerifyRunRecord)
 
+	// explainFn overrides the drill-down implementation. Nil in production —
+	// this exists so a test can make the work panic and pin that the recover
+	// in Explain's goroutine holds. Without a seam that guard is untestable,
+	// and it is the one whose failure mode is "a click stops capture".
+	explainFn func(ctx context.Context, indexDSN string, noArchive bool, schema, table string, pair verify.BaselinePair) (*console.VerifyExplanation, error)
+
 	mu   sync.Mutex
 	jobs map[string]*verifyJob
-	// explains caches the on-demand drill-downs, keyed serverID|schema|table.
+	// explains caches the on-demand drill-downs, keyed serverID|schema.table.
 	// Guarded by mu like jobs. Cleared for a server when a new run begins:
 	// an explanation belongs to the BaselinePair of the run that produced the
 	// verdict, so serving one across runs would explain a mismatch nobody is
-	// looking at any more.
+	// looking at any more. The map is GLOBAL across monitored servers while
+	// that invalidation is per-server, so its key count is the sum over
+	// servers, not one run's mismatch list.
 	explains map[string]*explainJob
 }
 
@@ -58,28 +66,33 @@ type verifySupervisor struct {
 // or an error. Written by the goroutine Explain starts, read by later polls —
 // every field under verifySupervisor.mu.
 //
-// The error is KEPT rather than discarded so a failed reconstruction reports
-// its reason on the next poll instead of silently restarting forever (the
-// poller would otherwise see "running" for as long as the operator waits).
-// Reading a finished job CONSUMES it, so a retry re-runs rather than
-// re-serving a stale failure.
+// The error is KEPT rather than discarded so ONE read can surface its reason;
+// dropping the entry instead would make the next poll look like a fresh
+// "running" and hide the failure entirely. It is a single shot: reading a
+// finished job CONSUMES it, so a retry re-runs rather than re-serving a stale
+// failure. That is why the console's poll loop stops at a delivered failure
+// instead of retrying it — retrying would just start a new reconstruction
+// every other tick and never show the operator anything.
 type explainJob struct {
 	done   bool
 	result *console.VerifyExplanation
 	err    error
+	// cancel stops the goroutine's work. Called when a new run invalidates
+	// this key, so an abandoned drill-down stops burning DuckDB on the daemon
+	// that also runs capture instead of grinding to a result nobody can be
+	// served. Set once at creation and never reassigned, so calling it needs
+	// no lock (context.CancelFunc is safe to call concurrently and twice).
+	cancel context.CancelFunc
 }
 
-// maxCachedExplains bounds the FINISHED entries only. Explanations carry
-// rendered text and up to the engine's per-table diff cap, so they are not
-// free; a run's mismatch list is the realistic upper bound on distinct keys
-// and this sits above it. Overflow drops every finished entry rather than
-// guessing which one matters — a dropped entry costs one recomputation.
-//
-// In-flight entries are deliberately NOT capped: evicting one would abandon
-// work still running and make the next poll start it again, which is the
-// pile-up this cache exists to prevent. Concurrent drill-downs are therefore
-// bounded by callers, not here — the same as before this cache existed, when
-// every request ran its own reconstruction with no dedup at all.
+// maxCachedExplains is the TOTAL map size at which finished entries are
+// swept. Explanations carry rendered text and up to the engine's per-table
+// diff cap, so they are not free. Only FINISHED entries are dropped —
+// evicting an in-flight one would abandon work still running and make the
+// next poll start it again — so in-flight entries consume the budget without
+// being reclaimable: with N in flight, at most 16-N finished results are
+// held, and with 16 in flight the map grows past this constant rather than
+// throwing away running work. Concurrency is therefore NOT bounded here.
 const maxCachedExplains = 16
 
 func explainKey(serverID, schema, table string) string {
@@ -169,10 +182,17 @@ func (s *verifySupervisor) begin(req console.VerifyRequest, trigger string) (str
 	// A new run invalidates this server's cached drill-downs: each belongs to
 	// the BaselinePair of the run that produced its verdict, so serving one
 	// afterwards would explain a mismatch the displayed results no longer
-	// claim. In-flight entries go too — finishExplain sees its
-	// job is no longer the one under that key and drops the result.
-	for k := range s.explains {
+	// claim. In-flight entries go too: they are CANCELED, not merely dropped.
+	// Deleting alone would leave the goroutine grinding DuckDB for minutes on
+	// the daemon that also runs capture, for a result finishExplain is then
+	// guaranteed to discard — and it would also remove the re-entry guard, so
+	// a click on the same table after the new run finishes would start a
+	// SECOND reconstruction alongside the orphan.
+	for k, ej := range s.explains {
 		if strings.HasPrefix(k, req.ServerID+"|") {
+			if ej.cancel != nil {
+				ej.cancel()
+			}
 			delete(s.explains, k)
 		}
 	}
@@ -203,8 +223,15 @@ func (s *verifySupervisor) Status(serverID string) console.VerifyStatus {
 // Explain re-runs the row-level drill-down for one table the last completed
 // baseline-anchored run reported as a mismatch, using the EXACT BaselinePair
 // that run verified — never a freshly re-derived one (see verifyJob's doc
-// comment). It opens its own short-lived index connection: the triggering
-// run's connection is already closed by the time an operator clicks Explain.
+// comment). explainNow opens its own short-lived index connection: the
+// triggering run's connection is already closed by the time an operator
+// clicks Explain.
+//
+// It NEVER blocks on the reconstruction (#1375, and VerifyController.Explain
+// requires it). Three answers: the explanation, console.ErrExplainRunning
+// while the work is in flight — the caller polls — or
+// console.ErrExplainUnavailable when no cached pair names this table. A
+// finished job is consumed by the read that delivers it.
 func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.VerifyExplanation, error) {
 	key := explainKey(serverID, schema, table)
 
@@ -225,10 +252,15 @@ func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.Ver
 		}
 		// Finished entries are CONSUMED on read: a retry after a failure
 		// re-runs the work instead of replaying the old error forever, and a
-		// delivered result stops holding its rendered text.
+		// delivered result stops holding its rendered text. Read the fields
+		// under the lock too — the delete already guarantees no finishExplain
+		// can match this job again, but keeping every access inside the
+		// critical section is the discipline explainJob's doc states, and a
+		// later post-done writer would silently break a read outside it.
+		res, rerr := ej.result, ej.err
 		delete(s.explains, key)
 		s.mu.Unlock()
-		return ej.result, ej.err
+		return res, rerr
 	}
 
 	j, ok := s.jobs[serverID]
@@ -247,20 +279,22 @@ func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.Ver
 		return nil, console.ErrExplainUnavailable
 	}
 	if len(s.explains) >= maxCachedExplains {
-		// Evict only FINISHED entries: dropping an in-flight one would throw
-		// away work that is still running and make the next poll start it
-		// again, which on a big table is exactly the pile-up this cache
-		// exists to prevent.
+		// Only FINISHED entries — see maxCachedExplains.
 		for k, ej := range s.explains {
 			if ej.done {
 				delete(s.explains, k)
 			}
 		}
 	}
-	job := &explainJob{}
+	ctx, cancel := context.WithCancel(s.ctx)
+	job := &explainJob{cancel: cancel}
 	s.explains[key] = job
 	s.mu.Unlock()
 
+	run := s.explainNow
+	if s.explainFn != nil {
+		run = s.explainFn
+	}
 	go func() {
 		// A panic here must NEVER take down the daemon: this background
 		// goroutine shares the process with the stream and console under
@@ -273,7 +307,7 @@ func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.Ver
 				s.finishExplain(key, job, nil, fmt.Errorf("internal error: %v", r))
 			}
 		}()
-		res, err := s.explainNow(indexDSN, noArchive, schema, table, pair)
+		res, err := run(ctx, indexDSN, noArchive, schema, table, pair)
 		s.finishExplain(key, job, res, err)
 	}()
 	return nil, console.ErrExplainRunning
@@ -288,10 +322,12 @@ func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.Ver
 // invalidation loop exists to prevent, reintroduced from the other end. On a
 // forensics surface that is wrong evidence, not merely stale UI.
 //
-// Every outcome is logged, because the response is NOT a reliable delivery
-// path: a poll only sees this result if the operator is still waiting and the
-// key survived. A failure nobody was polling for would otherwise exist
-// nowhere at all, and the daemon log is the surface that outlives the modal.
+// Failures and superseded results are LOGGED, because the response is not a
+// reliable delivery path: a poll only sees this result if the operator is
+// still waiting and the key survived. A failure nobody was polling for would
+// otherwise exist nowhere at all, and the daemon log outlives the modal. A
+// successful, still-live result is not logged — that is the case a poll is
+// expected to collect.
 func (s *verifySupervisor) finishExplain(key string, job *explainJob, res *console.VerifyExplanation, err error) {
 	s.mu.Lock()
 	cur, ok := s.explains[key]
@@ -300,6 +336,13 @@ func (s *verifySupervisor) finishExplain(key string, job *explainJob, res *conso
 		cur.result, cur.err, cur.done = res, err, true
 	}
 	s.mu.Unlock()
+
+	// The work is over either way, so release the per-job context. Safe
+	// unconditionally: cancel is idempotent, and a canceled context cannot
+	// affect a result already published.
+	if job.cancel != nil {
+		job.cancel()
+	}
 
 	switch {
 	case err != nil && live:
@@ -313,9 +356,10 @@ func (s *verifySupervisor) finishExplain(key string, job *explainJob, res *conso
 
 // explainNow performs the reconstruction and row-level diff. It is the old
 // synchronous body of Explain, called on the goroutine Explain starts; it
-// takes everything it needs by value so it holds no lock and touches no
-// supervisor state.
-func (s *verifySupervisor) explainNow(indexDSN string, noArchive bool, schema, table string, pair verify.BaselinePair) (*console.VerifyExplanation, error) {
+// takes everything it needs as arguments, so it holds no lock and reads no
+// supervisor state. ctx is per-job (derived from the daemon's) so a new run
+// can cancel an abandoned drill-down.
+func (s *verifySupervisor) explainNow(ctx context.Context, indexDSN string, noArchive bool, schema, table string, pair verify.BaselinePair) (*console.VerifyExplanation, error) {
 	db, err := config.Connect(indexDSN)
 	if err != nil {
 		return nil, fmt.Errorf("connect index: %w", err)
@@ -333,7 +377,7 @@ func (s *verifySupervisor) explainNow(indexDSN string, noArchive bool, schema, t
 		SourceFlavor: query.SourceFlavor(db),
 	}
 
-	ex, err := verify.ExplainBaselinePairMismatch(s.ctx, cfg, pair)
+	ex, err := verify.ExplainBaselinePairMismatch(ctx, cfg, pair)
 	if err != nil {
 		return nil, fmt.Errorf("explain %s.%s: %w", schema, table, err)
 	}

--- a/consoleapp/verify.go
+++ b/consoleapp/verify.go
@@ -48,7 +48,8 @@ type verifySupervisor struct {
 	// explainFn overrides the drill-down implementation. Nil in production —
 	// this exists so a test can make the work panic and pin that the recover
 	// in Explain's goroutine holds. Without a seam that guard is untestable,
-	// and it is the one whose failure mode is "a click stops capture".
+	// and it is the one whose failure mode is "a click stops capture". Set it
+	// before the first Explain, never after: it is read outside mu.
 	explainFn func(ctx context.Context, indexDSN string, noArchive bool, schema, table string, pair verify.BaselinePair) (*console.VerifyExplanation, error)
 
 	mu   sync.Mutex
@@ -229,10 +230,13 @@ func (s *verifySupervisor) Status(serverID string) console.VerifyStatus {
 // clicks Explain.
 //
 // It NEVER blocks on the reconstruction (#1375, and VerifyController.Explain
-// requires it). Three answers: the explanation, console.ErrExplainRunning
-// while the work is in flight — the caller polls — or
-// console.ErrExplainUnavailable when no cached pair names this table. A
-// finished job is consumed by the read that delivers it.
+// requires it). Four answers: the explanation; console.ErrExplainRunning
+// while the work is in flight — the caller polls; console.ErrExplainUnavailable
+// when no cached pair names this table; or the finished job's own error, which
+// the handler renders as a 500 and the console treats as terminal. A finished
+// job is consumed by the read that delivers it, error included — so that 500
+// is the ONE delivery of that failure, which is why retrying it client-side
+// would restart the work instead of re-reading it.
 func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.VerifyExplanation, error) {
 	key := explainKey(serverID, schema, table)
 
@@ -292,7 +296,7 @@ func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.Ver
 	s.explains[key] = job
 	s.mu.Unlock()
 
-	run := s.explainNow
+	run := explainNow
 	if s.explainFn != nil {
 		run = s.explainFn
 	}
@@ -327,8 +331,8 @@ func (s *verifySupervisor) Explain(serverID, schema, table string) (*console.Ver
 // reliable delivery path: a poll only sees this result if the operator is
 // still waiting and the key survived. A failure nobody was polling for would
 // otherwise exist nowhere at all, and the daemon log outlives the modal. A
-// successful, still-live result is not logged — that is the case a poll is
-// expected to collect.
+// successful, still-live result drops to Debug — it is the case a poll is
+// expected to collect, so it is a trace, not news.
 func (s *verifySupervisor) finishExplain(key string, job *explainJob, res *console.VerifyExplanation, err error) {
 	s.mu.Lock()
 	cur, ok := s.explains[key]
@@ -346,7 +350,13 @@ func (s *verifySupervisor) finishExplain(key string, job *explainJob, res *conso
 	}
 
 	level, msg := explainLogVerdict(err, live)
-	slog.Log(context.Background(), level, msg, "key", key, "error", err)
+	// No error attr when there is no error: `error=<nil>` on the delivered and
+	// superseded-success lines reads like a failure with a missing reason.
+	if err != nil {
+		slog.Log(context.Background(), level, msg, "key", key, "error", err)
+		return
+	}
+	slog.Log(context.Background(), level, msg, "key", key)
 }
 
 // explainLogVerdict decides how a finished drill-down is reported. Split out
@@ -380,7 +390,13 @@ func explainLogVerdict(err error, live bool) (slog.Level, string) {
 // takes everything it needs as arguments, so it holds no lock and reads no
 // supervisor state. ctx is per-job (derived from the daemon's) so a new run
 // can cancel an abandoned drill-down.
-func (s *verifySupervisor) explainNow(ctx context.Context, indexDSN string, noArchive bool, schema, table string, pair verify.BaselinePair) (*console.VerifyExplanation, error) {
+//
+// Deliberately NOT a method: with no receiver, s.ctx is not in scope, so the
+// per-job ctx cannot be quietly bypassed here — which would leave the cancel
+// wired but decorative, and explainJob.cancel's promise to stop burning
+// DuckDB false. A test could only catch that after the fact; this makes it
+// not compile.
+func explainNow(ctx context.Context, indexDSN string, noArchive bool, schema, table string, pair verify.BaselinePair) (*console.VerifyExplanation, error) {
 	db, err := config.Connect(indexDSN)
 	if err != nil {
 		return nil, fmt.Errorf("connect index: %w", err)

--- a/consoleapp/verify_test.go
+++ b/consoleapp/verify_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dbtrail/dbtrail/internal/console"
 	"github.com/dbtrail/dbtrail/internal/verify"
@@ -175,5 +176,126 @@ func TestVerifySupervisor_Explain_preconditions(t *testing.T) {
 	s.jobs["baseline"] = &verifyJob{status: console.VerifyStatus{State: "succeeded"}, mode: console.VerifyModeBaselineAnchored}
 	if _, err := s.Explain("baseline", "wp", "never_mismatched"); !errors.Is(err, console.ErrExplainUnavailable) {
 		t.Errorf("table never cached as a mismatch: err = %v, want ErrExplainUnavailable", err)
+	}
+}
+
+// explainableSupervisor returns a supervisor whose "s1" job has one cached
+// mismatch pair, so Explain gets past its preconditions and starts real work.
+// The index DSN points at a port nothing listens on: the reconstruction fails
+// fast at connect, which is exactly what these tests want — they are about the
+// job LIFECYCLE (running → finished → consumed), not about the diff engine.
+func explainableSupervisor(t *testing.T) *verifySupervisor {
+	t.Helper()
+	s := newVerifySupervisor(context.Background(), nil, nil)
+	s.jobs["s1"] = &verifyJob{
+		status:   console.VerifyStatus{State: "succeeded"},
+		mode:     console.VerifyModeBaselineAnchored,
+		indexDSN: "u:p@tcp(127.0.0.1:1)/idx",
+		pairs:    map[string]verify.BaselinePair{"wp.posts": {}},
+	}
+	return s
+}
+
+// waitExplain polls Explain the way the console does, returning the first
+// answer that is not "still running".
+func waitExplain(t *testing.T, s *verifySupervisor, schema, table string) (*console.VerifyExplanation, error) {
+	t.Helper()
+	for i := 0; i < 200; i++ {
+		ex, err := s.Explain("s1", schema, table)
+		if !errors.Is(err, console.ErrExplainRunning) {
+			return ex, err
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("explain never left the running state")
+	return nil, nil
+}
+
+// TestVerifySupervisor_ExplainIsAsync pins #1375's core contract: Explain
+// returns immediately with ErrExplainRunning and delivers the outcome on a
+// later call. A blocking implementation cannot outlive a fronting proxy's
+// read timeout, which made the button look dead on exactly the large tables
+// the drill-down exists for.
+func TestVerifySupervisor_ExplainIsAsync(t *testing.T) {
+	s := explainableSupervisor(t)
+
+	if _, err := s.Explain("s1", "wp", "posts"); !errors.Is(err, console.ErrExplainRunning) {
+		t.Fatalf("first call: err = %v, want ErrExplainRunning (it must not block on the reconstruction)", err)
+	}
+
+	// The work fails at connect (nothing listens on port 1), so the terminal
+	// answer is that error — surfaced, not swallowed, and not ErrExplainRunning.
+	_, err := waitExplain(t, s, "wp", "posts")
+	if err == nil {
+		t.Fatal("finished explain returned no error although the index is unreachable")
+	}
+	if errors.Is(err, console.ErrExplainRunning) || errors.Is(err, console.ErrExplainUnavailable) {
+		t.Errorf("terminal err = %v, want the underlying failure", err)
+	}
+
+	// Reading a finished job consumes it, so a retry re-runs instead of
+	// replaying the old failure forever.
+	s.mu.Lock()
+	_, still := s.explains[explainKey("s1", "wp", "posts")]
+	s.mu.Unlock()
+	if still {
+		t.Error("finished explain stayed cached; a retry would replay the stale error instead of re-running")
+	}
+}
+
+// TestVerifySupervisor_ExplainReentryGuard: polling (or an impatient second
+// click) must not launch a second reconstruction of the same table — that is
+// minutes of DuckDB work per extra job on a shared daemon.
+func TestVerifySupervisor_ExplainReentryGuard(t *testing.T) {
+	s := explainableSupervisor(t)
+	// Pre-seed an in-flight job so the guard is exercised without racing a
+	// real one to completion.
+	key := explainKey("s1", "wp", "posts")
+	s.mu.Lock()
+	first := &explainJob{}
+	s.explains[key] = first
+	s.mu.Unlock()
+
+	for i := 0; i < 3; i++ {
+		if _, err := s.Explain("s1", "wp", "posts"); !errors.Is(err, console.ErrExplainRunning) {
+			t.Fatalf("poll %d: err = %v, want ErrExplainRunning", i, err)
+		}
+	}
+	s.mu.Lock()
+	got, ok := s.explains[key]
+	n := len(s.explains)
+	s.mu.Unlock()
+	if !ok || got != first {
+		t.Error("a poll replaced the in-flight job — a second reconstruction was started")
+	}
+	if n != 1 {
+		t.Errorf("explains has %d entries, want 1", n)
+	}
+}
+
+// TestVerifySupervisor_ExplainInvalidatedByNewRun: an explanation belongs to
+// the BaselinePair of the run that produced its verdict, so a new run must
+// drop it. Serving it afterwards would explain a mismatch the displayed
+// results no longer claim.
+func TestVerifySupervisor_ExplainInvalidatedByNewRun(t *testing.T) {
+	s := explainableSupervisor(t)
+	s.mu.Lock()
+	s.explains[explainKey("s1", "wp", "posts")] = &explainJob{done: true, result: &console.VerifyExplanation{Schema: "wp", Table: "posts"}}
+	s.explains[explainKey("other", "wp", "posts")] = &explainJob{done: true, result: &console.VerifyExplanation{Schema: "wp", Table: "posts"}}
+	s.mu.Unlock()
+
+	if _, err := s.begin(console.VerifyRequest{ServerID: "s1", Mode: console.VerifyModeBaselineAnchored}, console.VerifyTriggerManual); err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+
+	s.mu.Lock()
+	_, stale := s.explains[explainKey("s1", "wp", "posts")]
+	_, otherKept := s.explains[explainKey("other", "wp", "posts")]
+	s.mu.Unlock()
+	if stale {
+		t.Error("a new run left the previous run's drill-down cached")
+	}
+	if !otherKept {
+		t.Error("a run on one server dropped another server's cached drill-down")
 	}
 }

--- a/consoleapp/verify_test.go
+++ b/consoleapp/verify_test.go
@@ -334,6 +334,40 @@ func TestVerifySupervisor_ExplainCancelsInvalidatedWork(t *testing.T) {
 	}
 }
 
+// TestVerifySupervisor_ExplainWorkSeesTheCancel pins the WIRING, not the two
+// halves: that the context Explain hands the work is the one a new run
+// cancels. Both are easy to get right separately and still leave the cancel
+// decorative, which would make explainJob.cancel's promise to stop burning
+// DuckDB false while every other test stayed green.
+func TestVerifySupervisor_ExplainWorkSeesTheCancel(t *testing.T) {
+	s := explainableSupervisor(t)
+	started := make(chan struct{})
+	observed := make(chan error, 1)
+	s.explainFn = func(ctx context.Context, _ string, _ bool, _, _ string, _ verify.BaselinePair) (*console.VerifyExplanation, error) {
+		close(started)
+		<-ctx.Done()
+		observed <- ctx.Err()
+		return nil, ctx.Err()
+	}
+
+	if _, err := s.Explain("s1", "wp", "posts"); !errors.Is(err, console.ErrExplainRunning) {
+		t.Fatalf("Explain: err = %v, want ErrExplainRunning", err)
+	}
+	<-started
+	if _, err := s.begin(console.VerifyRequest{ServerID: "s1", Mode: console.VerifyModeBaselineAnchored}, console.VerifyTriggerManual); err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+
+	select {
+	case err := <-observed:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("the work saw %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a new run did not reach the running drill-down: the work is on a context the purge cannot stop, so it keeps burning DuckDB for a result that will be discarded")
+	}
+}
+
 // TestExplainLogVerdict: a canceled drill-down is one WE abandoned, so it
 // must not be reported as a failure. Without this, every scheduled run that
 // overlaps an open drill-down logs an error, and the real failures this

--- a/consoleapp/verify_test.go
+++ b/consoleapp/verify_test.go
@@ -301,6 +301,61 @@ func TestVerifySupervisor_ExplainInvalidatedByNewRun(t *testing.T) {
 	}
 }
 
+// TestVerifySupervisor_ExplainCancelsInvalidatedWork: dropping the map entry
+// is not enough. The goroutine would keep reconstructing for minutes on the
+// daemon that also runs capture, for a result finishExplain is guaranteed to
+// discard — and with the entry gone, the re-entry guard no longer stops a
+// click on the same table from starting a SECOND one alongside it.
+func TestVerifySupervisor_ExplainCancelsInvalidatedWork(t *testing.T) {
+	s := explainableSupervisor(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	other, cancelOther := context.WithCancel(context.Background())
+	defer cancelOther()
+	s.mu.Lock()
+	s.explains[explainKey("s1", "wp", "posts")] = &explainJob{cancel: cancel}
+	s.explains[explainKey("other", "wp", "posts")] = &explainJob{cancel: cancelOther}
+	s.mu.Unlock()
+
+	if _, err := s.begin(console.VerifyRequest{ServerID: "s1", Mode: console.VerifyModeBaselineAnchored}, console.VerifyTriggerManual); err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Error("a new run abandoned an in-flight drill-down without canceling it; it keeps burning DuckDB for a result nobody can be served")
+	}
+	select {
+	case <-other.Done():
+		t.Error("a run on one server canceled another server's in-flight drill-down")
+	default:
+	}
+}
+
+// TestVerifySupervisor_ExplainSurvivesPanic pins the guard whose failure mode
+// is the worst in this file: the drill-down goroutine is bare, so before the
+// recover a panic in the reconstruct path took down the process — and under
+// `watch` that process is also the capture plane, so a click on Explain would
+// stop binlog capture. The panic must instead land as this job's error.
+func TestVerifySupervisor_ExplainSurvivesPanic(t *testing.T) {
+	s := explainableSupervisor(t)
+	s.explainFn = func(context.Context, string, bool, string, string, verify.BaselinePair) (*console.VerifyExplanation, error) {
+		panic("boom from the reconstruct path")
+	}
+
+	if _, err := s.Explain("s1", "wp", "posts"); !errors.Is(err, console.ErrExplainRunning) {
+		t.Fatalf("Explain: err = %v, want ErrExplainRunning", err)
+	}
+	_, err := waitExplain(t, s, "wp", "posts")
+	if err == nil {
+		t.Fatal("a panicking drill-down reported success")
+	}
+	if !strings.Contains(err.Error(), "boom from the reconstruct path") {
+		t.Errorf("terminal err = %v, want the panic value surfaced to the operator", err)
+	}
+}
+
 // TestVerifySupervisor_FinishExplainChecksJobIdentity is the other end of the
 // invalidation invariant, and the sequence that actually happens in
 // production: click Explain, let a new run start before the reconstruction

--- a/consoleapp/verify_test.go
+++ b/consoleapp/verify_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -330,6 +331,33 @@ func TestVerifySupervisor_ExplainCancelsInvalidatedWork(t *testing.T) {
 	case <-other.Done():
 		t.Error("a run on one server canceled another server's in-flight drill-down")
 	default:
+	}
+}
+
+// TestExplainLogVerdict: a canceled drill-down is one WE abandoned, so it
+// must not be reported as a failure. Without this, every scheduled run that
+// overlaps an open drill-down logs an error, and the real failures this
+// logging exists to surface drown in routine noise.
+func TestExplainLogVerdict(t *testing.T) {
+	canceled := fmt.Errorf("explain wp.posts: %w", context.Canceled)
+	for _, tc := range []struct {
+		name string
+		err  error
+		live bool
+		want slog.Level
+	}{
+		{"canceled by a new run", canceled, false, slog.LevelDebug},
+		{"canceled at shutdown", canceled, true, slog.LevelDebug},
+		{"failed and still wanted", errors.New("connect index: refused"), true, slog.LevelError},
+		{"failed after superseded", errors.New("connect index: refused"), false, slog.LevelError},
+		{"succeeded but superseded", nil, false, slog.LevelWarn},
+		{"succeeded and delivered", nil, true, slog.LevelDebug},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, _ := explainLogVerdict(tc.err, tc.live); got != tc.want {
+				t.Errorf("level = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/consoleapp/verify_test.go
+++ b/consoleapp/verify_test.go
@@ -3,6 +3,7 @@ package consoleapp
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -297,5 +298,131 @@ func TestVerifySupervisor_ExplainInvalidatedByNewRun(t *testing.T) {
 	}
 	if !otherKept {
 		t.Error("a run on one server dropped another server's cached drill-down")
+	}
+}
+
+// TestVerifySupervisor_FinishExplainChecksJobIdentity is the other end of the
+// invalidation invariant, and the sequence that actually happens in
+// production: click Explain, let a new run start before the reconstruction
+// lands. A key-presence check would pass here and publish a drill-down
+// computed against the PREVIOUS run's BaselinePair under the current run's
+// verdict — wrong evidence on a forensics surface, not merely stale UI.
+func TestVerifySupervisor_FinishExplainChecksJobIdentity(t *testing.T) {
+	s := explainableSupervisor(t)
+	key := explainKey("s1", "wp", "posts")
+	superseded := &explainJob{}
+	stale := &console.VerifyExplanation{Schema: "wp", Table: "posts"}
+
+	// Leg 1: a new run deleted the key (begin's purge). The late result must
+	// not resurrect it — the next click has to recompute against the new pair.
+	s.mu.Lock()
+	s.explains[key] = superseded
+	delete(s.explains, key)
+	s.mu.Unlock()
+
+	s.finishExplain(key, superseded, stale, nil)
+
+	s.mu.Lock()
+	_, resurrected := s.explains[key]
+	s.mu.Unlock()
+	if resurrected {
+		t.Error("a superseded drill-down re-created its own cache entry; the next poll would serve the previous run's diff")
+	}
+
+	// Leg 2: the key was re-created by a LATER request. The superseded
+	// goroutine must leave that job alone.
+	current := &explainJob{}
+	s.mu.Lock()
+	s.explains[key] = current
+	s.mu.Unlock()
+
+	s.finishExplain(key, superseded, stale, nil)
+
+	s.mu.Lock()
+	got := s.explains[key]
+	done, res := got.done, got.result
+	s.mu.Unlock()
+	if got != current {
+		t.Fatal("the superseded goroutine replaced the current job")
+	}
+	if done || res != nil {
+		t.Error("a superseded goroutine published its result into a later request's job — the operator would see a diff against the wrong snapshot pair")
+	}
+
+	// And the live case still publishes, or the identity check would be a
+	// guard that never lets anything through.
+	s.finishExplain(key, current, stale, nil)
+	s.mu.Lock()
+	done, res = s.explains[key].done, s.explains[key].result
+	s.mu.Unlock()
+	if !done || res != stale {
+		t.Error("finishExplain did not publish to the job that requested it")
+	}
+}
+
+// TestVerifySupervisor_ExplainReturnsFinishedResult covers the delivery half:
+// the other tests all drive failures (the helper's index is unreachable on
+// purpose), so without this one no test ever carries a real explanation back
+// out through Explain.
+func TestVerifySupervisor_ExplainReturnsFinishedResult(t *testing.T) {
+	s := explainableSupervisor(t)
+	key := explainKey("s1", "wp", "posts")
+	want := &console.VerifyExplanation{Schema: "wp", Table: "posts"}
+	s.mu.Lock()
+	s.explains[key] = &explainJob{done: true, result: want}
+	s.mu.Unlock()
+
+	got, err := s.Explain("s1", "wp", "posts")
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	if got != want {
+		t.Fatalf("Explain returned %v, want the cached explanation", got)
+	}
+	s.mu.Lock()
+	_, still := s.explains[key]
+	s.mu.Unlock()
+	if still {
+		t.Error("a delivered explanation stayed cached; it holds rendered diff text nobody will read again")
+	}
+}
+
+// TestVerifySupervisor_ExplainEvictsOnlyFinished pins the eviction policy the
+// const's comment claims: dropping an in-flight entry would abandon work still
+// running and make the next poll restart it — the pile-up this cache exists to
+// prevent.
+func TestVerifySupervisor_ExplainEvictsOnlyFinished(t *testing.T) {
+	s := explainableSupervisor(t)
+	inFlight := &explainJob{}
+	s.mu.Lock()
+	s.explains[explainKey("s1", "wp", "busy")] = inFlight
+	for i := 1; i < maxCachedExplains; i++ {
+		s.explains[explainKey("s1", "wp", fmt.Sprintf("t%d", i))] = &explainJob{done: true}
+	}
+	n := len(s.explains)
+	s.mu.Unlock()
+	if n != maxCachedExplains {
+		t.Fatalf("seeded %d entries, want %d", n, maxCachedExplains)
+	}
+
+	// wp.posts is the one table the helper cached a pair for, so this is the
+	// request that trips the eviction.
+	if _, err := s.Explain("s1", "wp", "posts"); !errors.Is(err, console.ErrExplainRunning) {
+		t.Fatalf("Explain: err = %v, want ErrExplainRunning", err)
+	}
+
+	s.mu.Lock()
+	kept, ok := s.explains[explainKey("s1", "wp", "busy")]
+	_, started := s.explains[explainKey("s1", "wp", "posts")]
+	n = len(s.explains)
+	s.mu.Unlock()
+	if !ok || kept != inFlight {
+		t.Error("eviction dropped an in-flight drill-down; its next poll would restart minutes of work already running")
+	}
+	if !started {
+		t.Error("the request that tripped eviction did not register its own job")
+	}
+	if n != 2 {
+		t.Errorf("explains has %d entries after eviction, want 2 (the in-flight one plus the new request)", n)
 	}
 }

--- a/docs/console.md
+++ b/docs/console.md
@@ -516,9 +516,10 @@ results a `verify` cron/CI run produced elsewhere:
   reopening simply recomputes, and nothing is lost but the wait. A new verify
   run is different: it discards (and cancels) the previous run's drill-downs,
   because each explains the snapshot pair its own run compared, and Explain
-  reports no explainable mismatch until that run finishes and reports the
-  table as a mismatch again. Failures are logged by the daemon whether or not
-  anyone is still polling.
+  reports no explainable mismatch until a *baseline-anchored* run reports the
+  table as a mismatch again — a live-source or check-recovery-inputs run
+  clears the drill-downs without being able to replace them. Failures are
+  logged by the daemon whether or not anyone is still polling.
 - **Check recovery inputs** is the console face of
   [`bintrail verify --check recover`](verify.md): index-only — no baseline
   and no source read — walking each primary key's event chain over the last

--- a/docs/console.md
+++ b/docs/console.md
@@ -511,12 +511,14 @@ results a `verify` cron/CI run produced elsewhere:
   table — behind a busy dialog that says so. Closing that dialog only stops
   the waiting: the drill-down keeps computing, and reopening **Explain**
   picks up the finished result if it is still held. It is not held
-  indefinitely — a new verify run discards the previous run's drill-downs
-  (each explains the snapshot pair its own run compared), the first reopen
-  consumes the result, and a finished result may be dropped to make room
-  once many tables have been explained. In every one of those cases
-  reopening simply recomputes; nothing is lost but the wait. Failures are
-  logged by the daemon whether or not anyone is still polling.
+  indefinitely: the first reopen consumes it, and a finished result may be
+  dropped to make room once many tables have been explained — in both cases
+  reopening simply recomputes, and nothing is lost but the wait. A new verify
+  run is different: it discards (and cancels) the previous run's drill-downs,
+  because each explains the snapshot pair its own run compared, and Explain
+  reports no explainable mismatch until that run finishes and reports the
+  table as a mismatch again. Failures are logged by the daemon whether or not
+  anyone is still polling.
 - **Check recovery inputs** is the console face of
   [`bintrail verify --check recover`](verify.md): index-only — no baseline
   and no source read — walking each primary key's event chain over the last

--- a/docs/console.md
+++ b/docs/console.md
@@ -506,7 +506,13 @@ results a `verify` cron/CI run produced elsewhere:
   baseline-anchored run gets an **Explain** button — an on-demand,
   never-precomputed row-level drill-down (`--explain`'s console equivalent),
   re-run only when clicked. Live-source mismatches have no explain support
-  (mirroring the CLI).
+  (mirroring the CLI). Because it REBUILDS the table to diff it, the work
+  runs on the daemon and the console polls for it — minutes on a large
+  table — behind a busy dialog that says so. Closing that dialog only stops
+  the waiting: the drill-down keeps computing, and reopening **Explain**
+  picks up the finished result. A new verify run discards the previous
+  run's drill-downs, since each explains the snapshot pair its own run
+  compared.
 - **Check recovery inputs** is the console face of
   [`bintrail verify --check recover`](verify.md): index-only — no baseline
   and no source read — walking each primary key's event chain over the last

--- a/docs/console.md
+++ b/docs/console.md
@@ -510,9 +510,13 @@ results a `verify` cron/CI run produced elsewhere:
   runs on the daemon and the console polls for it — minutes on a large
   table — behind a busy dialog that says so. Closing that dialog only stops
   the waiting: the drill-down keeps computing, and reopening **Explain**
-  picks up the finished result. A new verify run discards the previous
-  run's drill-downs, since each explains the snapshot pair its own run
-  compared.
+  picks up the finished result if it is still held. It is not held
+  indefinitely — a new verify run discards the previous run's drill-downs
+  (each explains the snapshot pair its own run compared), the first reopen
+  consumes the result, and a finished result may be dropped to make room
+  once many tables have been explained. In every one of those cases
+  reopening simply recomputes; nothing is lost but the wait. Failures are
+  logged by the daemon whether or not anyone is still polling.
 - **Check recovery inputs** is the console face of
   [`bintrail verify --check recover`](verify.md): index-only — no baseline
   and no source read — walking each primary key's event chain over the last

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -3787,7 +3787,8 @@ async function openVerifyExplain(id, schema, table, btn) {
     errTitle: "Couldn't explain this mismatch",
     facts: [["table", schema + "." + table]],
     note: "Rebuilding this table from the older snapshot and its change log to diff it row by row — minutes on a large table. " +
-      "The work continues on the server; closing this only stops the waiting.",
+      "The work continues on the server; closing this only stops the waiting. " +
+      "A new verify run discards drill-downs from the previous one, so reopening then starts over.",
     disable: btn ? [btn] : [],
     onCancel: () => ctrl.abort(),
   });
@@ -3800,6 +3801,12 @@ async function openVerifyExplain(id, schema, table, btn) {
     "?schema=" + encodeURIComponent(schema) + "&table=" + encodeURIComponent(table);
   const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
   let ex;
+  // A blip mid-poll must not be reported as a failed drill-down: the whole
+  // reason this endpoint went async is that long waits sit behind proxies
+  // that hiccup, and the daemon's job is unaffected by a dropped poll. But
+  // an endpoint that is genuinely down must still surface, so only
+  // CONSECUTIVE failures are tolerated — a single success resets the count.
+  let misses = 0;
   // ~20 minutes at 2s, the same cap and cadence pollVerify uses.
   for (let i = 0; i < 600; i++) {
     let res;
@@ -3807,17 +3814,24 @@ async function openVerifyExplain(id, schema, table, btn) {
       res = await api(url, { signal: ctrl.signal });
     } catch (err) {
       if (err && err.name === "AbortError") return; // Cancel/ESC already tore the modal down
-      busy.showError(err);
-      return;
+      if (++misses > 5) { busy.showError(err); return; }
+      await sleep(2000);
+      continue;
     }
+    misses = 0;
     if (gen !== serverGen) { busy.close(); return; }
     if (res && res.explain) { ex = res.explain; break; }
     // 202 → still running. api() returns the {state:"running"} body.
     await sleep(2000);
   }
   if (!ex) {
-    busy.showError(new Error(
-      "still working after 20 minutes — it keeps running on the server, so reopening Explain later will show the result."));
+    // NOT showError: giving up waiting is not the drill-down failing, and the
+    // red "Couldn't explain this mismatch" treatment would report a failure
+    // that has not happened. Mirrors pollBaseline's neutral "check back"
+    // toast. The wording promises nothing about reopening — a scheduled run
+    // may have discarded the result by then.
+    busy.close();
+    toast("Still working after 20 minutes — it continues on the server. Reopen Explain to check.");
     return;
   }
   busy.close();

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2052,18 +2052,21 @@ function recoverBusyFacts(f) {
   return facts;
 }
 
-// openBusyModal opens the busy dialog and disables the form's action
-// buttons until it closes. Returns {close(refocus), showError(err)}; Cancel
-// and ESC run opts.onCancel (the fetch abort) and restore focus to the
-// element that had it. Accessibility: role="dialog", aria-busy while working,
-// focus trapped inside, focus restored on cancel/dismiss.
+// openBusyModal opens the busy dialog over a long-running request. form, when
+// given, supplies the action row to disable; a caller with no form (Explain)
+// passes null and names its own elements in opts.disable. opts.note adds a
+// line under the title explaining what the wait is. Returns {close(refocus),
+// showError(err)}; Cancel and ESC run opts.onCancel (the fetch abort) and
+// restore focus to the element that had it. Accessibility: role="dialog",
+// aria-busy while working, focus trapped inside, focus restored on
+// cancel/dismiss.
 function openBusyModal(form, opts) {
   busyModalOpen = true;
   const mount = document.getElementById("modal");
   const trigger = document.activeElement;
   // A form caller disables its action row; a non-form caller (Explain) names
-  // the elements itself. Either way SOMETHING visibly stops accepting clicks,
-  // which is half of what tells an operator the click registered.
+  // the elements itself. Either may be empty — the scrim is what actually
+  // blocks input; this is the visible confirmation on top of it.
   const actions = opts.disable || (form ? $all(".filter-actions button", form) : []);
   actions.forEach((b) => { b.disabled = true; });
 
@@ -3776,8 +3779,11 @@ function renderVerifyResults(container, status, id) {
   container.append(cards);
 }
 
-// openVerifyExplain fetches and shows the row-level drill-down for one
-// mismatched table, re-using the modal chrome showRotationDialog established.
+// openVerifyExplain shows the row-level drill-down for one mismatched table,
+// re-using the modal chrome showRotationDialog established. The server
+// computes it in the background (#1375), so most of this is the wait: a busy
+// dialog with Cancel, a ~20-minute poll, and the rules for which failures are
+// worth retrying.
 async function openVerifyExplain(id, schema, table, btn) {
   if (busyModalActive()) return; // one drill-down at a time (#1375)
   const gen = serverGen;
@@ -3788,7 +3794,7 @@ async function openVerifyExplain(id, schema, table, btn) {
     facts: [["table", schema + "." + table]],
     note: "Rebuilding this table from the older snapshot and its change log to diff it row by row — minutes on a large table. " +
       "The work continues on the server; closing this only stops the waiting. " +
-      "A new verify run discards drill-downs from the previous one, so reopening then starts over.",
+      "A new verify run discards drill-downs from the previous one — Explain is unavailable until that run finishes.",
     disable: btn ? [btn] : [],
     onCancel: () => ctrl.abort(),
   });
@@ -3801,11 +3807,9 @@ async function openVerifyExplain(id, schema, table, btn) {
     "?schema=" + encodeURIComponent(schema) + "&table=" + encodeURIComponent(table);
   const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
   let ex;
-  // A blip mid-poll must not be reported as a failed drill-down: the whole
-  // reason this endpoint went async is that long waits sit behind proxies
-  // that hiccup, and the daemon's job is unaffected by a dropped poll. But
-  // an endpoint that is genuinely down must still surface, so only
-  // CONSECUTIVE failures are tolerated — a single success resets the count.
+  // Consecutive transport failures tolerated before giving up. A dropped
+  // poll does not affect the daemon's job, and the whole reason this endpoint
+  // went async is that long waits sit behind proxies that hiccup.
   let misses = 0;
   // ~20 minutes at 2s, the same cap and cadence pollVerify uses.
   for (let i = 0; i < 600; i++) {
@@ -3814,6 +3818,23 @@ async function openVerifyExplain(id, schema, table, btn) {
       res = await api(url, { signal: ctrl.signal });
     } catch (err) {
       if (err && err.name === "AbortError") return; // Cancel/ESC already tore the modal down
+      // A 401 already raised the sign-in gate inside api() and bumped
+      // serverGen. Bail on that here, not only in the success branch below:
+      // a dead session never reaches the success branch, and retrying would
+      // end in a red "Couldn't explain this mismatch: session expired" that
+      // blames the drill-down and pulls focus off the password field.
+      if (gen !== serverGen) { busy.close(); return; }
+      // Only a MISSING response or a gateway status is the proxy hiccup this
+      // loop tolerates. Any other status is an answer the console actually
+      // received, and retrying it is worse than useless: the 500 that carries
+      // the drill-down's own failure was CONSUMED by the read that produced
+      // it, so the next poll starts a whole new reconstruction and answers
+      // 202 — which resets the miss count. A failing drill-down would loop
+      // for the full 20 minutes and never show the operator the error.
+      // Durable 403/404 are terminal for the same reason pollVerify treats
+      // them so. Re-clicking Explain is the retry.
+      const gateway = err && (err.status === 502 || err.status === 503 || err.status === 504);
+      if (err && err.status && !gateway) { busy.showError(err); return; }
       if (++misses > 5) { busy.showError(err); return; }
       await sleep(2000);
       continue;
@@ -3821,17 +3842,20 @@ async function openVerifyExplain(id, schema, table, btn) {
     misses = 0;
     if (gen !== serverGen) { busy.close(); return; }
     if (res && res.explain) { ex = res.explain; break; }
-    // 202 → still running. api() returns the {state:"running"} body.
+    // api() does not throw on a 202: it returns the {state:"running"} body,
+    // which has no .explain, so the loop falls through to the sleep.
     await sleep(2000);
   }
   if (!ex) {
-    // NOT showError: giving up waiting is not the drill-down failing, and the
-    // red "Couldn't explain this mismatch" treatment would report a failure
-    // that has not happened. Mirrors pollBaseline's neutral "check back"
-    // toast. The wording promises nothing about reopening — a scheduled run
-    // may have discarded the result by then.
+    // NOT showError: after 600 ticks the last answer was a 202, so the daemon
+    // is still working — this loop cannot tell a slow reconstruction from one
+    // that is merely slow, and the red "Couldn't explain this mismatch"
+    // treatment would assert a failure it has not seen. Mirrors
+    // pollBaseline's neutral "check back" toast. The wording promises nothing
+    // about reopening: a scheduled run may have discarded the result, and the
+    // daemon log is where a repeat belongs.
     busy.close();
-    toast("Still working after 20 minutes — it continues on the server. Reopen Explain to check.");
+    toast("Still waiting after 20 minutes — it continues on the server. Reopen Explain to try again; check the daemon log if this repeats.");
     return;
   }
   busy.close();

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2006,7 +2006,13 @@ function setSelectWhenReady(form, name, value, cb) {
   }, 50);
 }
 
-// ── busy modal for the Restore actions (#1363) ───────────────────────────────
+// ── busy modal for long actions (#1363, generalized in #1375) ────────────────
+//
+// Originally Restore-only, hence the recover-flavored default note. Verify's
+// Explain reuses it (#1375) because it has the identical shape: one click
+// starts minutes of work with nothing to show, and the failure mode is an
+// operator concluding the button is dead. Callers that are not a form pass
+// opts.disable (the elements to hold disabled) instead of a form element.
 //
 // Generate-undo (and Preview, which sits on the same latency) used to give no
 // feedback until the fetch returned — seconds, when the window reaches
@@ -2020,19 +2026,19 @@ function setSelectWhenReady(form, name, value, cb) {
 // in-flight fetch via AbortController. Errors render IN the modal with the
 // server's own actionable text — never a silently-vanished overlay.
 
-let recoverBusyOpen = false; // one click = one generation (re-entry guard)
+let busyModalOpen = false; // one click = one generation (re-entry guard)
 
-// recoverBusyActive is the re-entry guard READ, and it self-heals: the shared
+// busyModalActive is the re-entry guard READ, and it self-heals: the shared
 // #modal slot has other occupants (Manage servers, the rotation dialog) that
 // replace its children without our teardown, so a set flag with no
 // .busy-modal actually in the slot is stale — honoring it would wedge every
 // future Generate/Preview click silently. The isConnected guards in
-// openRecoverBusy tear down on the next keystroke; this covers the click
+// openBusyModal tear down on the next keystroke; this covers the click
 // path that arrives first.
-function recoverBusyActive() {
-  if (!recoverBusyOpen) return false;
+function busyModalActive() {
+  if (!busyModalOpen) return false;
   if (document.querySelector("#modal .busy-modal")) return true;
-  recoverBusyOpen = false;
+  busyModalOpen = false;
   return false;
 }
 
@@ -2046,16 +2052,19 @@ function recoverBusyFacts(f) {
   return facts;
 }
 
-// openRecoverBusy opens the busy dialog and disables the form's action
+// openBusyModal opens the busy dialog and disables the form's action
 // buttons until it closes. Returns {close(refocus), showError(err)}; Cancel
 // and ESC run opts.onCancel (the fetch abort) and restore focus to the
 // element that had it. Accessibility: role="dialog", aria-busy while working,
 // focus trapped inside, focus restored on cancel/dismiss.
-function openRecoverBusy(form, opts) {
-  recoverBusyOpen = true;
+function openBusyModal(form, opts) {
+  busyModalOpen = true;
   const mount = document.getElementById("modal");
   const trigger = document.activeElement;
-  const actions = $all(".filter-actions button", form);
+  // A form caller disables its action row; a non-form caller (Explain) names
+  // the elements itself. Either way SOMETHING visibly stops accepting clicks,
+  // which is half of what tells an operator the click registered.
+  const actions = opts.disable || (form ? $all(".filter-actions button", form) : []);
   actions.forEach((b) => { b.disabled = true; });
 
   const scrim = el("div", { class: "modal-scrim show" });
@@ -2069,7 +2078,7 @@ function openRecoverBusy(form, opts) {
   (opts.facts || []).forEach(([k, v]) => facts.append(el("div", { class: "busy-fact" },
     el("span", { class: "bf-k", text: k }), el("span", { class: "bf-v", text: v }))));
   body.append(facts);
-  body.append(el("p", { class: "busy-note", text:
+  body.append(el("p", { class: "busy-note", text: opts.note ||
     "Reading indexed changes — a window that reaches archived hours can take a few seconds." }));
   const foot = el("div", { class: "modal-foot" });
   const cancelBtn = el("button", { class: "btn", type: "button", text: "Cancel", onclick: () => cancel() });
@@ -2115,7 +2124,7 @@ function openRecoverBusy(form, opts) {
     document.removeEventListener("keydown", onKey, true);
     scrim.remove();
     actions.forEach((b) => { b.disabled = false; });
-    recoverBusyOpen = false;
+    busyModalOpen = false;
     return true;
   };
   const restoreFocus = () => {
@@ -2152,7 +2161,7 @@ function openRecoverBusy(form, opts) {
 }
 
 async function previewRecover(form) {
-  if (recoverBusyActive()) return; // shares the one-in-flight guard with Generate (#1363)
+  if (busyModalActive()) return; // shares the one-in-flight guard with Generate (#1363)
   const gen = serverGen;
   const container = $("#recover-preview", VIEW());
   const warns = $("#recover-warnings", VIEW());
@@ -2166,7 +2175,7 @@ async function previewRecover(form) {
   params.limit = "1000";
   params.order = "desc";
   const ctrl = new AbortController();
-  const busy = openRecoverBusy(form, {
+  const busy = openBusyModal(form, {
     title: "Previewing affected rows",
     errTitle: "Couldn't preview the rows",
     facts: recoverBusyFacts(params),
@@ -2228,7 +2237,7 @@ async function previewRecover(form) {
 }
 
 async function generateUndo(form) {
-  if (recoverBusyActive()) return; // one click = one generation (#1363)
+  if (busyModalActive()) return; // one click = one generation (#1363)
   const gen = serverGen;
   const warns = $("#recover-warnings", VIEW());
   const out = $("#recover-out", VIEW());
@@ -2237,7 +2246,7 @@ async function generateUndo(form) {
   ["schema", "table", "pk", "since", "until"].forEach((k) => { if (f[k] && f[k].trim()) body[k] = f[k].trim(); });
   if (!body.schema) { renderError(out, "Choose at least a schema to search."); return; }
   const ctrl = new AbortController();
-  const busy = openRecoverBusy(form, {
+  const busy = openBusyModal(form, {
     title: "Generating undo SQL",
     errTitle: "Couldn't generate the undo SQL",
     facts: recoverBusyFacts(body),
@@ -3758,7 +3767,7 @@ function renderVerifyResults(container, status, id) {
       el("div", { class: "dc-name", text: r.schema + "." + r.table + " — " + r.status + (r.reason ? " — " + r.reason : "") }));
     if (r.explainable) {
       const explainBtn = el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Explain" });
-      explainBtn.onclick = () => openVerifyExplain(id, r.schema, r.table);
+      explainBtn.onclick = () => openVerifyExplain(id, r.schema, r.table, explainBtn);
       body.append(explainBtn);
     }
     card.append(body);
@@ -3769,15 +3778,49 @@ function renderVerifyResults(container, status, id) {
 
 // openVerifyExplain fetches and shows the row-level drill-down for one
 // mismatched table, re-using the modal chrome showRotationDialog established.
-async function openVerifyExplain(id, schema, table) {
+async function openVerifyExplain(id, schema, table, btn) {
+  if (busyModalActive()) return; // one drill-down at a time (#1375)
+  const gen = serverGen;
+  const ctrl = new AbortController();
+  const busy = openBusyModal(null, {
+    title: "Working out what differs",
+    errTitle: "Couldn't explain this mismatch",
+    facts: [["table", schema + "." + table]],
+    note: "Rebuilding this table from the older snapshot and its change log to diff it row by row — minutes on a large table. " +
+      "The work continues on the server; closing this only stops the waiting.",
+    disable: btn ? [btn] : [],
+    onCancel: () => ctrl.abort(),
+  });
+
+  // The server answers 202 while the reconstruction runs and 200 with the
+  // drill-down once it lands (#1375), so this polls instead of holding one
+  // long request open — a synchronous answer could not outlive a fronting
+  // proxy's read timeout, which is what made this button look dead.
+  const url = "/api/servers/" + encodeURIComponent(id) + "/verify/explain" +
+    "?schema=" + encodeURIComponent(schema) + "&table=" + encodeURIComponent(table);
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
   let ex;
-  try {
-    ex = (await api("/api/servers/" + encodeURIComponent(id) + "/verify/explain" +
-      "?schema=" + encodeURIComponent(schema) + "&table=" + encodeURIComponent(table))).explain;
-  } catch (err) {
-    toast("Explain failed: " + ((err && err.message) || err));
+  // ~20 minutes at 2s, the same cap and cadence pollVerify uses.
+  for (let i = 0; i < 600; i++) {
+    let res;
+    try {
+      res = await api(url, { signal: ctrl.signal });
+    } catch (err) {
+      if (err && err.name === "AbortError") return; // Cancel/ESC already tore the modal down
+      busy.showError(err);
+      return;
+    }
+    if (gen !== serverGen) { busy.close(); return; }
+    if (res && res.explain) { ex = res.explain; break; }
+    // 202 → still running. api() returns the {state:"running"} body.
+    await sleep(2000);
+  }
+  if (!ex) {
+    busy.showError(new Error(
+      "still working after 20 minutes — it keeps running on the server, so reopening Explain later will show the result."));
     return;
   }
+  busy.close();
   const mount = document.getElementById("modal");
   const scrim = el("div", { class: "modal-scrim show" });
   const modal = el("div", { class: "modal vfy-explain-modal", role: "dialog", "aria-label": "Verify mismatch drill-down" });

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -3794,7 +3794,7 @@ async function openVerifyExplain(id, schema, table, btn) {
     facts: [["table", schema + "." + table]],
     note: "Rebuilding this table from the older snapshot and its change log to diff it row by row — minutes on a large table. " +
       "The work continues on the server; closing this only stops the waiting. " +
-      "A new verify run discards drill-downs from the previous one — Explain is unavailable until that run finishes.",
+      "A new verify run discards drill-downs from the previous one — Explain is unavailable until a baseline-anchored run reports this table as a mismatch again.",
     disable: btn ? [btn] : [],
     onCancel: () => ctrl.abort(),
   });
@@ -3847,13 +3847,14 @@ async function openVerifyExplain(id, schema, table, btn) {
     await sleep(2000);
   }
   if (!ex) {
-    // NOT showError: after 600 ticks the last answer was a 202, so the daemon
-    // is still working — this loop cannot tell a slow reconstruction from one
-    // that is merely slow, and the red "Couldn't explain this mismatch"
-    // treatment would assert a failure it has not seen. Mirrors
-    // pollBaseline's neutral "check back" toast. The wording promises nothing
-    // about reopening: a scheduled run may have discarded the result, and the
-    // daemon log is where a repeat belongs.
+    // NOT showError: this loop cannot distinguish a STUCK reconstruction from
+    // a merely slow one, and it may have spent its last ticks on tolerated
+    // poll failures rather than 202s (misses resets on any success), so it
+    // cannot even assert the daemon answered recently. Either way the red
+    // "Couldn't explain this mismatch" treatment would claim a failure it has
+    // not seen. Mirrors pollBaseline's neutral "check back" toast. The
+    // wording promises nothing about reopening: a scheduled run may have
+    // discarded the result, and the daemon log is where a repeat belongs.
     busy.close();
     toast("Still waiting after 20 minutes — it continues on the server. Reopen Explain to try again; check the daemon log if this repeats.");
     return;

--- a/internal/console/auth.go
+++ b/internal/console/auth.go
@@ -228,8 +228,8 @@ const maxAPIBody = 1 << 20
 //     *http.MaxBytesError on overflow (writeBodyDecodeError maps it to 413);
 //   - clears the connection read deadline armed by the server-wide
 //     ReadTimeout. That timeout exists to bound unauthenticated slow-drip
-//     connections; several authenticated handlers (recover, verify explain,
-//     reconstruct over S3 archives) legitimately run past it, and net/http's
+//     connections; several authenticated handlers (recover, reconstruct over
+//     S3 archives) legitimately run past it, and net/http's
 //     background read hitting the deadline cancels the request context
 //     mid-flight. Best-effort: recorders and non-deadline writers just skip
 //     it.

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -18,6 +18,18 @@ var ErrVerifyRunning = errors.New("a verify run is already running for this serv
 // a newer run has since replaced it. The handler maps it to 404.
 var ErrExplainUnavailable = errors.New("no explainable mismatch for this table — run a baseline-anchored verify first, or this table was not reported as a mismatch by the last run")
 
+// ErrExplainRunning is returned by VerifyController.Explain while the
+// drill-down for that table is still being computed. The handler maps it to
+// 202 Accepted, and the caller polls the same URL until it answers 200.
+//
+// This exists because the drill-down RE-RECONSTRUCTS the table (#1375): on a
+// large table that is minutes of DuckDB work, which outlives any fronting
+// proxy's read timeout. Answering synchronously meant the operator's only
+// possible experience was a request that died in the proxy — a button that
+// silently did nothing. The work now runs on the daemon like a verify run
+// does, and the request returns immediately either way.
+var ErrExplainRunning = errors.New("the drill-down for this table is still being computed")
+
 // VerifyController runs bintrail verify's engine in-process for a monitored
 // server (#677) — the same internal/verify functions internal/cli/verify.go
 // calls, looped over a server's tables in a background goroutine so the
@@ -40,6 +52,13 @@ type VerifyController interface {
 	// re-reconstructs the table). Returns ErrExplainUnavailable when no such
 	// run/table exists (including: the last run was live-source, which has no
 	// explain support in the engine).
+	//
+	// It MUST NOT block on the reconstruction (#1375): implementations start
+	// the work in the background and return ErrExplainRunning immediately,
+	// answering with the result on a later call. The reconstruction takes
+	// minutes on a large table, and a synchronous answer cannot outlive a
+	// fronting proxy's read timeout — so a blocking implementation makes the
+	// feature unusable on exactly the tables an operator most needs it for.
 	Explain(serverID, schema, table string) (*VerifyExplanation, error)
 }
 
@@ -308,6 +327,14 @@ func (s *Server) handleVerifyExplain(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, ErrExplainUnavailable) {
 			writeJSONError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		// 202: the work is running on the daemon; the caller polls this same
+		// URL. Deliberately NOT an error body — a poll tick is a normal
+		// state, and rendering it as a failure is what would put a spurious
+		// "explain failed" in front of an operator who is merely waiting.
+		if errors.Is(err, ErrExplainRunning) {
+			writeJSON(w, http.StatusAccepted, map[string]any{"state": "running"})
 			return
 		}
 		writeJSONError(w, http.StatusInternalServerError, err.Error())

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -16,7 +16,13 @@ var ErrVerifyRunning = errors.New("a verify run is already running for this serv
 // no cached baseline pair to explain from: no completed baseline-anchored run
 // exists for this server, the table was not reported as a mismatch by it, or
 // a newer run has since replaced it. The handler maps it to 404.
-var ErrExplainUnavailable = errors.New("no explainable mismatch for this table — run a baseline-anchored verify first, or this table was not reported as a mismatch by the last run")
+// The message names the newer-run case explicitly: a scheduled run
+// (--verify-interval) that starts while a drill-down is still computing drops
+// the previous run's cached pairs, so an operator mid-wait can land here with
+// a verify actually in flight. Without that clause the text tells them to "run
+// a baseline-anchored verify first" while one is running — advice that sends
+// them looking for a problem that does not exist.
+var ErrExplainUnavailable = errors.New("no explainable mismatch for this table — run a baseline-anchored verify first, or this table was not reported as a mismatch by the last run, or a newer run has replaced the previous results (re-open Explain once it finishes)")
 
 // ErrExplainRunning is returned by VerifyController.Explain while the
 // drill-down for that table is still being computed. The handler maps it to

--- a/internal/console/verify_trigger.go
+++ b/internal/console/verify_trigger.go
@@ -22,18 +22,20 @@ var ErrVerifyRunning = errors.New("a verify run is already running for this serv
 // a verify actually in flight. Without that clause the text tells them to "run
 // a baseline-anchored verify first" while one is running — advice that sends
 // them looking for a problem that does not exist.
-var ErrExplainUnavailable = errors.New("no explainable mismatch for this table — run a baseline-anchored verify first, or this table was not reported as a mismatch by the last run, or a newer run has replaced the previous results (re-open Explain once it finishes)")
+var ErrExplainUnavailable = errors.New("no explainable mismatch for this table — run a baseline-anchored verify first, or this table was not reported as a mismatch by the last run, or a newer run has replaced the previous results (re-open Explain if that run still reports this table as a mismatch)")
 
 // ErrExplainRunning is returned by VerifyController.Explain while the
 // drill-down for that table is still being computed. The handler maps it to
-// 202 Accepted, and the caller polls the same URL until it answers 200.
+// 202 Accepted, and the caller polls the same URL until it answers 200, 404
+// (a newer run replaced the pair), or the caller's own cap.
 //
 // This exists because the drill-down RE-RECONSTRUCTS the table (#1375): on a
-// large table that is minutes of DuckDB work, which outlives any fronting
-// proxy's read timeout. Answering synchronously meant the operator's only
-// possible experience was a request that died in the proxy — a button that
-// silently did nothing. The work now runs on the daemon like a verify run
-// does, and the request returns immediately either way.
+// large table that is minutes of DuckDB work. The console itself tolerates
+// that — it sets no WriteTimeout and apiGuard clears the read deadline — but
+// a fronting reverse proxy at its stock read timeout (60s on nginx) does not,
+// so behind one the operator's only experience was a request that died in the
+// proxy: a button that silently did nothing. The work now runs on the daemon
+// like a verify run does, and the request returns immediately either way.
 var ErrExplainRunning = errors.New("the drill-down for this table is still being computed")
 
 // VerifyController runs bintrail verify's engine in-process for a monitored

--- a/internal/console/verify_trigger_test.go
+++ b/internal/console/verify_trigger_test.go
@@ -460,6 +460,31 @@ func TestVerifyExplain_unavailable(t *testing.T) {
 	}
 }
 
+// TestVerifyExplain_running: while the drill-down is being computed the
+// handler answers 202 with a plain running state — NOT an error body (#1375).
+// A poll tick is a normal state; rendering it as a failure would put a
+// spurious "explain failed" in front of an operator who is merely waiting,
+// which is the shape this whole change exists to remove.
+func TestVerifyExplain_running(t *testing.T) {
+	srv, ctrl := newVerifyTriggerServer(t)
+	ctrl.explainErr = ErrExplainRunning
+	id := addVerifyEntry(t, srv, "u:p@tcp(127.0.0.1:3306)/", "s3://b/baselines/", "")
+	rec, body := doServersReq(t, srv, "GET", "/api/servers/"+id+"/verify/explain?schema=wp&table=posts", "")
+	if rec.Code != 202 {
+		t.Fatalf("running: code=%d body=%s, want 202", rec.Code, body)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("body not JSON: %v (%s)", err, body)
+	}
+	if resp["state"] != "running" {
+		t.Errorf("body = %s, want state=running", body)
+	}
+	if _, isErr := resp["error"]; isErr {
+		t.Errorf("202 carries an error field (%s) — a poll tick must not read as a failure", body)
+	}
+}
+
 // TestVerifyExplain_happy: a successful drill-down round-trips through JSON.
 func TestVerifyExplain_happy(t *testing.T) {
 	srv, ctrl := newVerifyTriggerServer(t)

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1764,7 +1764,7 @@ try {
       // The click path can arrive before any keystroke: the re-entry guard
       // must self-heal on read when the flag is set but no .busy-modal is in
       // the slot.
-      const selfHealed = !recoverBusyActive() && !recoverBusyOpen;
+      const selfHealed = !busyModalActive() && !busyModalOpen;
       document.activeElement.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true }));
       await sleep(80);
       const clobberLeg = {
@@ -1772,7 +1772,7 @@ try {
         busyGone,
         selfHealed,
         btnEnabled: !genBtn.disabled,
-        flagReset: !recoverBusyOpen,
+        flagReset: !busyModalOpen,
         serversIntact: !!document.getElementById("servers-list"),
       };
       closeServersModal();
@@ -1869,9 +1869,9 @@ try {
   // Scenario 17b — the reduced-motion arm (#1363, same rule as the #1353
   // skeletons): under prefers-reduced-motion the CSS animation is replaced by
   // the static note; under no-preference the animation shows and the note
-  // hides. Driven through the REAL openRecoverBusy against emulated media.
+  // hides. Driven through the REAL openBusyModal against emulated media.
   const rmProbe = async () => page.evaluate(() => {
-    const busy = openRecoverBusy(document.getElementById("recover-form"),
+    const busy = openBusyModal(document.getElementById("recover-form"),
       { title: "probe", errTitle: "probe", facts: [], onCancel: () => {} });
     const res = {
       anim: getComputedStyle(document.querySelector("#modal .busy-anim")).display,


### PR DESCRIPTION
Closes #1375.

## The problem

`Explain` re-reconstructs the table to diff it (its own interface doc says so). It answered **synchronously** and the view rendered **nothing** until the response came back. Two consequences on a large table: the operator sees a dead button, and behind a fronting proxy the request dies at the read timeout — so the drill-down is unusable on exactly the tables it exists for. The failure then appeared only as a `toast()`, which fades.

## Server

`VerifyController.Explain` must not block (documented on the interface). The supervisor starts the work in the background and returns the new `ErrExplainRunning`; the handler maps it to **202** with `{state:"running"}` — deliberately not an error body, since a poll tick is a normal state.

Lifecycle decisions, all pinned by tests:
- **Finished entries are consumed on read** — a retry re-runs instead of replaying a stale failure forever.
- **A new run drops that server's drill-downs** — each explains the BaselinePair *its own run* compared; serving one afterwards would explain a verdict the results no longer show. Other servers' entries survive.
- **Polls reuse the in-flight job** — no second minutes-long DuckDB reconstruction per poll tick or impatient click.
- Cache eviction drops only *finished* entries, so overflow can't throw away running work and cause it to restart.

## Client

The #1363 busy modal (cancelable, re-entry-guarded, errors rendered **in** the dialog rather than a fading toast) now serves Explain too — hence the rename off its recover-specific name and the caller-supplied elements to disable. The view polls at `pollVerify`'s cadence/cap and states that the work continues server-side if the dialog is closed.

## Verification

`go vet` + full unit suite green. Mutation-checked: removing the re-entry guard fails `TestVerifySupervisor_ExplainReentryGuard`; removing the invalidation fails `TestVerifySupervisor_ExplainInvalidatedByNewRun`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
