### PR TITLE
baseline: make point-consistent dumps possible on managed MySQL (lock-all), and stop console failures from vanishing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,9 @@
 # The user needs REPLICATION SLAVE, REPLICATION CLIENT, and SELECT.
 # Baselines additionally need RELOAD (or FLUSH_TABLES), plus BACKUP_ADMIN on
 # MySQL/Percona 8.0+, because the snapshot is point-consistent by default.
-# Without them, set BASELINE_LOCK_MODE below instead of granting.
+# On managed MySQL (RDS/Aurora) BACKUP_ADMIN CANNOT be granted at all: grant
+# LOCK TABLES and set BASELINE_LOCK_MODE=lock-all, which is equally
+# point-consistent. Otherwise set BASELINE_LOCK_MODE below instead of granting.
 #
 # BASELINE_LOCK_MODE: how the baseline dump syncs mydumper's threads onto one
 # instant. ftwrl (default) is point-consistent; lock-all is also

--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,10 @@
 # Without them, set BASELINE_LOCK_MODE below instead of granting.
 #
 # BASELINE_LOCK_MODE: how the baseline dump syncs mydumper's threads onto one
-# instant. ftwrl (default) is point-consistent; safe-no-lock needs no extra
+# instant. ftwrl (default) is point-consistent; lock-all is also
+# point-consistent and needs only LOCK TABLES — use it on managed MySQL such as
+# RDS, where BACKUP_ADMIN cannot be granted and ftwrl therefore cannot work;
+# safe-no-lock needs no extra
 # privilege but ABORTS rather than write a snapshot stitched from several
 # instants, so expect it to refuse on a write-active source; no-lock accepts
 # such a snapshot. A baseline is the seed state reconstruct merges deltas onto,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Point-consistent baselines were impossible on managed MySQL** (#1381).
+  v0.58.0 made them the default; on RDS the button then failed for every
+  operator, for two independent reasons.
+  - The privilege preflight read `information_schema.USER_PRIVILEGES`, which
+    exposes only the rows the connecting user can SEE in `mysql.user`. A
+    managed master user cannot see its own: on RDS MySQL 8.4 that view returned
+    a single `USAGE` row for an account whose `SHOW GRANTS` listed `RELOAD` and
+    `FLUSH_TABLES` as direct grants. The check therefore failed **closed** on
+    every managed source and reported "the current user has neither" about
+    privileges the user held. It now parses `SHOW GRANTS FOR CURRENT_USER()`,
+    which needs no privilege to run and reflects the session's active roles.
+  - `ftwrl` genuinely cannot work on RDS: `BACKUP_ADMIN` is refused outright
+    (*"ERROR 1227 ... you need the RDSADMIN USER privilege"*) and mydumper's
+    FTWRL path issues `LOCK INSTANCE FOR BACKUP` first. So **`lock-all` is
+    new**: mydumper's fourth sync mode, equally point-consistent, synchronizing
+    workers by locking the exported tables instead of the instance. It needs
+    only `LOCK TABLES` — which the RDS master user already has — and was
+    verified to succeed against the exact privilege set on which `ftwrl` fails.
+    Available as `--lock-mode lock-all`, `BINTRAIL_CONSOLE_BASELINE_LOCK_MODE`
+    and `BASELINE_LOCK_MODE`.
+  - Privilege requirements are now evaluated PER MODE rather than assuming
+    every point-consistent mode needs the same grants, and a refusal names
+    `lock-all` **before** the weaker modes: on a source that cannot do `ftwrl`
+    it is the only alternative that is still point-consistent.
+
+### Changed
+- **Console failures no longer disappear on their own.** Every failure notice
+  was a toast that auto-hid after 2.2 seconds. The baseline privilege refusal
+  is ~550 characters — which privilege to grant, the exact `GRANT`, and the
+  alternative modes — so at that duration it was not merely easy to miss, it
+  was unreadable, and there was no way to recover the reason afterwards.
+  Failures now stay until dismissed with the close button or ESC, and scroll
+  if long; success and progress notices still fade.
+
 ## [0.58.0] - 2026-08-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,25 +22,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ftwrl` genuinely cannot work on RDS: `BACKUP_ADMIN` is refused outright
     (*"ERROR 1227 ... you need the RDSADMIN USER privilege"*) and mydumper's
     FTWRL path issues `LOCK INSTANCE FOR BACKUP` first. So **`lock-all` is
-    new**: mydumper's fourth sync mode, equally point-consistent, synchronizing
-    workers by locking the exported tables instead of the instance. It needs
-    only `LOCK TABLES` — which the RDS master user already has — and was
-    verified to succeed against the exact privilege set on which `ftwrl` fails.
-    Available as `--lock-mode lock-all`, `BINTRAIL_CONSOLE_BASELINE_LOCK_MODE`
-    and `BASELINE_LOCK_MODE`.
+    new**: bintrail's fourth lock mode, mapping to mydumper's `LOCK_ALL`, which
+    is equally point-consistent and synchronizes workers by locking the exported
+    tables instead of the instance. mydumper names it for this itself — *"We
+    support LOCK_ALL and SAFE_NO_LOCK modes for RDS/Aurora"* — and it needs only
+    `LOCK TABLES`, at any scope covering the dumped tables, which the RDS master
+    user already has. Verified to succeed against the exact privilege set on
+    which `ftwrl` fails. Available as `--lock-mode lock-all`,
+    `BINTRAIL_CONSOLE_BASELINE_LOCK_MODE` and `BASELINE_LOCK_MODE`.
+    Note this changes which privileges are required, not which tables can be
+    dumped: like `ftwrl`, it refuses a source with non-transactional tables.
   - Privilege requirements are now evaluated PER MODE rather than assuming
     every point-consistent mode needs the same grants, and a refusal names
     `lock-all` **before** the weaker modes: on a source that cannot do `ftwrl`
     it is the only alternative that is still point-consistent.
 
 ### Changed
-- **Console failures no longer disappear on their own.** Every failure notice
-  was a toast that auto-hid after 2.2 seconds. The baseline privilege refusal
-  is ~550 characters — which privilege to grant, the exact `GRANT`, and the
+- **Console failures no longer disappear on their own.** Failure notices were
+  toasts that auto-hid after 2.2 seconds. The baseline privilege refusal is
+  ~550 characters — which privilege to grant, the exact `GRANT`, and the
   alternative modes — so at that duration it was not merely easy to miss, it
   was unreadable, and there was no way to recover the reason afterwards.
   Failures now stay until dismissed with the close button or ESC, and scroll
-  if long; success and progress notices still fade.
+  if long; success and progress notices still fade. Concurrent failures stack
+  instead of overwriting each other, and a success notice no longer replaces an
+  unread failure — with no auto-hide, a silent overwrite would destroy a message
+  the operator never saw.
 
 ## [0.58.0] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Privilege requirements are now evaluated PER MODE rather than assuming
     every point-consistent mode needs the same grants, and a refusal names
     `lock-all` **before** the weaker modes: on a source that cannot do `ftwrl`
-    it is the only alternative that is still point-consistent.
+    it is the only alternative that is still point-consistent. `lock-all`
+    accepts `LOCK TABLES` granted on the dumped schema rather than demanding it
+    globally — `LOCK_ALL` locks the exported tables, and a dump runs to
+    completion with only `GRANT SELECT, LOCK TABLES, SHOW VIEW ON <schema>.*`.
+  - **Partial revokes are no longer read as a grant.** MySQL 8.0.16+ renders
+    `REVOKE LOCK TABLES ON \`db\`.*` as its own `SHOW GRANTS` line; reading only
+    the `GRANT` lines reported a privilege the user does not have, and mydumper
+    would then launch and die partway leaving a partial dump. A revoke that
+    provably covers a dumped schema is now a refusal naming it, one that
+    provably does not is ignored, and an undecidable grant pattern is a
+    warning — never a refusal, which would be the same over-refusal as above.
 
 ### Changed
 - **Console failures no longer disappear on their own.** Failure notices were
@@ -44,10 +54,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alternative modes — so at that duration it was not merely easy to miss, it
   was unreadable, and there was no way to recover the reason afterwards.
   Failures now stay until dismissed with the close button or ESC, and scroll
-  if long; success and progress notices still fade. Concurrent failures stack
-  instead of overwriting each other, and a success notice no longer replaces an
-  unread failure — with no auto-hide, a silent overwrite would destroy a message
-  the operator never saw.
+  if long; success and progress notices still fade. Failures render in their own
+  element, so neither channel can suppress the other: a success notice cannot
+  replace an unread failure, and an undismissed failure cannot swallow a warning
+  that is reported nowhere else (an interrupted MCP-token display, a schema
+  snapshot that capture did not restart onto, an export hitting its row cap).
+  Concurrent failures stack, and a repeat of a message already on screen is
+  counted rather than dropped — several of them carry no server name, so a
+  second failure would otherwise change nothing on screen.
 
 ## [0.58.0] - 2026-08-16
 

--- a/cliapp/dump.go
+++ b/cliapp/dump.go
@@ -62,7 +62,7 @@ func init() {
 	dumpCmd.Flags().StringVar(&dmpMydumperImage, "mydumper-image", "mydumper/mydumper:latest", "Docker image for mydumper (used when no local binary is found)")
 	dumpCmd.Flags().IntVar(&dmpThreads, "threads", 4, "Number of mydumper dump threads")
 	dumpCmd.Flags().StringVar(&dmpLockMode, "lock-mode", string(baseline.DefaultLockMode),
-		"How mydumper syncs its threads onto one instant: ftwrl (default, point-consistent, needs RELOAD/FLUSH_TABLES and BACKUP_ADMIN on MySQL 8.0+), safe-no-lock (no extra privilege, ABORTS rather than emit a torn snapshot), no-lock (accepts a torn snapshot)")
+		"How mydumper syncs its threads onto one instant: ftwrl (default, point-consistent; needs RELOAD/FLUSH_TABLES plus BACKUP_ADMIN on MySQL 8.0+), lock-all (point-consistent, needs only LOCK TABLES — the mode that works on managed MySQL such as RDS, where BACKUP_ADMIN cannot be granted), safe-no-lock (no extra privilege, ABORTS rather than emit a torn snapshot), no-lock (accepts a torn snapshot)")
 	dumpCmd.Flags().StringVar(&dmpFormat, "format", "text", "Output format: text or json")
 	dumpCmd.Flags().BoolVar(&dmpEncrypt, "encrypt", false, "Encrypt dump files at rest using AES-256-CBC and write an HMAC-SHA256 integrity sidecar (<file>.enc.hmac) per file (requires openssl on $PATH)")
 	dumpCmd.Flags().StringVar(&dmpEncryptKey, "encrypt-key", "", "Path to encryption key file (default: ~/.config/bintrail/dump.key; generate with 'bintrail generate-key')")
@@ -268,7 +268,7 @@ func runDump(cmd *cobra.Command, args []string) error {
 	// point-consistent mode the default here too, so the guard has to come
 	// with it. Skipped when the flag is not being sent at all.
 	if supportsLockMode && lockMode.NeedsElevatedPrivileges() {
-		if err := mydumperlock.CheckPrivileges(cmd.Context(), dmpSourceDSN, mydumperlock.RemedyCLI); err != nil {
+		if err := mydumperlock.CheckPrivileges(cmd.Context(), dmpSourceDSN, lockMode, mydumperlock.RemedyCLI); err != nil {
 			return err
 		}
 	}

--- a/cliapp/dump.go
+++ b/cliapp/dump.go
@@ -23,6 +23,14 @@ import (
 	"github.com/dbtrail/dbtrail/internal/mydumperlock"
 )
 
+// checkMydumperPrivileges is mydumperlock.CheckPrivileges behind a seam, so a
+// test can observe the LOCK MODE this call site actually forwards. Without it
+// the argument is unverifiable: every mode fails identically against an
+// unreachable source, so hardcoding one here passes the whole suite while
+// re-introducing #1381 — an operator who selected lock-all gets judged against
+// ftwrl's requirements and told to grant BACKUP_ADMIN, which RDS refuses.
+var checkMydumperPrivileges = mydumperlock.CheckPrivileges
+
 var dumpCmd = &cobra.Command{
 	Use:   "dump",
 	Short: "Invoke mydumper to create a logical dump of the source MySQL instance",
@@ -268,7 +276,7 @@ func runDump(cmd *cobra.Command, args []string) error {
 	// point-consistent mode the default here too, so the guard has to come
 	// with it. Skipped when the flag is not being sent at all.
 	if supportsLockMode && lockMode.NeedsElevatedPrivileges() {
-		if err := mydumperlock.CheckPrivileges(cmd.Context(), dmpSourceDSN, lockMode, mydumperlock.RemedyCLI); err != nil {
+		if err := checkMydumperPrivileges(cmd.Context(), dmpSourceDSN, lockMode, mydumperlock.RemedyCLI); err != nil {
 			return err
 		}
 	}

--- a/cliapp/dump.go
+++ b/cliapp/dump.go
@@ -276,7 +276,7 @@ func runDump(cmd *cobra.Command, args []string) error {
 	// point-consistent mode the default here too, so the guard has to come
 	// with it. Skipped when the flag is not being sent at all.
 	if supportsLockMode && lockMode.NeedsElevatedPrivileges() {
-		if err := checkMydumperPrivileges(cmd.Context(), dmpSourceDSN, lockMode, mydumperlock.RemedyCLI); err != nil {
+		if err := checkMydumperPrivileges(cmd.Context(), dmpSourceDSN, lockMode, mydumperlock.RemedyCLI, schemas); err != nil {
 			return err
 		}
 	}

--- a/cliapp/dump_lockmode_test.go
+++ b/cliapp/dump_lockmode_test.go
@@ -28,6 +28,7 @@ func TestBuildMydumperArgsCarriesLockMode(t *testing.T) {
 		want string
 	}{
 		{baseline.LockModeFTWRL, "FTWRL"},
+		{baseline.LockModeLockAll, "LOCK_ALL"},
 		{baseline.LockModeSafeNoLock, "SAFE_NO_LOCK"},
 		{baseline.LockModeNoLock, "NO_LOCK"},
 	} {

--- a/cliapp/dump_runlockmode_test.go
+++ b/cliapp/dump_runlockmode_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -142,8 +143,9 @@ func TestRunDumpForwardsTheSelectedModeToThePreflight(t *testing.T) {
 
 	var got baseline.LockMode
 	var gotRemedy mydumperlock.Remedy
-	checkMydumperPrivileges = func(_ context.Context, _ string, m baseline.LockMode, r mydumperlock.Remedy) error {
-		got, gotRemedy = m, r
+	var gotSchemas []string
+	checkMydumperPrivileges = func(_ context.Context, _ string, m baseline.LockMode, r mydumperlock.Remedy, sch []string) error {
+		got, gotRemedy, gotSchemas = m, r, sch
 		return errStopAfterPreflight
 	}
 	t.Cleanup(func() { checkMydumperPrivileges = mydumperlock.CheckPrivileges })
@@ -151,9 +153,12 @@ func TestRunDumpForwardsTheSelectedModeToThePreflight(t *testing.T) {
 	dmpSourceDSN = "u:p@tcp(127.0.0.1:1)/"
 	dmpOutputDir = filepath.Join(dir, "out")
 	dmpMydumperPath = bin
-	dmpLockMode = "lock-all"
+	// NOTE: dmpLockMode is deliberately NOT set here — newDumpCmdForTest's
+	// StringVar registration resets it, so only the Flags().Set below carries
+	// the mode. Assigning it here would read as load-bearing and be inert.
+	dmpSchemas = "appdb"
 	dmpFormat = "text"
-	t.Cleanup(func() { dmpLockMode = "ftwrl"; dmpSourceDSN = ""; dmpOutputDir = "" })
+	t.Cleanup(func() { dmpLockMode = "ftwrl"; dmpSchemas = ""; dmpSourceDSN = ""; dmpOutputDir = "" })
 
 	cmd := newDumpCmdForTest(t)
 	if err := cmd.Flags().Set("mydumper-path", bin); err != nil {
@@ -170,6 +175,11 @@ func TestRunDumpForwardsTheSelectedModeToThePreflight(t *testing.T) {
 	}
 	if gotRemedy != mydumperlock.RemedyCLI {
 		t.Errorf("remedy = %q, want the CLI's own knob named in the refusal", gotRemedy)
+	}
+	// The schema list decides whether a partial REVOKE applies to THIS dump.
+	// Forwarding the wrong one turns a provable refusal into a guess.
+	if !slices.Equal(gotSchemas, []string{"appdb"}) {
+		t.Errorf("schemas = %v, want the dump's own --schemas filter", gotSchemas)
 	}
 }
 

--- a/cliapp/dump_runlockmode_test.go
+++ b/cliapp/dump_runlockmode_test.go
@@ -2,12 +2,16 @@ package cliapp
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/mydumperlock"
 )
 
 // fakeMydumper0180 writes a fake mydumper that reports a version NEW ENOUGH to
@@ -118,3 +122,55 @@ func TestRunDumpSafeNoLockSkipsPreflightAndCarriesTheMode(t *testing.T) {
 		t.Errorf("argv = %q; the operator asked for safe-no-lock and mydumper was told something else", argv)
 	}
 }
+
+// TestRunDumpForwardsTheSelectedModeToThePreflight closes a gap that a green
+// suite hid: nothing verified that the mode the OPERATOR chose is the mode the
+// privilege check judges. Hardcoding baseline.LockModeFTWRL at the call site
+// passed every other test in this package, because an unreachable source fails
+// identically for every mode.
+//
+// The consequence of that mutation is exactly #1381: an RDS operator passes
+// --lock-mode lock-all, is judged against ftwrl's requirements, and is told to
+// grant BACKUP_ADMIN — which RDS refuses to grant at all.
+func TestRunDumpForwardsTheSelectedModeToThePreflight(t *testing.T) {
+	dir := t.TempDir()
+	bin, _ := fakeMydumper0180(t, dir)
+
+	stubPingSource(t)
+	dumpLockDir = func() string { return dir }
+	t.Cleanup(func() { dumpLockDir = os.TempDir })
+
+	var got baseline.LockMode
+	var gotRemedy mydumperlock.Remedy
+	checkMydumperPrivileges = func(_ context.Context, _ string, m baseline.LockMode, r mydumperlock.Remedy) error {
+		got, gotRemedy = m, r
+		return errStopAfterPreflight
+	}
+	t.Cleanup(func() { checkMydumperPrivileges = mydumperlock.CheckPrivileges })
+
+	dmpSourceDSN = "u:p@tcp(127.0.0.1:1)/"
+	dmpOutputDir = filepath.Join(dir, "out")
+	dmpMydumperPath = bin
+	dmpLockMode = "lock-all"
+	dmpFormat = "text"
+	t.Cleanup(func() { dmpLockMode = "ftwrl"; dmpSourceDSN = ""; dmpOutputDir = "" })
+
+	cmd := newDumpCmdForTest(t)
+	if err := cmd.Flags().Set("mydumper-path", bin); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("lock-mode", "lock-all"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runDump(cmd, nil); !errors.Is(err, errStopAfterPreflight) {
+		t.Fatalf("runDump err = %v, want the preflight's own error to propagate unchanged", err)
+	}
+	if got != baseline.LockModeLockAll {
+		t.Errorf("preflight judged %q, but the operator asked for lock-all — on RDS this refuses a working config", got)
+	}
+	if gotRemedy != mydumperlock.RemedyCLI {
+		t.Errorf("remedy = %q, want the CLI's own knob named in the refusal", gotRemedy)
+	}
+}
+
+var errStopAfterPreflight = errors.New("stop after preflight")

--- a/consoleapp/baseline.go
+++ b/consoleapp/baseline.go
@@ -276,7 +276,7 @@ func runMydumper(ctx context.Context, sourceDSN string, schemas []string, dumpDi
 		// Hard gate, unlike the NO_LOCK warning below: granting BACKUP_ADMIN
 		// without RELOAD/FLUSH_TABLES does not fail cleanly in mydumper — it
 		// SEGFAULTS (verified against the pinned build, #800). Never skipped.
-		if err := checkMydumperPrivileges(ctx, sourceDSN, lockMode, mydumperlock.RemedyConsole); err != nil {
+		if err := checkMydumperPrivileges(ctx, sourceDSN, lockMode, mydumperlock.RemedyConsole, schemas); err != nil {
 			return err
 		}
 	} else if lockMode == baseline.LockModeNoLock {

--- a/consoleapp/baseline.go
+++ b/consoleapp/baseline.go
@@ -268,7 +268,7 @@ func runMydumper(ctx context.Context, sourceDSN string, schemas []string, dumpDi
 		// Hard gate, unlike the NO_LOCK warning below: granting BACKUP_ADMIN
 		// without RELOAD/FLUSH_TABLES does not fail cleanly in mydumper — it
 		// SEGFAULTS (verified against the pinned build, #800). Never skipped.
-		if err := mydumperlock.CheckPrivileges(ctx, sourceDSN, mydumperlock.RemedyConsole); err != nil {
+		if err := mydumperlock.CheckPrivileges(ctx, sourceDSN, lockMode, mydumperlock.RemedyConsole); err != nil {
 			return err
 		}
 	} else if lockMode == baseline.LockModeNoLock {

--- a/consoleapp/baseline.go
+++ b/consoleapp/baseline.go
@@ -20,6 +20,14 @@ import (
 	"github.com/dbtrail/dbtrail/internal/pgbaseline"
 )
 
+// checkMydumperPrivileges is mydumperlock.CheckPrivileges behind a seam, so a
+// test can observe the LOCK MODE this call site actually forwards. Without it
+// the argument is unverifiable: every mode fails identically against an
+// unreachable source, so hardcoding one here passes the whole suite while
+// re-introducing #1381 — an operator who selected lock-all gets judged against
+// ftwrl's requirements and told to grant BACKUP_ADMIN, which RDS refuses.
+var checkMydumperPrivileges = mydumperlock.CheckPrivileges
+
 // baselineSupervisor implements console.BaselineController by running the
 // dump→convert→upload pipeline IN-PROCESS (#613): the console image bundles
 // mydumper, so a baseline never starts a sibling container and the daemon never
@@ -268,7 +276,7 @@ func runMydumper(ctx context.Context, sourceDSN string, schemas []string, dumpDi
 		// Hard gate, unlike the NO_LOCK warning below: granting BACKUP_ADMIN
 		// without RELOAD/FLUSH_TABLES does not fail cleanly in mydumper — it
 		// SEGFAULTS (verified against the pinned build, #800). Never skipped.
-		if err := mydumperlock.CheckPrivileges(ctx, sourceDSN, lockMode, mydumperlock.RemedyConsole); err != nil {
+		if err := checkMydumperPrivileges(ctx, sourceDSN, lockMode, mydumperlock.RemedyConsole); err != nil {
 			return err
 		}
 	} else if lockMode == baseline.LockModeNoLock {
@@ -314,14 +322,16 @@ const systemSchemaExcludeRegex = `^(?!(mysql|sys|performance_schema|information_
 // (#800, #1377). internal/baseline.LockMode carries the measured comparison of
 // the three modes; the two consequences specific to THIS call site:
 //
-//   - FTWRL (the default) covers TRANSACTIONAL tables only, and --trx-tables
-//     makes mydumper REFUSE the whole dump when it finds a non-transactional
-//     one ("Non transactional table found ... Restart backup using
+//   - EVERY point-consistent mode covers TRANSACTIONAL tables only — LOCK_ALL
+//     exactly as much as FTWRL, verified for each — and --trx-tables makes
+//     mydumper REFUSE the whole dump when it finds a non-transactional one
+//     ("Non transactional table found ... Restart backup using
 //     --trx-tables=0"), which the console propagates as the run's error. The
 //     same flag under NO_LOCK only warns and proceeds — verified empirically
 //     on the identical MyISAM table (#800). The refusal is gated to an actual
 //     "consistent backup attempt" in mydumper's own wording, which NO_LOCK is
-//     explicitly not making.
+//     explicitly not making. So this is NOT a reason to move an RDS source off
+//     LOCK_ALL: switching modes among the consistent ones cannot avoid it.
 //   - FTWRL needs RELOAD/FLUSH_TABLES on every flavor, plus BACKUP_ADMIN on
 //     MySQL/Percona 8.0+ (for LOCK INSTANCE FOR BACKUP). Granting BACKUP_ADMIN
 //     WITHOUT RELOAD does not fail cleanly — the pinned build SEGFAULTS — which
@@ -396,10 +406,11 @@ func warnIfMultiTableNoLock(ctx context.Context, sourceDSN string, schemas []str
 	if count > 1 {
 		slog.Warn("baseline: dumping multiple tables under no-lock — each table's snapshot is "+
 			"anchored at a slightly different instant (no cross-table synchronization barrier), so a multi-table "+
-			"reconstruct (e.g. a parent/child FK pair) can be mutually inconsistent; unset "+
-			"BINTRAIL_CONSOLE_BASELINE_LOCK_MODE to return to the point-consistent default across all transactional "+
-			"tables (requires the RELOAD or FLUSH_TABLES privilege; MySQL/Percona 8.0+ also requires BACKUP_ADMIN, not "+
-			"needed on MariaDB or MySQL 5.7) — see docs/dump-and-baseline.md",
+			"reconstruct (e.g. a parent/child FK pair) can be mutually inconsistent; set "+
+			"BINTRAIL_CONSOLE_BASELINE_LOCK_MODE=lock-all for a point-consistent snapshot (needs only LOCK TABLES, and "+
+			"is the mode that works on managed MySQL such as RDS), or unset it for the ftwrl default (requires the "+
+			"RELOAD or FLUSH_TABLES privilege; MySQL/Percona 8.0+ also requires BACKUP_ADMIN, which RDS will not grant "+
+			"and which MariaDB and MySQL 5.7 do not have) — see docs/dump-and-baseline.md",
 			"tables", count)
 	}
 }

--- a/consoleapp/baseline_lockmode_test.go
+++ b/consoleapp/baseline_lockmode_test.go
@@ -29,6 +29,7 @@ func TestBuildConsoleMydumperArgsCarriesLockMode(t *testing.T) {
 		want string
 	}{
 		{baseline.LockModeFTWRL, "FTWRL"},
+		{baseline.LockModeLockAll, "LOCK_ALL"},
 		{baseline.LockModeSafeNoLock, "SAFE_NO_LOCK"},
 		{baseline.LockModeNoLock, "NO_LOCK"},
 	} {

--- a/consoleapp/baseline_lockmode_test.go
+++ b/consoleapp/baseline_lockmode_test.go
@@ -59,9 +59,10 @@ func TestBuildConsoleMydumperArgsCarriesLockMode(t *testing.T) {
 func TestRunMydumperForwardsTheSelectedModeToThePreflight(t *testing.T) {
 	var got baseline.LockMode
 	var gotRemedy mydumperlock.Remedy
+	var gotSchemas []string
 	sentinel := errors.New("stop after preflight")
-	checkMydumperPrivileges = func(_ context.Context, _ string, m baseline.LockMode, r mydumperlock.Remedy) error {
-		got, gotRemedy = m, r
+	checkMydumperPrivileges = func(_ context.Context, _ string, m baseline.LockMode, r mydumperlock.Remedy, sch []string) error {
+		got, gotRemedy, gotSchemas = m, r, sch
 		return sentinel
 	}
 	t.Cleanup(func() { checkMydumperPrivileges = mydumperlock.CheckPrivileges })
@@ -76,5 +77,8 @@ func TestRunMydumperForwardsTheSelectedModeToThePreflight(t *testing.T) {
 	}
 	if gotRemedy != mydumperlock.RemedyConsole {
 		t.Errorf("remedy = %q, want the console's own knob named in the refusal", gotRemedy)
+	}
+	if !slices.Equal(gotSchemas, []string{"appdb"}) {
+		t.Errorf("schemas = %v, want the request's own schema filter", gotSchemas)
 	}
 }

--- a/consoleapp/baseline_lockmode_test.go
+++ b/consoleapp/baseline_lockmode_test.go
@@ -1,10 +1,13 @@
 package consoleapp
 
 import (
+	"context"
+	"errors"
 	"slices"
 	"testing"
 
 	"github.com/dbtrail/dbtrail/internal/baseline"
+	"github.com/dbtrail/dbtrail/internal/mydumperlock"
 )
 
 // TestConsoleBaselineDefaultsToConsistent: the console's Create-baseline button
@@ -41,5 +44,37 @@ func TestBuildConsoleMydumperArgsCarriesLockMode(t *testing.T) {
 		if args[i+1] != tc.want {
 			t.Errorf("mode %s produced %q, want %q", tc.mode, args[i+1], tc.want)
 		}
+	}
+}
+
+// TestRunMydumperForwardsTheSelectedModeToThePreflight is the console's half of
+// the CLI's identically-named test. The console had NO preflight test at all,
+// so hardcoding a mode at this call site passed the whole package.
+//
+// This is the surface where it matters most: the console is where the
+// **Create baseline** button lives, and BINTRAIL_CONSOLE_BASELINE_LOCK_MODE is
+// the only way its operator can select lock-all. Judging their choice against
+// ftwrl's requirements is #1381 — a refusal demanding BACKUP_ADMIN, which
+// managed MySQL will not grant under any circumstances.
+func TestRunMydumperForwardsTheSelectedModeToThePreflight(t *testing.T) {
+	var got baseline.LockMode
+	var gotRemedy mydumperlock.Remedy
+	sentinel := errors.New("stop after preflight")
+	checkMydumperPrivileges = func(_ context.Context, _ string, m baseline.LockMode, r mydumperlock.Remedy) error {
+		got, gotRemedy = m, r
+		return sentinel
+	}
+	t.Cleanup(func() { checkMydumperPrivileges = mydumperlock.CheckPrivileges })
+
+	err := runMydumper(context.Background(), "u:p@tcp(127.0.0.1:1)/db", []string{"appdb"},
+		t.TempDir(), baseline.LockModeLockAll)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("runMydumper err = %v, want the preflight's own error to propagate unchanged", err)
+	}
+	if got != baseline.LockModeLockAll {
+		t.Errorf("preflight judged %q, but the console was configured for lock-all — on RDS this refuses a working config", got)
+	}
+	if gotRemedy != mydumperlock.RemedyConsole {
+		t.Errorf("remedy = %q, want the console's own knob named in the refusal", gotRemedy)
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -281,7 +281,9 @@ services:
       # volume.
       BINTRAIL_CONSOLE_BASELINE_TRIGGER: ${BASELINE_TRIGGER:-1}
       # How a console-triggered baseline syncs mydumper's threads onto one
-      # instant: ftwrl (default, point-consistent), safe-no-lock (no extra
+      # instant: ftwrl (default, point-consistent), lock-all (point-consistent,
+      # needs only LOCK TABLES — use it on managed MySQL such as RDS, where
+      # BACKUP_ADMIN cannot be granted), safe-no-lock (no extra
       # privilege, ABORTS rather than emit a torn snapshot) or no-lock
       # (accepts a torn snapshot). A baseline is the seed state reconstruct
       # merges deltas onto, so the weaker modes must be asked for (#1377/#1378).
@@ -527,7 +529,7 @@ services:
       # information_schema are always excluded, see the dump command below).
       BASELINE_SCHEMAS: ${BASELINE_SCHEMAS:-${SCHEMAS:-}}
       # Same knob and same vocabulary as the console's
-      # BINTRAIL_CONSOLE_BASELINE_LOCK_MODE: ftwrl | safe-no-lock | no-lock.
+      # BINTRAIL_CONSOLE_BASELINE_LOCK_MODE: ftwrl | lock-all | safe-no-lock | no-lock.
       # It MUST be listed here or it never enters the container and the
       # operator's choice is silently ignored (#1378).
       BASELINE_LOCK_MODE: ${BASELINE_LOCK_MODE:-ftwrl}
@@ -574,9 +576,10 @@ services:
         # the default is that a torn snapshot has to be asked for.
         case "$${BASELINE_LOCK_MODE:-ftwrl}" in
           ftwrl)        sync_mode=FTWRL ;;
+          lock-all)     sync_mode=LOCK_ALL ;;
           safe-no-lock) sync_mode=SAFE_NO_LOCK ;;
           no-lock)      sync_mode=NO_LOCK ;;
-          *) echo "FATAL: BASELINE_LOCK_MODE='$$BASELINE_LOCK_MODE' is not one of: ftwrl, safe-no-lock, no-lock" >&2; exit 1 ;;
+          *) echo "FATAL: BASELINE_LOCK_MODE='$$BASELINE_LOCK_MODE' is not one of: ftwrl, lock-all, safe-no-lock, no-lock" >&2; exit 1 ;;
         esac
         set -- --host "$$host" --port "$$port" --user "$$user" \
           --threads 4 --compress-protocol --complete-insert \

--- a/docs/console.md
+++ b/docs/console.md
@@ -454,8 +454,10 @@ straight from the Storage page, and it only runs on the `watch` daemon:
   (or `FLUSH_TABLES`) plus `BACKUP_ADMIN` on MySQL/Percona 8.0+. The daemon
   checks those privileges before launching mydumper and refuses with an
   actionable error if any are missing — it never silently falls back to a
-  weaker mode. Set `BINTRAIL_CONSOLE_BASELINE_LOCK_MODE=safe-no-lock` to dump
-  without them (it aborts rather than write a snapshot stitched from several
+  weaker mode. On managed MySQL such as RDS, `BACKUP_ADMIN` cannot be
+  granted at all, so use `BINTRAIL_CONSOLE_BASELINE_LOCK_MODE=lock-all` — equally
+  point-consistent, needs only `LOCK TABLES`. Or `=safe-no-lock` to dump
+  without any of them (it aborts rather than write a snapshot stitched from several
   instants, so expect it to refuse on a write-active source) or `=no-lock` to
   accept such a snapshot; only under `no-lock` does the daemon log a warning
   when a dump spans more than one table. See
@@ -624,7 +626,7 @@ see the metrics tables and example alert rules in
 - `BINTRAIL_CONSOLE_BASELINE_STAGING` (`watch` only) — local staging dir for
   S3-destined baselines created by that button (default a temp subdir).
 - `BINTRAIL_CONSOLE_BASELINE_LOCK_MODE` (`watch` only) — `ftwrl` (default),
-  `safe-no-lock` or `no-lock`. Selects how mydumper synchronizes its worker
+  `lock-all`, `safe-no-lock` or `no-lock`. Selects how mydumper synchronizes its worker
   threads onto one instant for the **Create baseline** button. The default is
   point-consistent and needs `RELOAD`/`FLUSH_TABLES` (plus `BACKUP_ADMIN` on
   MySQL/Percona 8.0+); `safe-no-lock` needs neither but aborts rather than

--- a/docs/console.md
+++ b/docs/console.md
@@ -629,8 +629,11 @@ see the metrics tables and example alert rules in
   `lock-all`, `safe-no-lock` or `no-lock`. Selects how mydumper synchronizes its worker
   threads onto one instant for the **Create baseline** button. The default is
   point-consistent and needs `RELOAD`/`FLUSH_TABLES` (plus `BACKUP_ADMIN` on
-  MySQL/Percona 8.0+); `safe-no-lock` needs neither but aborts rather than
-  write a torn snapshot; `no-lock` accepts one. A baseline is the seed state
+  MySQL/Percona 8.0+). `lock-all` is also point-consistent and needs only
+  `LOCK TABLES` — **the mode to use on RDS/Aurora**, where `BACKUP_ADMIN`
+  cannot be granted and `ftwrl` therefore cannot run. `safe-no-lock` needs no
+  elevated privilege but aborts rather than write a torn snapshot; `no-lock`
+  accepts one. A baseline is the seed state
   `reconstruct` merges deltas onto, which is why the weaker modes must be named
   explicitly. An unrecognized value disables baseline DUMPS only — capture and
   the periodic refresh keep running.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -430,9 +430,12 @@ Notes:
   — same default as `bintrail dump`. FTWRL holds one global read lock only
   long enough for every worker to open its snapshot at the same instant, and
   needs `RELOAD`/`FLUSH_TABLES` (plus `BACKUP_ADMIN` on MySQL/Percona 8.0+).
-  Set `BASELINE_LOCK_MODE=safe-no-lock` to dump without those privileges (it
+  On **managed MySQL (RDS/Aurora) `BACKUP_ADMIN` cannot be granted**, so
+  `ftwrl` cannot run there: set `BASELINE_LOCK_MODE=lock-all`, which is
+  equally point-consistent and needs only `LOCK TABLES`. Otherwise
+  `BASELINE_LOCK_MODE=safe-no-lock` dumps without either privilege (it
   aborts rather than write a torn snapshot, so expect it to refuse on a
-  write-active source) or `=no-lock` to accept a torn one. It still reads every row of the selected
+  write-active source) or `=no-lock` accepts a torn one. It still reads every row of the selected
   schemas; schedule it off-peak for large sources. On sources with
   non-transactional tables (MyISAM), the binlog coordinates embedded in the
   snapshot may not exactly match those tables' data — the same caveat as

--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -129,7 +129,7 @@ This dumps **every accessible schema** into `/tmp/mydumper-output` — bare `bin
 | `--mydumper-path` | `mydumper` | Path to the mydumper binary. When set, skips Docker fallback. |
 | `--mydumper-image` | `mydumper/mydumper:latest` | Docker image for mydumper. Used only when no local binary is found. |
 | `--threads` | `4` | Number of parallel dump threads |
-| `--lock-mode` | `ftwrl` | How mydumper syncs its threads onto one instant: `ftwrl` (point-consistent), `safe-no-lock` (no extra privilege, aborts rather than emit a torn snapshot), `no-lock` (accepts a torn snapshot) |
+| `--lock-mode` | `ftwrl` | How mydumper syncs its threads onto one instant: `ftwrl` (point-consistent), `lock-all` (point-consistent, needs only LOCK TABLES — use it on managed MySQL), `safe-no-lock` (no extra privilege, aborts rather than emit a torn snapshot), `no-lock` (accepts a torn snapshot) |
 | `--encrypt` | `false` | Encrypt dump files at rest using AES-256-CBC, with an HMAC-SHA256 integrity sidecar per file (requires `openssl` on `$PATH`) |
 | `--encrypt-key` | `~/.config/bintrail/dump.key` | Path to the encryption key file (generate with `bintrail generate-key`) |
 | `--format` | `text` | Output format: `text` or `json` |
@@ -194,8 +194,18 @@ default to `ftwrl` and the weaker modes must be asked for by name.
 | `--lock-mode` | mydumper mode | Point-consistent? | Works on a write-active source? | Privileges |
 |---|---|---|---|---|
 | `ftwrl` (default) | `FTWRL` | yes | yes | `RELOAD`/`FLUSH_TABLES`, plus `BACKUP_ADMIN` on MySQL/Percona 8.0+ |
+| `lock-all` | `LOCK_ALL` | yes | yes | `LOCK TABLES` |
 | `safe-no-lock` | `SAFE_NO_LOCK` | yes — or it aborts | **usually not** | `SELECT` + `REPLICATION CLIENT` |
 | `no-lock` | `NO_LOCK` | **no** | yes | `SELECT` + `REPLICATION CLIENT` |
+
+**On managed MySQL, use `lock-all`.** RDS (and equivalents) will not grant
+`BACKUP_ADMIN` at all — `GRANT BACKUP_ADMIN ON *.* TO CURRENT_USER()` is refused
+with *"ERROR 1227 ... you need the RDSADMIN USER privilege"* — and mydumper's
+`FTWRL` path issues `LOCK INSTANCE FOR BACKUP` first, so `ftwrl` cannot work
+there no matter what else you grant. `lock-all` synchronizes the workers by
+locking the exported tables instead of the instance, needs only `LOCK TABLES`
+(which the RDS master user already has), and is equally point-consistent.
+Verified both ways against the same privilege set.
 
 `safe-no-lock` does not *prevent* thread skew — it *detects* it. mydumper compares the binlog
 position before and after syncing threads and, on any difference, stops with *"we cannot guarantee

--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -204,8 +204,10 @@ with *"ERROR 1227 ... you need the RDSADMIN USER privilege"* — and mydumper's
 `FTWRL` path issues `LOCK INSTANCE FOR BACKUP` first, so `ftwrl` cannot work
 there no matter what else you grant. `lock-all` synchronizes the workers by
 locking the exported tables instead of the instance, needs only `LOCK TABLES`
-(which the RDS master user already has), and is equally point-consistent.
-Verified both ways against the same privilege set.
+(which the RDS master user already has, and which also works granted on just the
+dumped schema), and is equally point-consistent. mydumper says so itself — its
+help carries *"We support LOCK_ALL and SAFE_NO_LOCK modes for RDS/Aurora"* — and
+both directions were verified against the pinned build.
 
 `safe-no-lock` does not *prevent* thread skew — it *detects* it. mydumper compares the binlog
 position before and after syncing threads and, on any difference, stops with *"we cannot guarantee
@@ -214,16 +216,17 @@ torn snapshot, but on a source taking concurrent writes it will mostly refuse. V
 against mydumper `v1.0.3-1` and MySQL 8.0: it aborts under sustained writes, and it is the only
 low-privilege mode that will not lie to you.
 
-`no-lock` accepts a torn snapshot. mydumper's own documentation describes it as the mode to use *"if
-you don't need a consistent backup"*, and **deprecated it in 0.18.1**. Choose it only when you
+`no-lock` accepts a torn snapshot. mydumper's own help describes it as the mode to use *"if you
+don't need a consistent backup"* and pointedly leaves it out of its list of sync modes (*"There are 4
+modes that can be use to sync: SAFE_NO_LOCK, FTWRL, LOCK_ALL and GTID"*). Choose it only when you
 knowingly accept that the snapshot may not represent any single instant.
 
 Neither surface downgrades silently: if the privileges for `ftwrl` are missing, the dump refuses
 with an actionable error naming the alternatives, rather than quietly producing a weaker snapshot.
 
-`FTWRL` mode covers **transactional tables only** — the same `--trx-tables` flag as the other modes, but it behaves differently under `FTWRL`: mydumper detects a non-transactional (MyISAM) table and **refuses to dump at all** ("Non transactional table found ... Restart backup using --trx-tables=0"), which the console propagates as the run's error, instead of silently proceeding the way it does under `NO_LOCK`. Verified empirically: the identical MyISAM table dumped successfully (with only a warning) under `NO_LOCK`, and was hard-refused under `FTWRL`, in the same test session — the refusal is gated to an actual "consistent backup attempt" (mydumper's own wording), which `NO_LOCK` explicitly is not attempting and `FTWRL` is.
+**Every point-consistent mode covers transactional tables only** — `lock-all` exactly as much as `ftwrl`, verified separately for each. bintrail passes `--trx-tables` on all modes, and under a mode that is attempting a consistent backup mydumper detects a non-transactional (MyISAM) table and **refuses to dump at all** ("Non transactional table found ... Restart backup using --trx-tables=0"), which the console propagates as the run's error, instead of silently proceeding the way it does under `NO_LOCK`. Verified empirically: the identical MyISAM table dumped successfully (with only a warning) under `NO_LOCK`, and was hard-refused under both `FTWRL` and `LOCK_ALL` — the refusal is gated to an actual "consistent backup attempt" (mydumper's own wording), which `NO_LOCK` explicitly is not attempting and the point-consistent modes are. **Switching `ftwrl` → `lock-all` does not get you past it**; a source with MyISAM tables needs those tables converted, excluded via `--tables`, or a low-privilege mode.
 
-`FTWRL` mode needs `RELOAD` or the `FLUSH_TABLES` dynamic privilege (for `FLUSH TABLES WITH READ LOCK`) on **every** source flavor, verified against the pinned mydumper build (`v1.0.3-1`) against a real MySQL 8.0 source — plus `BACKUP_ADMIN` (for `LOCK INSTANCE FOR BACKUP`) **only on MySQL/Percona 8.0+**. `BACKUP_ADMIN` is a MySQL 8.0+ dynamic privilege: it does not exist on MariaDB (any version) or MySQL 5.7, and neither of those issues `LOCK INSTANCE FOR BACKUP`, so `FTWRL` there needs only `RELOAD`/`FLUSH_TABLES`. The console detects this from the source's own `SELECT VERSION()` and checks for exactly the privileges that source actually needs **before** invoking mydumper, refusing with a clear, actionable error if any are missing — this is not just belt-and-suspenders: on a MySQL/Percona 8.0+ source, granting `BACKUP_ADMIN` **without** `RELOAD`/`FLUSH_TABLES` does not make mydumper fail cleanly, it makes the pinned build **crash** (a segfault, reproduced on both amd64 and arm64), so the console's own preflight check exists specifically to turn that crash into a clean error instead of ever letting mydumper attempt it half-privileged. Point-consistent mode never silently falls back to `NO_LOCK`. Both surfaces expose the same three modes: `bintrail dump --lock-mode`, and `BINTRAIL_CONSOLE_BASELINE_LOCK_MODE` for the console's in-process baseline pipeline.
+`FTWRL` mode needs `RELOAD` or the `FLUSH_TABLES` dynamic privilege (for `FLUSH TABLES WITH READ LOCK`) on **every** source flavor, verified against the pinned mydumper build (`v1.0.3-1`) against a real MySQL 8.0 source — plus `BACKUP_ADMIN` (for `LOCK INSTANCE FOR BACKUP`) **only on MySQL/Percona 8.0+**. `BACKUP_ADMIN` is a MySQL 8.0+ dynamic privilege: it does not exist on MariaDB (any version) or MySQL 5.7, and neither of those issues `LOCK INSTANCE FOR BACKUP`, so `FTWRL` there needs only `RELOAD`/`FLUSH_TABLES`. The console detects this from the source's own `SELECT VERSION()` and checks for exactly the privileges that source actually needs **before** invoking mydumper, refusing with a clear, actionable error if any are missing — this is not just belt-and-suspenders: on a MySQL/Percona 8.0+ source, granting `BACKUP_ADMIN` **without** `RELOAD`/`FLUSH_TABLES` does not make mydumper fail cleanly, it makes the pinned build **crash** (a segfault, reproduced on both amd64 and arm64), so the console's own preflight check exists specifically to turn that crash into a clean error instead of ever letting mydumper attempt it half-privileged. Point-consistent mode never silently falls back to `NO_LOCK`. Both surfaces expose the same four modes: `bintrail dump --lock-mode`, and `BINTRAIL_CONSOLE_BASELINE_LOCK_MODE` for the console's in-process baseline pipeline.
 
 ### Concurrency protection
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,9 +21,12 @@ the **command line**. Both need a source MySQL user first.
   -- Baselines are point-consistent by default and need these too.
   -- BACKUP_ADMIN is MySQL/Percona 8.0+ only; omit it on MariaDB and MySQL 5.7.
   GRANT RELOAD, BACKUP_ADMIN ON *.* TO 'dbtrail'@'%';
+  -- On RDS/Aurora, BACKUP_ADMIN cannot be granted at all. Use LOCK TABLES
+  -- and BASELINE_LOCK_MODE=lock-all instead — see below.
   ```
 
-  `RELOAD`/`BACKUP_ADMIN` let the baseline dump take a point-in-time snapshot — skip them and set `BASELINE_LOCK_MODE=safe-no-lock` if you would rather not grant them (it never writes a torn snapshot, but it refuses on a write-active source).
+  `RELOAD`/`BACKUP_ADMIN` let the baseline dump take a point-in-time snapshot.
+  **On managed MySQL (RDS/Aurora), `GRANT BACKUP_ADMIN` is refused outright**, so grant `LOCK TABLES` and set `BASELINE_LOCK_MODE=lock-all` — equally point-consistent, and the mode mydumper itself names for RDS. If you would rather grant nothing extra on a self-hosted source, `BASELINE_LOCK_MODE=safe-no-lock` never writes a torn snapshot, but it refuses on a write-active source.
   `REPLICATION SLAVE`/`REPLICATION CLIENT` drive the binlog stream; `SELECT` lets
   dbtrail snapshot the schema. dbtrail never writes to or locks the source.
   (Least-privilege variant: [streaming.md](streaming.md#the-source-mysql-user).)

--- a/internal/baseline/lockmode.go
+++ b/internal/baseline/lockmode.go
@@ -26,17 +26,38 @@ import "fmt"
 //     SAFE_NO_LOCK." Verified: under sustained concurrent writes it aborts.
 //     So it never lies, but on a write-active source it mostly refuses.
 //   - LOCK_ALL synchronizes workers by locking the exported tables instead of
-//     the instance. It needs only LOCK TABLES, and it is the mode that works on
-//     managed MySQL: on RDS the master user CANNOT be granted BACKUP_ADMIN
-//     ("ERROR 1227 ... you need the RDSADMIN USER privilege"), so FTWRL is
-//     impossible there, while LOCK_ALL succeeds with exactly the privilege set
-//     RDS hands out. Measured both ways against the same user.
+//     the instance, so it needs only LOCK TABLES — at any scope covering the
+//     dumped tables, not necessarily globally. mydumper names it itself: "We
+//     support LOCK_ALL and SAFE_NO_LOCK modes for RDS/Aurora" (string in the
+//     pinned v1.0.3-1 binary). Measured separately from the users above, on an
+//     RDS MySQL 8.4 master account and on a local user granted only
+//     `SELECT, LOCK TABLES, SHOW VIEW` on the dumped schema: FTWRL fails for
+//     both ("ERROR 1227 ... you need the RDSADMIN USER privilege" when granting
+//     BACKUP_ADMIN on RDS), LOCK_ALL succeeds for both.
 //   - NO_LOCK always succeeds and is the only mode that can silently produce a
-//     torn snapshot. mydumper's own docs describe it as the choice for when
-//     "you don't need a consistent backup", and DEPRECATED it in v0.18.1.
+//     torn snapshot. mydumper's help presents it as the choice for when "you
+//     don't need a consistent backup"; it is also the one value NOT in the help
+//     text's list of sync modes ("SAFE_NO_LOCK, FTWRL, LOCK_ALL and GTID"),
+//     which is the closest thing to a deprecation the pinned build states.
 //
-// Hence the default is FTWRL: SAFE_NO_LOCK is unusable as a default on the
-// sources that most need a baseline, and NO_LOCK is not a backup.
+// Two properties are NOT mode-specific and catch people out:
+//
+//   - Every point-consistent mode — LOCK_ALL included, verified — REFUSES the
+//     whole dump when it meets a non-transactional table, because bintrail
+//     passes --trx-tables: "Non transactional table found: `db`.`t` on a
+//     consistent backup attempt". Switching FTWRL→LOCK_ALL does not avoid it.
+//   - LOCK TABLES also implies SELECT on the locked tables, which mydumper
+//     needs regardless, so "needs only LOCK TABLES" is relative to that floor.
+//
+// The default stays FTWRL for the reason #1377 chose it: it is the one
+// point-consistent mode that needs no per-object privilege, so it works on a
+// self-hosted source with a single global grant and on every flavor including
+// MariaDB and MySQL 5.7. LOCK_ALL is not a worse mode — the locking-cost
+// comparison between the two has NOT been measured here, and no claim is made
+// either way — it is simply the one that requires knowing which objects will be
+// dumped. It is the right answer where FTWRL cannot run, which the refusal in
+// internal/mydumperlock names first. SAFE_NO_LOCK is unusable as a default on
+// the sources that most need a baseline, and NO_LOCK is not a backup.
 type LockMode string
 
 const (
@@ -60,8 +81,8 @@ const (
 const DefaultLockMode = LockModeFTWRL
 
 // LockModeValues lists the accepted spellings. Test-only today: the flag
-// help, ParseLockMode's error and the compose case statement each spell the
-// three names out, so adding a mode means updating all of them by hand.
+// help, ParseLockMode's error and the compose case statement each spell all
+// four names out, so adding a mode means updating every one of them by hand.
 var LockModeValues = []LockMode{LockModeFTWRL, LockModeLockAll, LockModeSafeNoLock, LockModeNoLock}
 
 // ParseLockMode maps an operator-supplied string to a LockMode. It is

--- a/internal/baseline/lockmode.go
+++ b/internal/baseline/lockmode.go
@@ -25,6 +25,12 @@ import "fmt"
 //     the backup to be consistent. Stopping backup due to the use of
 //     SAFE_NO_LOCK." Verified: under sustained concurrent writes it aborts.
 //     So it never lies, but on a write-active source it mostly refuses.
+//   - LOCK_ALL synchronizes workers by locking the exported tables instead of
+//     the instance. It needs only LOCK TABLES, and it is the mode that works on
+//     managed MySQL: on RDS the master user CANNOT be granted BACKUP_ADMIN
+//     ("ERROR 1227 ... you need the RDSADMIN USER privilege"), so FTWRL is
+//     impossible there, while LOCK_ALL succeeds with exactly the privilege set
+//     RDS hands out. Measured both ways against the same user.
 //   - NO_LOCK always succeeds and is the only mode that can silently produce a
 //     torn snapshot. mydumper's own docs describe it as the choice for when
 //     "you don't need a consistent backup", and DEPRECATED it in v0.18.1.
@@ -37,6 +43,11 @@ const (
 	// LockModeFTWRL holds one global read lock only long enough for every
 	// worker to open its snapshot at the same instant, then releases it.
 	LockModeFTWRL LockMode = "ftwrl"
+	// LockModeLockAll locks the exported tables long enough for every worker to
+	// open its snapshot together. Needs LOCK TABLES and no more, which makes it
+	// the point-consistent mode available on managed MySQL where BACKUP_ADMIN
+	// cannot be granted.
+	LockModeLockAll LockMode = "lock-all"
 	// LockModeSafeNoLock needs no elevated privilege and refuses rather than
 	// emit a torn snapshot. Expect it to abort on a write-active source.
 	LockModeSafeNoLock LockMode = "safe-no-lock"
@@ -51,7 +62,7 @@ const DefaultLockMode = LockModeFTWRL
 // LockModeValues lists the accepted spellings. Test-only today: the flag
 // help, ParseLockMode's error and the compose case statement each spell the
 // three names out, so adding a mode means updating all of them by hand.
-var LockModeValues = []LockMode{LockModeFTWRL, LockModeSafeNoLock, LockModeNoLock}
+var LockModeValues = []LockMode{LockModeFTWRL, LockModeLockAll, LockModeSafeNoLock, LockModeNoLock}
 
 // ParseLockMode maps an operator-supplied string to a LockMode. It is
 // deliberately strict: a typo must not silently land on a weaker mode, because
@@ -60,6 +71,8 @@ func ParseLockMode(s string) (LockMode, error) {
 	switch LockMode(s) {
 	case LockModeFTWRL:
 		return LockModeFTWRL, nil
+	case LockModeLockAll:
+		return LockModeLockAll, nil
 	case LockModeSafeNoLock:
 		return LockModeSafeNoLock, nil
 	case LockModeNoLock:
@@ -67,13 +80,15 @@ func ParseLockMode(s string) (LockMode, error) {
 	case "":
 		return DefaultLockMode, nil
 	}
-	return "", fmt.Errorf("unknown lock mode %q: want one of %s, %s, %s",
-		s, LockModeFTWRL, LockModeSafeNoLock, LockModeNoLock)
+	return "", fmt.Errorf("unknown lock mode %q: want one of %s, %s, %s, %s",
+		s, LockModeFTWRL, LockModeLockAll, LockModeSafeNoLock, LockModeNoLock)
 }
 
 // MydumperValue is the --sync-thread-lock-mode argument for this mode.
 func (m LockMode) MydumperValue() string {
 	switch m {
+	case LockModeLockAll:
+		return "LOCK_ALL"
 	case LockModeSafeNoLock:
 		return "SAFE_NO_LOCK"
 	case LockModeNoLock:

--- a/internal/baseline/lockmode_test.go
+++ b/internal/baseline/lockmode_test.go
@@ -22,6 +22,7 @@ func TestLockModeMydumperValue(t *testing.T) {
 		want string
 	}{
 		{LockModeFTWRL, "FTWRL"},
+		{LockModeLockAll, "LOCK_ALL"},
 		{LockModeSafeNoLock, "SAFE_NO_LOCK"},
 		{LockModeNoLock, "NO_LOCK"},
 	} {
@@ -37,6 +38,7 @@ func TestLockModeMydumperValue(t *testing.T) {
 func TestLockModePointConsistent(t *testing.T) {
 	for mode, want := range map[LockMode]bool{
 		LockModeFTWRL:      true,
+		LockModeLockAll:    true,
 		LockModeSafeNoLock: true,
 		LockModeNoLock:     false,
 	} {
@@ -54,6 +56,7 @@ func TestLockModePointConsistent(t *testing.T) {
 func TestLockModeNeedsElevatedPrivileges(t *testing.T) {
 	for mode, want := range map[LockMode]bool{
 		LockModeFTWRL:      true,
+		LockModeLockAll:    true,
 		LockModeSafeNoLock: false,
 		LockModeNoLock:     false,
 	} {
@@ -105,5 +108,21 @@ func TestLockModeZeroValueIsTreatedAsFTWRL(t *testing.T) {
 		if !m.PointConsistent() {
 			t.Errorf("%q.PointConsistent() = false while it sends FTWRL; the three methods must agree", m)
 		}
+	}
+}
+
+// TestLockAllIsPointConsistent pins the property that makes lock-all worth
+// having: it is the point-consistent mode reachable on managed MySQL, where
+// BACKUP_ADMIN cannot be granted and ftwrl therefore cannot run at all.
+// Demoting it to "weak" would leave RDS with no consistent option.
+func TestLockAllIsPointConsistent(t *testing.T) {
+	if !LockModeLockAll.PointConsistent() {
+		t.Fatal("lock-all reported as able to emit a torn snapshot; it locks the exported tables to synchronize workers")
+	}
+	if !LockModeLockAll.NeedsElevatedPrivileges() {
+		t.Error("lock-all reported as needing no privileges; it needs LOCK TABLES, and skipping the preflight would let mydumper fail mid-dump instead of refusing up front")
+	}
+	if got := LockModeLockAll.MydumperValue(); got != "LOCK_ALL" {
+		t.Errorf("MydumperValue = %q, want LOCK_ALL", got)
 	}
 }

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -611,18 +611,17 @@ async function submitPasswordChange(form, msg, firstSet) {
 // toast shows a transient notice. Use it for things that went RIGHT, or for
 // neutral progress. Failures must not fade — see toastError.
 //
-// A visible error OUTRANKS it. #toast is one shared node, and the common
-// sequence is a failure followed immediately by progress from another panel
-// ("Baseline started…", a poll's "still running"); overwriting would delete an
-// unread failure on a timer the operator never saw start. The dropped notice is
-// by definition the one that reports nothing went wrong.
+// It writes to its OWN node, never the error node. An earlier attempt shared
+// one element and had toast() yield to a visible error, which silently dropped
+// messages this function also carries: "rotate your MCP token" after a display
+// interruption (the token is already unrecoverable by then), "capture did NOT
+// restart onto the new snapshot", export-truncation warnings. Each is reported
+// nowhere else, and one undismissed error would have suppressed them all for
+// the rest of the session. Two nodes, no contention.
 function toast(msg) {
   const t = document.getElementById("toast");
   if (!t) return;
-  if (!t.hidden && t.classList.contains("toast-error")) return;
   clearTimeout(toast._t);
-  t.classList.remove("toast-error");
-  t.removeAttribute("role");
   t.textContent = msg;
   t.hidden = false;
   toast._t = setTimeout(() => { t.hidden = true; }, 2200);
@@ -637,15 +636,23 @@ function toast(msg) {
 // operator was left with a button that did nothing and no way to recover the
 // reason. Nothing here starts a timer.
 function toastError(msg) {
-  const t = document.getElementById("toast");
+  const t = document.getElementById("toast-error");
   if (!t) return;
-  clearTimeout(toast._t);
   // A second failure STACKS rather than replaces. These never auto-hide, so a
   // silent overwrite would destroy an unread failure with nothing to hint one
-  // existed \u2014 two servers' baselines refusing together is the ordinary case.
-  const prior = t.hidden ? [] : $all(".toast-msg", t).map((n) => n.textContent);
-  if (prior.includes(msg)) return;
-  t.classList.add("toast-error");
+  // existed — two servers' baselines refusing together is the ordinary case.
+  //
+  // A REPEAT of a message already showing gets a count, not a dropped call.
+  // Dropping it was wrong: several of these messages carry no server name
+  // ("Startup checks failed", "Copy failed."), so failing on server B after
+  // server A produced NO change on screen — indistinguishable from success.
+  const prior = t.hidden ? [] : $all(".toast-msg", t).map((n) => ({
+    text: n.dataset.msg || n.textContent,
+    n: Number(n.dataset.count || "1"),
+  }));
+  const dupe = prior.find((p) => p.text === msg);
+  if (dupe) dupe.n += 1;
+  else prior.push({ text: msg, n: 1 });
   // role=alert so a screen reader announces it; the visual persistence is
   // useless to someone who cannot see it fade. The node is unhidden BEFORE the
   // text lands: a live region that appears with its content already in place
@@ -654,8 +661,12 @@ function toastError(msg) {
   t.replaceChildren();
   t.hidden = false;
   const body = el("div", { class: "toast-body" });
-  for (const m of prior) body.append(el("span", { class: "toast-msg", text: m }));
-  body.append(el("span", { class: "toast-msg", text: msg }));
+  for (const m of prior) {
+    const span = el("span", { class: "toast-msg", text: m.n > 1 ? m.text + "  (\u00d7" + m.n + ")" : m.text });
+    span.dataset.msg = m.text;
+    span.dataset.count = String(m.n);
+    body.append(span);
+  }
   t.append(body);
   const close = el("button", { class: "toast-close", type: "button", "aria-label": "Dismiss all" });
   close.textContent = "\u2715";
@@ -664,10 +675,9 @@ function toastError(msg) {
 }
 
 function dismissToast() {
-  const t = document.getElementById("toast");
+  const t = document.getElementById("toast-error");
   if (!t) return;
   t.hidden = true;
-  t.classList.remove("toast-error");
   t.removeAttribute("role");
   t.textContent = "";
 }
@@ -675,30 +685,40 @@ function dismissToast() {
 // ESC dismisses a persistent error, matching every other dismissible surface
 // in this console — but only as the LAST of them.
 //
-// Restricting this to the error variant is not enough on its own. cmdkKeydown
-// closes the ⌘K palette WITHOUT stopping propagation (deliberately, see
-// globalKeydown), so the same Escape reaches the document and would also
-// destroy an unread error — the failure this whole change exists to prevent,
-// arriving through a different door.
+// cmdkKeydown closes the ⌘K palette WITHOUT stopping propagation
+// (deliberately, see globalKeydown), so the same Escape reaches the document
+// and would also destroy an unread error — the failure this whole change
+// exists to prevent, arriving through a different door.
 //
 // Hence the CAPTURE phase (registered with `true` in init). Deciding on the
 // bubble phase cannot work: by then globalKeydown has already emptied #modal
 // and cmdkKeydown has already emptied #cmdk-mount, so the very state this
 // guard reads to yield the key has been erased by the handlers it is yielding
-// to, and it would dismiss the notice anyway. Capture runs before all of them,
-// while "is a dialog open" is still answerable.
+// to, and it would dismiss the notice anyway. Verified in a browser: on the
+// bubble phase one Escape closes a modal AND wipes the notice behind it.
 //
 // It never calls preventDefault or stopPropagation, so yielding is all it does
 // — the dialog handlers still run normally on the same event.
 function toastEscape(e) {
   if (e.key !== "Escape") return;
+  if (loginGateRaised) return;
   const cmdk = document.getElementById("cmdk-mount");
   if (cmdk && cmdk.firstChild) return;
   const modalMount = document.getElementById("modal");
   if (modalMount && modalMount.firstChild) return;
-  const t = document.getElementById("toast");
-  if (t && !t.hidden && t.classList.contains("toast-error")) dismissToast();
+  // Every surface that consumes Escape must be listed here, including ones
+  // that are NOT inside #modal. The date picker renders into document.body
+  // (see toggleDatePicker) and closes itself on Escape without stopping
+  // propagation, so closing a calendar popover used to destroy the notice —
+  // the same defect as the ⌘K palette, through a third door. A fourth surface
+  // will not announce itself; if you add one that handles Escape, add it here.
+  if (document.querySelector(ESCAPE_OWNING_POPOVERS)) return;
+  const t = document.getElementById("toast-error");
+  if (t && !t.hidden) dismissToast();
 }
+
+// Popovers that live outside #modal and consume Escape themselves.
+const ESCAPE_OWNING_POPOVERS = ".dt-pop";
 
 function renderError(container, err) {
   if (!container) return;
@@ -4215,13 +4235,13 @@ async function renderConnect() {
   if (gen !== serverGen) {
     // The consumed plaintext cannot be re-shown; say so instead of losing it
     // silently (the user must rotate to get a usable value).
-    if (minted) toast("Token display interrupted — rotate to get a fresh value");
+    if (minted) toastError("Token display interrupted — the plaintext token is gone; rotate to get a fresh value");
     return;
   }
   try {
     buildConnect(servers, tokStatus, minted);
   } catch (err) {
-    if (minted) toast("Token display interrupted — rotate to get a fresh value");
+    if (minted) toastError("Token display interrupted — the plaintext token is gone; rotate to get a fresh value");
     const v = VIEW(); clear(v); v.append(pageHead("Connect AI", null)); renderError(v, err);
   }
 }

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -608,14 +608,61 @@ async function submitPasswordChange(form, msg, firstSet) {
 
 // ── toast / errors / warnings ─────────────────────────────────────────────────
 
+// toast shows a transient notice. Use it for things that went RIGHT, or for
+// neutral progress. Failures must not fade — see toastError.
 function toast(msg) {
   const t = document.getElementById("toast");
   if (!t) return;
+  clearTimeout(toast._t);
+  t.classList.remove("toast-error");
+  t.removeAttribute("role");
   t.textContent = msg;
   t.hidden = false;
-  clearTimeout(toast._t);
   toast._t = setTimeout(() => { t.hidden = true; }, 2200);
 }
+
+// toastError shows a failure that stays until the operator dismisses it.
+//
+// A failure that disappears on its own is a failure nobody saw. The baseline
+// privilege refusal is ~550 characters of remediation — which privilege to
+// grant, the exact GRANT statement, and the alternative modes — and at the
+// 2.2s auto-hide it was not merely easy to miss, it was unreadable. The
+// operator was left with a button that did nothing and no way to recover the
+// reason. Nothing here starts a timer.
+function toastError(msg) {
+  const t = document.getElementById("toast");
+  if (!t) return;
+  clearTimeout(toast._t);
+  t.classList.add("toast-error");
+  // role=alert so a screen reader announces it; the visual persistence is
+  // useless to someone who cannot see it fade.
+  t.setAttribute("role", "alert");
+  t.replaceChildren();
+  t.append(el("span", { class: "toast-msg", text: msg }));
+  const close = el("button", { class: "toast-close", type: "button", "aria-label": "Dismiss" });
+  close.textContent = "\u2715";
+  close.addEventListener("click", () => dismissToast());
+  t.append(close);
+  t.hidden = false;
+}
+
+function dismissToast() {
+  const t = document.getElementById("toast");
+  if (!t) return;
+  t.hidden = true;
+  t.classList.remove("toast-error");
+  t.removeAttribute("role");
+  t.textContent = "";
+}
+
+// ESC dismisses a persistent error, matching every other dismissible surface
+// in this console. Registered once, and only acts on the error variant so it
+// cannot swallow an ESC meant for an open modal.
+document.addEventListener("keydown", (e) => {
+  if (e.key !== "Escape") return;
+  const t = document.getElementById("toast");
+  if (t && !t.hidden && t.classList.contains("toast-error")) dismissToast();
+});
 
 function renderError(container, err) {
   if (!container) return;
@@ -1804,7 +1851,7 @@ async function exportEvents(kind, btn) {
       toast("Exported the newest " + rows.length + " matches — the search has more. Narrow it with a time range to export the rest.");
     }
   } catch (err) {
-    toast("Export failed: " + (err && err.message ? err.message : String(err)));
+    toastError("Export failed: " + (err && err.message ? err.message : String(err)));
   } finally {
     if (btn) { btn.disabled = false; btn.textContent = label; }
   }
@@ -1899,7 +1946,7 @@ function downloadBlob(filename, content, mime) {
     const a = el("a", { href: url, download: filename });
     document.body.append(a); a.click(); a.remove();
     URL.revokeObjectURL(url);
-  } catch (err) { toast("download failed: " + ((err && err.message) || err)); }
+  } catch (err) { toastError("download failed: " + ((err && err.message) || err)); }
 }
 function csvCell(v) {
   if (v === null || v === undefined) return "";
@@ -2341,7 +2388,7 @@ function codePanel(sql, metaLabel) {
   return panel;
 }
 function copySQL() {
-  navigator.clipboard.writeText(lastSQL).then(() => toast("SQL copied to clipboard"), () => toast("Copy failed."));
+  navigator.clipboard.writeText(lastSQL).then(() => toast("SQL copied to clipboard"), () => toastError("Copy failed."));
 }
 function downloadSQL() { downloadBlob("dbtrail-undo.sql", lastSQL, "application/sql"); }
 
@@ -2894,7 +2941,7 @@ async function refreshSchemaSnapshot(id, btn) {
   try {
     await api("/api/servers/" + encodeURIComponent(id) + "/schema-snapshot", { method: "POST", body: {} });
   } catch (err) {
-    toast("Schema snapshot failed: " + ((err && err.message) || err));
+    toastError("Schema snapshot failed: " + ((err && err.message) || err));
     restore();
     return;
   }
@@ -2903,7 +2950,7 @@ async function refreshSchemaSnapshot(id, btn) {
   restore();
   if (!done) { toast("Schema snapshot still running — check back shortly."); return; }
   if (done.state !== "succeeded") {
-    toast("Schema snapshot failed: " + (done.last_error || "unknown error"));
+    toastError("Schema snapshot failed: " + (done.last_error || "unknown error"));
     return;
   }
   let msg = "Schema snapshot updated: " + (done.tables || 0) + " table(s).";
@@ -3518,7 +3565,7 @@ async function createBaseline(id, btn) {
   try {
     await api("/api/servers/" + encodeURIComponent(id) + "/baseline", { method: "POST", body: {} });
   } catch (err) {
-    toast("Baseline failed: " + ((err && err.message) || err));
+    toastError("Baseline failed: " + ((err && err.message) || err));
     restore();
     return;
   }
@@ -3529,7 +3576,7 @@ async function createBaseline(id, btn) {
     toast("Baseline complete: " + (done.tables || 0) + " table(s)" +
       (done.uploaded ? ", " + done.uploaded + " file(s) uploaded" : ""));
   } else if (done) {
-    toast("Baseline failed: " + (done.last_error || "unknown error"));
+    toastError("Baseline failed: " + (done.last_error || "unknown error"));
   } else {
     toast("Baseline still running — check back shortly.");
   }
@@ -3637,7 +3684,7 @@ async function createVerify(id, mode, btn, resultsEl) {
   try {
     status = (await api("/api/servers/" + encodeURIComponent(id) + "/verify", { method: "POST", body: { mode } })).verify;
   } catch (err) {
-    toast("Verify failed: " + ((err && err.message) || err));
+    toastError("Verify failed: " + ((err && err.message) || err));
     restore();
     return;
   }
@@ -3654,7 +3701,7 @@ async function createVerify(id, mode, btn, resultsEl) {
     toast(done.note || ("Verification complete: " + s.match + " match, " + s.mismatch + " mismatch, " +
       s.inconclusive + " inconclusive, " + s.error + " error"));
   } else if (done) {
-    toast("Verification failed: " + (done.last_error || "unknown error"));
+    toastError("Verification failed: " + (done.last_error || "unknown error"));
   } else {
     toast("Verification still running — check back shortly.");
   }
@@ -4062,7 +4109,7 @@ async function loadTables(form) {
     // A failed listing leaves the combo as usable free text with its value
     // intact — we cannot know whether the value belongs to the new schema,
     // and a dead or emptied field would be worse than a stale suggestion.
-    toast("failed to load tables: " + ((err && err.message) || err));
+    toastError("failed to load tables: " + ((err && err.message) || err));
     return;
   }
   if (combo) combo.removeAttribute("aria-busy");
@@ -4167,7 +4214,7 @@ function mcpURL(servers) {
 }
 
 function copyText(text, what) {
-  navigator.clipboard.writeText(text).then(() => toast(what + " copied to clipboard"), () => toast("Copy failed."));
+  navigator.clipboard.writeText(text).then(() => toast(what + " copied to clipboard"), () => toastError("Copy failed."));
 }
 
 function buildConnect(servers, tokStatus, minted) {
@@ -4198,7 +4245,7 @@ async function mintMCPToken(rotate) {
   try {
     res = await api("/api/mcp-token", { method: "POST" });
   } catch (err) {
-    toast("Token generation failed: " + (err.message || err));
+    toastError("Token generation failed: " + (err.message || err));
     return;
   }
   mcpMintedOnce = (res && res.token) || null;
@@ -4211,7 +4258,7 @@ async function revokeMCPToken() {
   try {
     await api("/api/mcp-token", { method: "DELETE" });
   } catch (err) {
-    toast("Revoke failed: " + (err.message || err));
+    toastError("Revoke failed: " + (err.message || err));
     return;
   }
   toast("Managed MCP token revoked");

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -610,9 +610,16 @@ async function submitPasswordChange(form, msg, firstSet) {
 
 // toast shows a transient notice. Use it for things that went RIGHT, or for
 // neutral progress. Failures must not fade — see toastError.
+//
+// A visible error OUTRANKS it. #toast is one shared node, and the common
+// sequence is a failure followed immediately by progress from another panel
+// ("Baseline started…", a poll's "still running"); overwriting would delete an
+// unread failure on a timer the operator never saw start. The dropped notice is
+// by definition the one that reports nothing went wrong.
 function toast(msg) {
   const t = document.getElementById("toast");
   if (!t) return;
+  if (!t.hidden && t.classList.contains("toast-error")) return;
   clearTimeout(toast._t);
   t.classList.remove("toast-error");
   t.removeAttribute("role");
@@ -633,17 +640,27 @@ function toastError(msg) {
   const t = document.getElementById("toast");
   if (!t) return;
   clearTimeout(toast._t);
+  // A second failure STACKS rather than replaces. These never auto-hide, so a
+  // silent overwrite would destroy an unread failure with nothing to hint one
+  // existed \u2014 two servers' baselines refusing together is the ordinary case.
+  const prior = t.hidden ? [] : $all(".toast-msg", t).map((n) => n.textContent);
+  if (prior.includes(msg)) return;
   t.classList.add("toast-error");
   // role=alert so a screen reader announces it; the visual persistence is
-  // useless to someone who cannot see it fade.
+  // useless to someone who cannot see it fade. The node is unhidden BEFORE the
+  // text lands: a live region that appears with its content already in place
+  // is the shape screen readers routinely fail to announce.
   t.setAttribute("role", "alert");
   t.replaceChildren();
-  t.append(el("span", { class: "toast-msg", text: msg }));
-  const close = el("button", { class: "toast-close", type: "button", "aria-label": "Dismiss" });
+  t.hidden = false;
+  const body = el("div", { class: "toast-body" });
+  for (const m of prior) body.append(el("span", { class: "toast-msg", text: m }));
+  body.append(el("span", { class: "toast-msg", text: msg }));
+  t.append(body);
+  const close = el("button", { class: "toast-close", type: "button", "aria-label": "Dismiss all" });
   close.textContent = "\u2715";
   close.addEventListener("click", () => dismissToast());
   t.append(close);
-  t.hidden = false;
 }
 
 function dismissToast() {
@@ -656,13 +673,32 @@ function dismissToast() {
 }
 
 // ESC dismisses a persistent error, matching every other dismissible surface
-// in this console. Registered once, and only acts on the error variant so it
-// cannot swallow an ESC meant for an open modal.
-document.addEventListener("keydown", (e) => {
+// in this console — but only as the LAST of them.
+//
+// Restricting this to the error variant is not enough on its own. cmdkKeydown
+// closes the ⌘K palette WITHOUT stopping propagation (deliberately, see
+// globalKeydown), so the same Escape reaches the document and would also
+// destroy an unread error — the failure this whole change exists to prevent,
+// arriving through a different door.
+//
+// Hence the CAPTURE phase (registered with `true` in init). Deciding on the
+// bubble phase cannot work: by then globalKeydown has already emptied #modal
+// and cmdkKeydown has already emptied #cmdk-mount, so the very state this
+// guard reads to yield the key has been erased by the handlers it is yielding
+// to, and it would dismiss the notice anyway. Capture runs before all of them,
+// while "is a dialog open" is still answerable.
+//
+// It never calls preventDefault or stopPropagation, so yielding is all it does
+// — the dialog handlers still run normally on the same event.
+function toastEscape(e) {
   if (e.key !== "Escape") return;
+  const cmdk = document.getElementById("cmdk-mount");
+  if (cmdk && cmdk.firstChild) return;
+  const modalMount = document.getElementById("modal");
+  if (modalMount && modalMount.firstChild) return;
   const t = document.getElementById("toast");
   if (t && !t.hidden && t.classList.contains("toast-error")) dismissToast();
-});
+}
 
 function renderError(container, err) {
   if (!container) return;
@@ -2196,7 +2232,7 @@ function openBusyModal(form, opts) {
         // vanished failure this modal exists to prevent. Tear down and
         // surface the error where it can be seen.
         teardown();
-        toast(opts.errTitle + ": " + msg);
+        toastError(opts.errTitle + ": " + msg);
         return;
       }
       panel.setAttribute("aria-busy", "false");
@@ -2489,7 +2525,7 @@ async function runState(form, history) {
 // and quietly restore to the wrong place.
 function aimUndoAtInstant(form, at) {
   const since = shiftSeconds(at, 1);
-  if (!since) { toast("Could not read the selected instant."); return; }
+  if (!since) { toastError("Could not read the selected instant."); return; }
   form.elements.since.value = since;
   form.elements.until.value = "";
   previewRecover(form);
@@ -2901,7 +2937,7 @@ async function acknowledgeCaptureSkips(total, btn) {
   } catch (err) {
     // The 409 here is the stale-tab refusal, and its message already says to
     // reload — surfacing the server's own text keeps the two in one voice.
-    toast("Could not mark as read: " + ((err && err.message) || err));
+    toastError("Could not mark as read: " + ((err && err.message) || err));
     if (btn) { btn.disabled = false; btn.textContent = "Mark as read"; }
     return;
   }
@@ -3229,7 +3265,7 @@ function duckdbCard() {
       downloadBlob("views.sql", sql, "text/plain");
       toast("views.sql downloaded — run it with: duckdb lake.db < views.sql");
     } catch (err) {
-      toast("could not generate views: " + ((err && err.message) || err));
+      toastError("could not generate views: " + ((err && err.message) || err));
     } finally {
       btn.disabled = false;
     }
@@ -3386,7 +3422,7 @@ async function setTelemetry(enabled) {
   try {
     await api("/api/telemetry", { method: "POST", body: JSON.stringify({ enabled: enabled }) });
   } catch (e) {
-    toast("Could not change telemetry: " + ((e && e.message) || e));
+    toastError("Could not change telemetry: " + ((e && e.message) || e));
     return;
   }
   toast(enabled ? "Telemetry turned on." : "Telemetry turned off — this daemon stops beaconing now.");
@@ -4692,7 +4728,7 @@ async function showRotationDialog() {
   if (loginGateRaised) return;
   let cur;
   try { cur = await api("/api/rotation"); }
-  catch (err) { toast("Could not load rotation settings: " + ((err && err.message) || err)); return; }
+  catch (err) { toastError("Could not load rotation settings: " + ((err && err.message) || err)); return; }
 
   const mount = document.getElementById("modal");
   const scrim = el("div", { class: "modal-scrim show" });
@@ -5016,7 +5052,7 @@ async function editServer(id) {
   // as an uncaught error, not masquerade as "failed to load server".
   let s;
   try { s = await api("/api/servers/" + encodeURIComponent(id)); }
-  catch (err) { toast("Could not load server: " + ((err && err.message) || err)); return false; }
+  catch (err) { toastError("Could not load server: " + ((err && err.message) || err)); return false; }
   showServerForm(s);
   return true;
 }
@@ -5049,7 +5085,7 @@ async function saveServer(form) {
 async function deleteServer(s) {
   if (!window.confirm('Remove server "' + s.name + '"? This only removes the saved connection — nothing happens to the server itself.')) return;
   try { await api("/api/servers/" + encodeURIComponent(s.id), { method: "DELETE" }); }
-  catch (err) { toast("Could not remove server: " + ((err && err.message) || err)); return; }
+  catch (err) { toastError("Could not remove server: " + ((err && err.message) || err)); return; }
   if (currentServer === s.id) { await switchServer(""); const sel = document.getElementById("server-select"); if (sel) sel.value = defaultServerId; }
   await refreshServersList();
   toast("Server removed");
@@ -5113,7 +5149,7 @@ function renderDoctor(report) {
 
 async function startMonitor(id) {
   try { return await api("/api/servers/" + encodeURIComponent(id) + "/monitor/start", { method: "POST", body: {} }); }
-  catch (err) { toast("Could not start: " + ((err && err.message) || err)); return null; }
+  catch (err) { toastError("Could not start: " + ((err && err.message) || err)); return null; }
 }
 
 async function startMonitorRow(id) {
@@ -5127,12 +5163,13 @@ async function startMonitorRow(id) {
   if (opened) {
     renderDoctor(res.doctor);
     formMsg(res.started ? "Monitoring started — review the warnings below" : "Startup checks failed — fix the items below, save, and start again", !res.started);
-  } else { toast(res.started ? "Monitoring started — with warnings" : "Startup checks failed"); }
+  } else if (res.started) { toast("Monitoring started — with warnings"); }
+  else { toastError("Startup checks failed"); }
 }
 
 async function stopMonitorRow(id) {
   try { await api("/api/servers/" + encodeURIComponent(id) + "/monitor/stop", { method: "POST", body: {} }); toast("Monitoring stopped"); }
-  catch (err) { toast("Could not stop: " + ((err && err.message) || err)); }
+  catch (err) { toastError("Could not stop: " + ((err && err.message) || err)); }
   await refreshServersList();
 }
 
@@ -5279,7 +5316,7 @@ async function bootSequence() {
   // error when its fetch fails.
   try { servers = await loadServers(); } catch (err) {
     if (err && err.status === 401) return null;
-    toast("Could not load servers: " + ((err && err.message) || err));
+    toastError("Could not load servers: " + ((err && err.message) || err));
   }
   try { await gateCapabilities(); } catch (err) {
     if (err && err.status === 401) return null;
@@ -5295,6 +5332,10 @@ async function init() {
   document.getElementById("open-cmdk").addEventListener("click", openCmdk);
   document.getElementById("logout-btn").addEventListener("click", doLogout);
   document.addEventListener("keydown", globalKeydown);
+  // Capture phase on purpose — see toastEscape. An Escape that closes a dialog
+  // must not also dismiss an error notice behind it, and only the capture phase
+  // still sees that the dialog was open.
+  document.addEventListener("keydown", toastEscape, true);
 
   // Sidebar nav (real hrefs upgraded to in-place swaps). A manual nav starts
   // fresh — clear any carried "Undo" context so the sidebar's Recover link
@@ -5329,7 +5370,7 @@ async function init() {
     // password): raise the gate with the SSO entry instead of toasting about
     // a printed token link that never existed in that deployment.
     if (auth.sso_start) { showLoginOverlay({ passwordLogin: false, ssoName: auth.sso_name, ssoStart: auth.sso_start }); return; }
-    toast("No token in URL — open the link printed by `bintrail-console`.");
+    toastError("No token in URL — open the link printed by `bintrail-console`.");
   }
 
   const servers = await bootSequence();

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -147,6 +147,11 @@
   <div id="cmdk-mount"></div>
 
   <div id="toast" class="toast" hidden></div>
+  <!-- Failures get their OWN node. Sharing one with the transient toast forced a
+       choice between two bad options: let a success notice delete an unread
+       failure, or let a stuck failure suppress every later notice — including
+       warnings that are reported nowhere else. Two nodes, no contention. -->
+  <div id="toast-error" class="toast toast-error" hidden></div>
   <script src="app.js"></script>
 </body>
 </html>

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1647,6 +1647,25 @@ button { font-family: inherit; }
   padding: 11px 18px; box-shadow: 0 8px 28px -10px oklch(0.3 0.03 305 / 0.5);
 }
 
+/* Persistent failure notice. Unlike the transient toast it never auto-hides,
+   so it has to survive being long: a privilege refusal carries the GRANT to
+   run and the alternative modes, and truncating that would put the operator
+   back where the fading toast left them. */
+.toast.toast-error {
+  display: flex; align-items: flex-start; gap: 12px;
+  max-width: min(70ch, 90vw); max-height: 60vh; overflow-y: auto;
+  text-align: left; line-height: 1.5; white-space: pre-wrap;
+}
+.toast.toast-error .toast-msg { flex: 1; }
+.toast.toast-error .toast-close {
+  flex: none; align-self: flex-start;
+  background: none; border: 0; cursor: pointer;
+  color: var(--bg); opacity: 0.75; font-size: 14px; line-height: 1;
+  padding: 2px 4px; border-radius: var(--radius-sm);
+}
+.toast.toast-error .toast-close:hover { opacity: 1; }
+.toast.toast-error .toast-close:focus-visible { outline: 2px solid var(--bg); outline-offset: 1px; }
+
 /* loading shimmer for #view while a screen fetches */
 .view-loading { font-family: var(--f-mono); font-size: 12.5px; color: var(--ink-4); padding: 20px 2px; }
 

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1656,7 +1656,10 @@ button { font-family: inherit; }
   max-width: min(70ch, 90vw); max-height: 60vh; overflow-y: auto;
   text-align: left; line-height: 1.5; white-space: pre-wrap;
 }
-.toast.toast-error .toast-msg { flex: 1; }
+/* Concurrent failures stack rather than overwrite, so the messages need their
+   own column — as direct children of the flex row they would sit side by side. */
+.toast.toast-error .toast-body { flex: 1; display: flex; flex-direction: column; gap: 10px; min-width: 0; }
+.toast.toast-error .toast-msg + .toast-msg { border-top: 1px solid oklch(1 0 0 / 0.18); padding-top: 10px; }
 .toast.toast-error .toast-close {
   flex: none; align-self: flex-start;
   background: none; border: 0; cursor: pointer;

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1655,6 +1655,11 @@ button { font-family: inherit; }
   display: flex; align-items: flex-start; gap: 12px;
   max-width: min(70ch, 90vw); max-height: 60vh; overflow-y: auto;
   text-align: left; line-height: 1.5; white-space: pre-wrap;
+  /* Sits ABOVE the transient toast: they are separate nodes now (so neither can
+     suppress the other) and both are position:fixed, so without an offset they
+     would render on top of each other. Growing upward keeps the transient one
+     where operators already expect it. */
+  bottom: 84px;
 }
 /* Concurrent failures stack rather than overwrite, so the messages need their
    own column — as direct children of the flex row they would sit side by side. */

--- a/internal/mydumperlock/privileges.go
+++ b/internal/mydumperlock/privileges.go
@@ -116,13 +116,19 @@ func (r Remedy) noCheckModes() string {
 // dump rather than being swallowed, because the alternative — letting mydumper
 // attempt FTWRL half-privileged — is a segfault, not a clean error (#800).
 // Never silently falls back to a mode that is not point-consistent.
-func CheckPrivileges(ctx context.Context, sourceDSN string, mode baseline.LockMode, remedy Remedy) error {
+func CheckPrivileges(ctx context.Context, sourceDSN string, mode baseline.LockMode, remedy Remedy, schemas []string) error {
 	db, err := config.Connect(sourceDSN)
 	if err != nil {
-		return fmt.Errorf("point-consistent baseline: cannot connect to source to verify privileges: %w%s", err, remedy.noCheckModes())
+		// Deliberately NO alternatives clause. An unreachable source is not a
+		// privilege problem: mydumper cannot dump in ANY mode, so naming the
+		// weaker ones buys nothing and actively misleads — on the console the
+		// knob is a daemon environment variable, so an operator who sets
+		// no-lock to get past a transient blip silently degrades EVERY future
+		// baseline, with nothing to expire it or prompt a revert.
+		return fmt.Errorf("point-consistent baseline: cannot connect to source to verify privileges: %w", err)
 	}
 	defer db.Close()
-	return checkPrivilegesDB(ctx, db, mode, remedy)
+	return checkPrivilegesDB(ctx, db, mode, remedy, schemas)
 }
 
 // grantSet is what SHOW GRANTS FOR CURRENT_USER() told us, split by SCOPE.
@@ -136,6 +142,16 @@ type grantSet struct {
 	// `db`.`tbl`). Kept as the raw object text so a refusal can quote back
 	// what the operator's own SHOW GRANTS shows.
 	scoped map[string][]string
+	// revoked maps a privilege to the objects a PARTIAL REVOKE took it back on.
+	// MySQL 8.0.16+ renders these as separate REVOKE lines in SHOW GRANTS, and
+	// reading only the GRANT lines reports a privilege the user does not have —
+	// verified on MySQL 8.0.46 with partial_revokes=ON: a user holding
+	// `GRANT LOCK TABLES ON *.*` with `REVOKE LOCK TABLES ON \`appdb\`.*` gets
+	// "ERROR 1044 Access denied ... to database 'appdb'" on LOCK TABLES there.
+	// That is the FALSE-PASS direction: mydumper launches and dies partway,
+	// leaving a partial dump, which is exactly what this preflight exists to
+	// prevent. partial_revokes defaults OFF, but it is a one-way switch.
+	revoked map[string][]string
 	// unparsed counts grant lines this parser did not recognise as either a
 	// privilege grant or a role membership. It exists so a misparse is
 	// DEBUGGABLE: the failure this whole package is fixing was a check that
@@ -167,6 +183,10 @@ func (g *grantSet) scopesFor(p string) string {
 
 // add parses one SHOW GRANTS line into the set.
 func (g *grantSet) add(line string) {
+	if strings.HasPrefix(line, "REVOKE ") {
+		g.addRevoke(line)
+		return
+	}
 	if !strings.HasPrefix(line, "GRANT ") {
 		g.unparsed++
 		return
@@ -202,6 +222,86 @@ func (g *grantSet) add(line string) {
 	for _, n := range names {
 		g.scoped[n] = append(g.scoped[n], obj)
 	}
+}
+
+// addRevoke parses "REVOKE <privs> ON <object> FROM <user>".
+func (g *grantSet) addRevoke(line string) {
+	rest := line[len("REVOKE "):]
+	oi := strings.Index(rest, " ON ")
+	if oi < 0 {
+		g.unparsed++
+		return
+	}
+	obj := rest[oi+len(" ON "):]
+	fi := strings.Index(obj, " FROM ")
+	if fi < 0 {
+		g.unparsed++
+		return
+	}
+	names := splitPrivileges(rest[:oi])
+	if len(names) == 0 {
+		g.unparsed++
+		return
+	}
+	obj = strings.TrimSpace(obj[:fi])
+	for _, n := range names {
+		g.revoked[n] = append(g.revoked[n], obj)
+	}
+}
+
+// revokeSchema extracts the schema component of a grant/revoke object
+// (`appdb`.* → appdb). Returns ok=false for a shape it does not recognise —
+// which is treated as "cannot evaluate", never as "does not apply".
+func revokeSchema(obj string) (string, bool) {
+	dot := strings.Index(obj, ".")
+	if dot <= 0 {
+		return "", false
+	}
+	return strings.Trim(obj[:dot], "`\""), true
+}
+
+// revokesAffecting splits the partial revokes of p into those that PROVABLY
+// apply to a dump of these schemas and those that cannot be decided.
+//
+// The split matters because the two directions have opposite costs. Refusing a
+// dump whose schemas a revoke does not touch is a false refusal — the defect
+// #1381 was filed for. Passing one it does touch lets mydumper die partway.
+// So only a LITERAL schema-name match counts as blocking: a MySQL grant pattern
+// may contain `%`/`_` wildcards, and a pattern equal to the schema name matches
+// it whatever the wildcard rules say, while a non-equal pattern containing a
+// wildcard MIGHT match and is reported rather than acted on.
+//
+// An empty schema list means "dump every non-system schema", so any revoke is
+// blocking: whatever it names is inside the dump.
+func (g *grantSet) revokesAffecting(p string, schemas []string) (blocking, undecidable []string) {
+	var objs []string
+	objs = append(objs, g.revoked[p]...)
+	objs = append(objs, g.revoked["ALL PRIVILEGES"]...)
+	for _, obj := range objs {
+		if len(schemas) == 0 {
+			blocking = append(blocking, obj)
+			continue
+		}
+		name, ok := revokeSchema(obj)
+		if !ok {
+			undecidable = append(undecidable, obj)
+			continue
+		}
+		matched := false
+		for _, s := range schemas {
+			if strings.EqualFold(name, s) {
+				matched = true
+				break
+			}
+		}
+		switch {
+		case matched:
+			blocking = append(blocking, obj)
+		case strings.ContainsAny(name, "%_"):
+			undecidable = append(undecidable, obj)
+		}
+	}
+	return blocking, undecidable
 }
 
 // splitPrivileges turns "SELECT (a, b), LOCK TABLES" into the privilege names
@@ -250,7 +350,7 @@ func parseGrants(ctx context.Context, db *sql.DB) (*grantSet, error) {
 	}
 	defer rows.Close()
 
-	g := &grantSet{global: map[string]bool{}, scoped: map[string][]string{}}
+	g := &grantSet{global: map[string]bool{}, scoped: map[string][]string{}, revoked: map[string][]string{}}
 	for rows.Next() {
 		var line string
 		if err := rows.Scan(&line); err != nil {
@@ -295,10 +395,13 @@ func parseGrants(ctx context.Context, db *sql.DB) (*grantSet, error) {
 //   - The low-privilege modes never reach here.
 //
 // ALL PRIVILEGES satisfies any of them at the matching scope.
-func checkPrivilegesDB(ctx context.Context, db *sql.DB, mode baseline.LockMode, remedy Remedy) error {
+func checkPrivilegesDB(ctx context.Context, db *sql.DB, mode baseline.LockMode, remedy Remedy, schemas []string) error {
 	g, err := parseGrants(ctx, db)
 	if err != nil {
-		return err
+		// The hatch belongs HERE, not on the connect path: the source answered,
+		// so a dump can genuinely still succeed — it is only this check that
+		// could not run.
+		return fmt.Errorf("%w%s", err, remedy.noCheckModes())
 	}
 
 	// SHOW GRANTS expands the privileges of a session's ACTIVE roles (measured
@@ -311,18 +414,42 @@ func checkPrivilegesDB(ctx context.Context, db *sql.DB, mode baseline.LockMode, 
 
 	if mode == baseline.LockModeLockAll {
 		if g.grantedAnywhere("LOCK TABLES") {
+			blocking, undecidable := g.revokesAffecting("LOCK TABLES", schemas)
+			if len(undecidable) > 0 {
+				slog.Warn("lock-all: a partial revoke of LOCK TABLES may cover a schema in this dump;"+
+					" if mydumper fails with \"Access denied\", this is why",
+					"revokes", strings.Join(undecidable, ", "), "schemas", schemas)
+			}
+			if len(blocking) > 0 {
+				return fmt.Errorf("lock-all baseline mode requires LOCK TABLES on the dumped schemas, and a partial"+
+					" REVOKE takes it back on %s — the global grant does not apply there (verified: LOCK TABLES then"+
+					" fails with \"ERROR 1044 Access denied\"). Restore it, e.g."+
+					" GRANT LOCK TABLES ON <schema>.* TO '<user>'@'%%', or exclude that schema from the dump%s",
+					strings.Join(blocking, ", "), remedy.noCheckModes())
+			}
 			if !g.grantedGlobally("LOCK TABLES") {
-				// Accepted, but say which schemas it covers: if the dump reaches a
+				// Accepted, but say which objects it covers: if the dump reaches a
 				// schema outside them mydumper fails cleanly, and this line is what
-				// makes that error make sense.
-				slog.Info("lock-all: LOCK TABLES is granted per schema, not globally;"+
-					" the dump must stay within these", "scopes", g.scopesFor("LOCK TABLES"))
+				// makes that error make sense. Not a refusal — the grant patterns
+				// can carry wildcards, so "does it cover the dump" is not decidable
+				// here, and guessing wrong is the false refusal #1381 was about.
+				slog.Info("lock-all: LOCK TABLES is granted per object, not globally;"+
+					" the dump must stay within these", "scopes", g.scopesFor("LOCK TABLES"),
+					"schemas", schemas)
 			}
 			return nil
 		}
+		// Name ftwrl when the user could actually run it: an operator who copied
+		// an RDS recipe onto a self-hosted source holding global RELOAD would
+		// otherwise be steered straight past the point-consistent mode they have.
+		alt := remedy.noCheckModes()
+		if g.grantedGlobally("RELOAD") || g.grantedGlobally("FLUSH_TABLES") {
+			alt = " — this user already holds RELOAD/FLUSH_TABLES globally, so " +
+				remedy.forMode(baseline.LockModeFTWRL) + " is available and is also point-consistent" + alt
+		}
 		return fmt.Errorf("lock-all baseline mode requires the LOCK TABLES privilege, which the current user does not"+
 			" have at any scope — grant it, e.g. GRANT LOCK TABLES ON *.* TO '<user>'@'%%' (a grant on just the dumped"+
-			" schema also works, since LOCK_ALL locks the exported tables)%s%s", roleCaveat, remedy.noCheckModes())
+			" schema also works, since LOCK_ALL locks the exported tables)%s%s", roleCaveat, alt)
 	}
 
 	if g.grantedGlobally("ALL PRIVILEGES") {
@@ -331,9 +458,20 @@ func checkPrivilegesDB(ctx context.Context, db *sql.DB, mode baseline.LockMode, 
 
 	requireBackupAdmin, err := requiresBackupAdmin(ctx, db)
 	if err != nil {
+		// Unlike the paths above, the grants ARE known here — so if this user
+		// can run lock-all, say so instead of offering only the weaker modes.
+		// noCheckModes exists for when the grant query itself failed.
+		if g.grantedAnywhere("LOCK TABLES") {
+			return fmt.Errorf("%w — this user holds LOCK TABLES, so %s, which is point-consistent and needs no"+
+				" version check%s", err, remedy.forMode(baseline.LockModeLockAll), remedy.noCheckModes())
+		}
 		return fmt.Errorf("%w%s", err, remedy.noCheckModes())
 	}
 	hasFlush := g.grantedGlobally("RELOAD") || g.grantedGlobally("FLUSH_TABLES")
+	// A partial revoke cannot take back a global-only privilege like RELOAD in a
+	// way that affects FLUSH TABLES WITH READ LOCK (which is not schema-scoped),
+	// so no revoke check here — but say so, or the asymmetry with lock-all above
+	// reads as an oversight.
 	missingBackupAdmin := requireBackupAdmin && !g.grantedGlobally("BACKUP_ADMIN")
 	if hasFlush && !missingBackupAdmin {
 		return nil

--- a/internal/mydumperlock/privileges.go
+++ b/internal/mydumperlock/privileges.go
@@ -14,25 +14,14 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/config"
 )
-
-// requiredPrivileges are the MySQL privileges the pinned
-// mydumper build (v1.0.3-1) can need for --sync-thread-lock-mode FTWRL,
-// verified empirically against a real MySQL 8.0 source (#800): BACKUP_ADMIN
-// for `LOCK INSTANCE FOR BACKUP` (checked first — missing it alone fails
-// cleanly with a CRITICAL "Access denied ... BACKUP_ADMIN" and exit 1) and
-// RELOAD or the FLUSH_TABLES dynamic privilege for the subsequent `FLUSH
-// TABLES WITH READ LOCK` (missing THIS one while BACKUP_ADMIN is present does
-// NOT fail cleanly — mydumper segfaults). BACKUP_ADMIN itself is required only
-// on MySQL/Percona 8.0+ — see RequiresBackupAdmin. Both classic (RELOAD)
-// and dynamic (BACKUP_ADMIN, FLUSH_TABLES) privileges appear side by side in
-// information_schema.USER_PRIVILEGES on MySQL 8.0+.
-var requiredPrivileges = []string{"BACKUP_ADMIN", "RELOAD", "FLUSH_TABLES"}
 
 // requiresBackupAdmin reports whether the connected server needs the
 // BACKUP_ADMIN privilege for FTWRL's `LOCK INSTANCE FOR BACKUP` step.
@@ -84,21 +73,22 @@ func serverMajorVersion(version string) (major int, ok bool) {
 	return n, true
 }
 
-// CheckPrivileges queries the source for its required
-// point-consistent privileges and fails loudly, before mydumper ever runs,
-// unless they are present. This is a hard gate, not an advisory warning:
-// unlike the no-lock skew warning in consoleapp, a query failure here aborts the dump
-// rather than being swallowed, because the alternative — letting mydumper
-// attempt FTWRL half-privileged — is a segfault, not a clean error (#800).
-// Never silently falls back to NO_LOCK.
-// Remedy is how the CALLING surface selects a weaker lock mode. It is a
-// parameter because the refusal text is the one actionable sentence an
-// operator gets, and naming the other surface's knob is worse than naming
-// none: `bintrail dump` does not read the console's environment variable, and
-// the console has no flags. Both callers reach this on their DEFAULT path
-// since #1377, so this is the first thing an upgrading least-privilege
-// deployment sees on either one.
+// Remedy identifies the CALLING surface, so a refusal can name that surface's
+// own way of selecting a different lock mode. It is a parameter because the
+// refusal text is the one actionable sentence an operator gets, and naming the
+// other surface's knob is worse than naming none: `bintrail dump` does not read
+// the console's environment variable, and the console has no flags. Both
+// callers reach this on their DEFAULT path since #1377, so this is the first
+// thing an upgrading least-privilege deployment sees on either one.
 type Remedy string
+
+const (
+	// RemedyCLI marks `bintrail dump`, whose knob is the --lock-mode flag.
+	RemedyCLI Remedy = "cli"
+	// RemedyConsole marks the console daemon, which has no flag surface and is
+	// configured by environment variable.
+	RemedyConsole Remedy = "console"
+)
 
 // forMode renders this surface's way of selecting a specific mode.
 func (r Remedy) forMode(m baseline.LockMode) string {
@@ -108,23 +98,140 @@ func (r Remedy) forMode(m baseline.LockMode) string {
 	return "set BINTRAIL_CONSOLE_BASELINE_LOCK_MODE=" + string(m)
 }
 
-const (
-	// RemedyCLI is `bintrail dump`'s knob.
-	RemedyCLI Remedy = "cli"
-	// RemedyConsole is the console daemon's; it has no flag surface.
-	RemedyConsole Remedy = "console"
-)
+// noCheckModes names the modes that skip this gate entirely. It is the escape
+// hatch offered when the CHECK ITSELF could not run — suggesting lock-all there
+// would be useless, since lock-all is verified by this same query. Without it,
+// an operator whose source cannot answer SHOW GRANTS gets a hard stop on the
+// default path with nothing to try.
+func (r Remedy) noCheckModes() string {
+	return " — to proceed without this check, " + r.forMode(baseline.LockModeSafeNoLock) +
+		", which needs no privilege but ABORTS rather than write a snapshot stitched from" +
+		" several instants; or " + r.forMode(baseline.LockModeNoLock) + " to accept such a snapshot"
+}
 
+// CheckPrivileges queries the source for the privileges the requested
+// point-consistent lock mode needs and fails loudly, before mydumper ever runs,
+// unless they are present. This is a hard gate, not an advisory warning:
+// unlike the no-lock skew warning in consoleapp, a query failure here aborts the
+// dump rather than being swallowed, because the alternative — letting mydumper
+// attempt FTWRL half-privileged — is a segfault, not a clean error (#800).
+// Never silently falls back to a mode that is not point-consistent.
 func CheckPrivileges(ctx context.Context, sourceDSN string, mode baseline.LockMode, remedy Remedy) error {
 	db, err := config.Connect(sourceDSN)
 	if err != nil {
-		return fmt.Errorf("point-consistent baseline: cannot connect to source to verify privileges: %w", err)
+		return fmt.Errorf("point-consistent baseline: cannot connect to source to verify privileges: %w%s", err, remedy.noCheckModes())
 	}
 	defer db.Close()
 	return checkPrivilegesDB(ctx, db, mode, remedy)
 }
 
-// grantedPrivileges reads the connecting user's GLOBAL privileges.
+// grantSet is what SHOW GRANTS FOR CURRENT_USER() told us, split by SCOPE.
+// The distinction is load-bearing: FTWRL's privileges are global-only, while
+// LOCK_ALL's LOCK TABLES is grantable per schema and is routinely held that
+// way by a least-privilege account.
+type grantSet struct {
+	// global holds privileges granted ON *.*.
+	global map[string]bool
+	// scoped maps a privilege to the objects it was granted on (`db`.*,
+	// `db`.`tbl`). Kept as the raw object text so a refusal can quote back
+	// what the operator's own SHOW GRANTS shows.
+	scoped map[string][]string
+	// unparsed counts grant lines this parser did not recognise as either a
+	// privilege grant or a role membership. It exists so a misparse is
+	// DEBUGGABLE: the failure this whole package is fixing was a check that
+	// refused confidently while reading the wrong source, and the operator had
+	// no way to tell a real refusal from a blind one.
+	unparsed int
+}
+
+// grantedGlobally reports whether p was granted ON *.*, directly or via
+// ALL PRIVILEGES. This is the right question for RELOAD, FLUSH_TABLES and
+// BACKUP_ADMIN: MySQL only accepts those at global scope.
+func (g *grantSet) grantedGlobally(p string) bool {
+	return g.global[p] || g.global["ALL PRIVILEGES"]
+}
+
+// grantedAnywhere reports whether p was granted at ANY scope. This is the
+// right question for LOCK TABLES under LOCK_ALL — see checkPrivilegesDB.
+func (g *grantSet) grantedAnywhere(p string) bool {
+	return g.grantedGlobally(p) || len(g.scoped[p]) > 0 || len(g.scoped["ALL PRIVILEGES"]) > 0
+}
+
+// scopesFor renders the objects p was granted on, for a message.
+func (g *grantSet) scopesFor(p string) string {
+	s := append([]string{}, g.scoped[p]...)
+	s = append(s, g.scoped["ALL PRIVILEGES"]...)
+	sort.Strings(s)
+	return strings.Join(s, ", ")
+}
+
+// add parses one SHOW GRANTS line into the set.
+func (g *grantSet) add(line string) {
+	if !strings.HasPrefix(line, "GRANT ") {
+		g.unparsed++
+		return
+	}
+	rest := line[len("GRANT "):]
+	oi := strings.Index(rest, " ON ")
+	if oi < 0 {
+		// A role membership: "GRANT `r`@`%` TO `u`@`%`". Not a privilege grant,
+		// and nothing is lost by skipping it — MySQL expands an ACTIVE role's
+		// privileges into their own ON *.* lines in this same result set
+		// (measured on MySQL 8.0: a user whose RELOAD and FLUSH_TABLES came
+		// only from a default-activated role saw both listed inline, attributed
+		// to the user). Not counted as unparsed: it is a normal line.
+		return
+	}
+	obj := rest[oi+len(" ON "):]
+	ti := strings.Index(obj, " TO ")
+	if ti < 0 {
+		g.unparsed++
+		return
+	}
+	names := splitPrivileges(rest[:oi])
+	if len(names) == 0 {
+		g.unparsed++
+		return
+	}
+	if obj = strings.TrimSpace(obj[:ti]); obj == "*.*" {
+		for _, n := range names {
+			g.global[n] = true
+		}
+		return
+	}
+	for _, n := range names {
+		g.scoped[n] = append(g.scoped[n], obj)
+	}
+}
+
+// splitPrivileges turns "SELECT (a, b), LOCK TABLES" into the privilege names
+// alone. Column lists are stripped BEFORE the comma split — splitting first
+// would parse the column names as privileges.
+func splitPrivileges(s string) []string {
+	var b strings.Builder
+	depth := 0
+	for _, r := range s {
+		switch {
+		case r == '(':
+			depth++
+		case r == ')':
+			if depth > 0 {
+				depth--
+			}
+		case depth == 0:
+			b.WriteRune(r)
+		}
+	}
+	var out []string
+	for _, p := range strings.Split(b.String(), ",") {
+		if p = strings.ToUpper(strings.TrimSpace(p)); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// parseGrants reads the connecting user's privileges.
 //
 // It parses SHOW GRANTS FOR CURRENT_USER() rather than reading
 // information_schema.USER_PRIVILEGES, which was the source until this was
@@ -134,47 +241,37 @@ func CheckPrivileges(ctx context.Context, sourceDSN string, mode baseline.LockMo
 // SHOW GRANTS listed RELOAD and FLUSH_TABLES as direct grants. Reading it made
 // this check fail CLOSED on every managed source, which since #1377 made the
 // point-consistent default unreachable there. SHOW GRANTS needs no privilege
-// to run for the current user and expands whatever the session actually has.
-//
-// Only global grants count: a privilege is what it is on `ON *.*`, and a
-// schema-scoped grant does not authorize FLUSH TABLES WITH READ LOCK or
-// LOCK INSTANCE FOR BACKUP.
-func grantedPrivileges(ctx context.Context, db *sql.DB) (map[string]bool, error) {
+// to run for the current user and expands whatever the session actually has,
+// including the privileges of active roles.
+func parseGrants(ctx context.Context, db *sql.DB) (*grantSet, error) {
 	rows, err := db.QueryContext(ctx, "SHOW GRANTS FOR CURRENT_USER()")
 	if err != nil {
 		return nil, fmt.Errorf("point-consistent baseline: cannot verify source privileges: %w", err)
 	}
 	defer rows.Close()
 
-	have := map[string]bool{}
+	g := &grantSet{global: map[string]bool{}, scoped: map[string][]string{}}
 	for rows.Next() {
 		var line string
 		if err := rows.Scan(&line); err != nil {
 			return nil, fmt.Errorf("point-consistent baseline: cannot read source privileges: %w", err)
 		}
-		// "GRANT <privs> ON *.* TO ..." — anything else (schema grants, role
-		// memberships, proxy grants) carries no global privilege.
-		const on = " ON *.* TO "
-		idx := strings.Index(line, on)
-		if idx < 0 || !strings.HasPrefix(line, "GRANT ") {
-			continue
-		}
-		for _, p := range strings.Split(line[len("GRANT "):idx], ",") {
-			p = strings.ToUpper(strings.TrimSpace(p))
-			// A privilege can carry a column list, e.g. SELECT (col). Keep the
-			// name; the parenthesised part is never global-only anyway.
-			if k := strings.IndexByte(p, '('); k >= 0 {
-				p = strings.TrimSpace(p[:k])
-			}
-			if p != "" {
-				have[p] = true
-			}
-		}
+		g.add(line)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("point-consistent baseline: cannot read source privileges: %w", err)
 	}
-	return have, nil
+	// The parsed verdict is the input to a refusal an operator reads mid-incident.
+	// Log what we actually read so a misparse is diagnosable from the daemon log
+	// instead of being indistinguishable from a genuine refusal.
+	names := make([]string, 0, len(g.global))
+	for n := range g.global {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	slog.Debug("read source privileges for baseline lock mode",
+		"global", names, "scoped", g.scoped, "unrecognized_lines", g.unparsed)
+	return g, nil
 }
 
 // checkPrivilegesDB is CheckPrivileges' core logic against an already-open
@@ -184,37 +281,60 @@ func grantedPrivileges(ctx context.Context, db *sql.DB) (map[string]bool, error)
 //   - FTWRL needs RELOAD or FLUSH_TABLES on every flavor, plus BACKUP_ADMIN on
 //     MySQL/Percona 8.0+ (it issues LOCK INSTANCE FOR BACKUP first). Granting
 //     BACKUP_ADMIN WITHOUT RELOAD does not fail cleanly — the pinned build
-//     SEGFAULTS — which is why this check exists at all.
-//   - LOCK_ALL needs LOCK TABLES and nothing else. This is the mode that works
-//     on managed MySQL, where BACKUP_ADMIN is not grantable.
+//     SEGFAULTS — which is why this check exists at all. All three are
+//     global-only privileges, so only an ON *.* grant can satisfy them.
+//   - LOCK_ALL needs LOCK TABLES, at ANY scope. mydumper's own help names it as
+//     one of the two modes it supports on RDS/Aurora ("We support LOCK_ALL and
+//     SAFE_NO_LOCK modes for RDS/Aurora", string in the pinned v1.0.3-1 binary),
+//     and it locks the EXPORTED TABLES rather than the instance — so a
+//     least-privilege account holding LOCK TABLES on just the dumped schema is
+//     enough. Verified: a dump ran to completion with only
+//     `GRANT SELECT, LOCK TABLES, SHOW VIEW ON \`appdb\`.*`. Requiring it
+//     globally would refuse a configuration that demonstrably works, which is
+//     the exact defect (#1381) this mode was added to fix.
 //   - The low-privilege modes never reach here.
 //
-// ALL PRIVILEGES satisfies any of them.
+// ALL PRIVILEGES satisfies any of them at the matching scope.
 func checkPrivilegesDB(ctx context.Context, db *sql.DB, mode baseline.LockMode, remedy Remedy) error {
-	have, err := grantedPrivileges(ctx, db)
+	g, err := parseGrants(ctx, db)
 	if err != nil {
 		return err
 	}
-	if have["ALL PRIVILEGES"] {
-		return nil
-	}
 
-	const roleCaveat = " (if these are granted through a role, activate it for this connection — SHOW GRANTS reflects the session's active roles)"
+	// SHOW GRANTS expands the privileges of a session's ACTIVE roles (measured
+	// on MySQL 8.0). The remedy is therefore server-side: bintrail opens this
+	// connection itself and mydumper opens its own, so there is no point at
+	// which an operator could issue SET ROLE for either.
+	const roleCaveat = " (if these are granted through a role, make it active on connect —" +
+		" SET DEFAULT ROLE ALL TO '<user>'@'<host>', or activate_all_roles_on_login=ON —" +
+		" since neither this check nor mydumper can issue SET ROLE on its own connection)"
 
 	if mode == baseline.LockModeLockAll {
-		if have["LOCK TABLES"] {
+		if g.grantedAnywhere("LOCK TABLES") {
+			if !g.grantedGlobally("LOCK TABLES") {
+				// Accepted, but say which schemas it covers: if the dump reaches a
+				// schema outside them mydumper fails cleanly, and this line is what
+				// makes that error make sense.
+				slog.Info("lock-all: LOCK TABLES is granted per schema, not globally;"+
+					" the dump must stay within these", "scopes", g.scopesFor("LOCK TABLES"))
+			}
 			return nil
 		}
-		return fmt.Errorf("lock-all baseline mode requires the LOCK TABLES privilege; the current user does not have it"+
-			" — grant it, e.g. GRANT LOCK TABLES ON *.* TO '<user>'@'%%'%s", roleCaveat)
+		return fmt.Errorf("lock-all baseline mode requires the LOCK TABLES privilege, which the current user does not"+
+			" have at any scope — grant it, e.g. GRANT LOCK TABLES ON *.* TO '<user>'@'%%' (a grant on just the dumped"+
+			" schema also works, since LOCK_ALL locks the exported tables)%s%s", roleCaveat, remedy.noCheckModes())
+	}
+
+	if g.grantedGlobally("ALL PRIVILEGES") {
+		return nil
 	}
 
 	requireBackupAdmin, err := requiresBackupAdmin(ctx, db)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w%s", err, remedy.noCheckModes())
 	}
-	hasFlush := have["RELOAD"] || have["FLUSH_TABLES"]
-	missingBackupAdmin := requireBackupAdmin && !have["BACKUP_ADMIN"]
+	hasFlush := g.grantedGlobally("RELOAD") || g.grantedGlobally("FLUSH_TABLES")
+	missingBackupAdmin := requireBackupAdmin && !g.grantedGlobally("BACKUP_ADMIN")
 	if hasFlush && !missingBackupAdmin {
 		return nil
 	}
@@ -229,12 +349,14 @@ func checkPrivilegesDB(ctx context.Context, db *sql.DB, mode baseline.LockMode, 
 	// operator hunting a privilege their server cannot have.
 	lockAllNote := ", which is also point-consistent and needs only LOCK TABLES"
 	if requireBackupAdmin {
-		lockAllNote += " (the mode that works on managed MySQL, where BACKUP_ADMIN cannot be granted at all)"
+		lockAllNote += " (the mode that works on managed MySQL, where BACKUP_ADMIN cannot be granted at all;" +
+			" mydumper's own help names LOCK_ALL and SAFE_NO_LOCK as the modes it supports on RDS/Aurora)"
 	}
 	alternatives := " — or " + remedy.forMode(baseline.LockModeLockAll) + lockAllNote +
 		"; or " + remedy.forMode(baseline.LockModeSafeNoLock) +
 		", which needs no privilege but ABORTS rather than write a snapshot stitched from several instants," +
-		" so expect it to refuse on a write-active source; or no-lock to accept such a snapshot"
+		" so expect it to refuse on a write-active source; or " + remedy.forMode(baseline.LockModeNoLock) +
+		" to accept such a snapshot"
 
 	switch {
 	case !hasFlush && missingBackupAdmin:
@@ -242,8 +364,19 @@ func checkPrivilegesDB(ctx context.Context, db *sql.DB, mode baseline.LockMode, 
 			" BACKUP_ADMIN and the RELOAD (or FLUSH_TABLES) privilege (MySQL/Percona 8.0+); the current user has"+
 			" neither — grant both, e.g. GRANT BACKUP_ADMIN, RELOAD ON *.* TO '<user>'@'%%'%s%s", alternatives, roleCaveat)
 	case !hasFlush:
-		return fmt.Errorf("point-consistent baseline mode requires the RELOAD (or FLUSH_TABLES) privilege; the current"+
-			" user has neither — grant it, e.g. GRANT RELOAD ON *.* TO '<user>'@'%%'%s%s", alternatives, roleCaveat)
+		// Reached when BACKUP_ADMIN is present (or not required) but RELOAD is
+		// not. On MySQL 8.0+ that half-grant is the #800 crash input, and it is
+		// worth naming: an operator holding BACKUP_ADMIN has already been told
+		// once that it was the missing privilege, and needs to know why the
+		// remaining half is not merely another clean refusal.
+		crashNote := ""
+		if requireBackupAdmin {
+			crashNote = " — granting BACKUP_ADMIN alone is the dangerous half-grant:" +
+				" the pinned mydumper build SEGFAULTS on it rather than failing cleanly, which is why this check runs first"
+		}
+		return fmt.Errorf("point-consistent baseline mode requires the RELOAD (or FLUSH_TABLES) privilege, which the"+
+			" current user has at neither name — grant it, e.g. GRANT RELOAD ON *.* TO '<user>'@'%%'%s%s%s",
+			crashNote, alternatives, roleCaveat)
 	default:
 		return fmt.Errorf("point-consistent baseline mode requires the BACKUP_ADMIN privilege (MySQL/Percona 8.0+) in"+
 			" addition to RELOAD/FLUSH_TABLES, which the current user already has — grant it, e.g."+

--- a/internal/mydumperlock/privileges.go
+++ b/internal/mydumperlock/privileges.go
@@ -13,11 +13,11 @@ package mydumperlock
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
+	"github.com/dbtrail/dbtrail/internal/baseline"
 	"github.com/dbtrail/dbtrail/internal/config"
 )
 
@@ -100,113 +100,154 @@ func serverMajorVersion(version string) (major int, ok bool) {
 // deployment sees on either one.
 type Remedy string
 
+// forMode renders this surface's way of selecting a specific mode.
+func (r Remedy) forMode(m baseline.LockMode) string {
+	if r == RemedyCLI {
+		return "pass --lock-mode " + string(m)
+	}
+	return "set BINTRAIL_CONSOLE_BASELINE_LOCK_MODE=" + string(m)
+}
+
 const (
 	// RemedyCLI is `bintrail dump`'s knob.
-	RemedyCLI Remedy = "pass --lock-mode safe-no-lock"
+	RemedyCLI Remedy = "cli"
 	// RemedyConsole is the console daemon's; it has no flag surface.
-	RemedyConsole Remedy = "set BINTRAIL_CONSOLE_BASELINE_LOCK_MODE=safe-no-lock"
+	RemedyConsole Remedy = "console"
 )
 
-func CheckPrivileges(ctx context.Context, sourceDSN string, remedy Remedy) error {
+func CheckPrivileges(ctx context.Context, sourceDSN string, mode baseline.LockMode, remedy Remedy) error {
 	db, err := config.Connect(sourceDSN)
 	if err != nil {
 		return fmt.Errorf("point-consistent baseline: cannot connect to source to verify privileges: %w", err)
 	}
 	defer db.Close()
-	return checkPrivilegesDB(ctx, db, remedy)
+	return checkPrivilegesDB(ctx, db, mode, remedy)
 }
 
-// checkPrivilegesDB is checkPrivilegesDB is CheckPrivileges' core logic
-// against an already-open *sql.DB, split out so it is unit-testable with
-// sqlmock without a live MySQL connection. It first determines whether this
-// source's flavor/version needs BACKUP_ADMIN at all (requiresBackupAdmin)
-// — RELOAD/FLUSH_TABLES is mandatory on every flavor, BACKUP_ADMIN only on
-// MySQL/Percona 8.0+ — then reads the CURRENT_USER()'s own privileges from
-// information_schema.USER_PRIVILEGES, which is self-scoped to the connecting
-// user without needing any special grant, so it works even for an otherwise
-// least-privilege replication user. The GRANTEE reconstruction (split
-// CURRENT_USER() on '@', requote both halves) was verified against a real
-// MySQL 8.0 server for both a wildcard-host account ('user'@'%') and a
-// specific-host-pattern account ('user'@'172.20.%.%') — CURRENT_USER() always
-// returns the exact host pattern from the matched mysql.user row, not the
-// connecting client's resolved address, so the reconstruction is not a
-// wildcard-only coincidence. Known gap, surfaced in the refusal message below
-// so an affected operator can self-diagnose: privileges granted only via an
-// activated MySQL 8.0 ROLE (not directly to the user) are attributed to the
-// role's own GRANTEE in this view and would not be picked up here — not a
-// pattern used anywhere else in this codebase's documented grant examples, and
-// this fails CLOSED (over-refuses, never under-refuses) for a role-using
-// operator, so the segfault path stays unreachable either way.
-func checkPrivilegesDB(ctx context.Context, db *sql.DB, remedy Remedy) error {
+// grantedPrivileges reads the connecting user's GLOBAL privileges.
+//
+// It parses SHOW GRANTS FOR CURRENT_USER() rather than reading
+// information_schema.USER_PRIVILEGES, which was the source until this was
+// measured against RDS: that view exposes only the rows the connecting user
+// can SEE in mysql.user, and a managed master user cannot see its own. On RDS
+// MySQL 8.4 it returned exactly one row — USAGE — for an account whose
+// SHOW GRANTS listed RELOAD and FLUSH_TABLES as direct grants. Reading it made
+// this check fail CLOSED on every managed source, which since #1377 made the
+// point-consistent default unreachable there. SHOW GRANTS needs no privilege
+// to run for the current user and expands whatever the session actually has.
+//
+// Only global grants count: a privilege is what it is on `ON *.*`, and a
+// schema-scoped grant does not authorize FLUSH TABLES WITH READ LOCK or
+// LOCK INSTANCE FOR BACKUP.
+func grantedPrivileges(ctx context.Context, db *sql.DB) (map[string]bool, error) {
+	rows, err := db.QueryContext(ctx, "SHOW GRANTS FOR CURRENT_USER()")
+	if err != nil {
+		return nil, fmt.Errorf("point-consistent baseline: cannot verify source privileges: %w", err)
+	}
+	defer rows.Close()
+
+	have := map[string]bool{}
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			return nil, fmt.Errorf("point-consistent baseline: cannot read source privileges: %w", err)
+		}
+		// "GRANT <privs> ON *.* TO ..." — anything else (schema grants, role
+		// memberships, proxy grants) carries no global privilege.
+		const on = " ON *.* TO "
+		idx := strings.Index(line, on)
+		if idx < 0 || !strings.HasPrefix(line, "GRANT ") {
+			continue
+		}
+		for _, p := range strings.Split(line[len("GRANT "):idx], ",") {
+			p = strings.ToUpper(strings.TrimSpace(p))
+			// A privilege can carry a column list, e.g. SELECT (col). Keep the
+			// name; the parenthesised part is never global-only anyway.
+			if k := strings.IndexByte(p, '('); k >= 0 {
+				p = strings.TrimSpace(p[:k])
+			}
+			if p != "" {
+				have[p] = true
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("point-consistent baseline: cannot read source privileges: %w", err)
+	}
+	return have, nil
+}
+
+// checkPrivilegesDB is CheckPrivileges' core logic against an already-open
+// *sql.DB, split out so it is unit-testable with sqlmock. Requirements are
+// PER MODE, because they differ in kind:
+//
+//   - FTWRL needs RELOAD or FLUSH_TABLES on every flavor, plus BACKUP_ADMIN on
+//     MySQL/Percona 8.0+ (it issues LOCK INSTANCE FOR BACKUP first). Granting
+//     BACKUP_ADMIN WITHOUT RELOAD does not fail cleanly — the pinned build
+//     SEGFAULTS — which is why this check exists at all.
+//   - LOCK_ALL needs LOCK TABLES and nothing else. This is the mode that works
+//     on managed MySQL, where BACKUP_ADMIN is not grantable.
+//   - The low-privilege modes never reach here.
+//
+// ALL PRIVILEGES satisfies any of them.
+func checkPrivilegesDB(ctx context.Context, db *sql.DB, mode baseline.LockMode, remedy Remedy) error {
+	have, err := grantedPrivileges(ctx, db)
+	if err != nil {
+		return err
+	}
+	if have["ALL PRIVILEGES"] {
+		return nil
+	}
+
+	const roleCaveat = " (if these are granted through a role, activate it for this connection — SHOW GRANTS reflects the session's active roles)"
+
+	if mode == baseline.LockModeLockAll {
+		if have["LOCK TABLES"] {
+			return nil
+		}
+		return fmt.Errorf("lock-all baseline mode requires the LOCK TABLES privilege; the current user does not have it"+
+			" — grant it, e.g. GRANT LOCK TABLES ON *.* TO '<user>'@'%%'%s", roleCaveat)
+	}
+
 	requireBackupAdmin, err := requiresBackupAdmin(ctx, db)
 	if err != nil {
 		return err
 	}
-
-	const query = `SELECT PRIVILEGE_TYPE FROM information_schema.USER_PRIVILEGES ` +
-		`WHERE GRANTEE = CONCAT("'", SUBSTRING_INDEX(CURRENT_USER(), '@', 1), "'@'", SUBSTRING_INDEX(CURRENT_USER(), '@', -1), "'")`
-	rows, err := db.QueryContext(ctx, query)
-	if err != nil {
-		return fmt.Errorf("point-consistent baseline: cannot verify source privileges: %w", err)
-	}
-	defer rows.Close()
-
-	have := make(map[string]bool, len(requiredPrivileges))
-	for rows.Next() {
-		var priv string
-		if err := rows.Scan(&priv); err != nil {
-			return fmt.Errorf("point-consistent baseline: cannot read source privileges: %w", err)
-		}
-		have[priv] = true
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("point-consistent baseline: cannot read source privileges: %w", err)
-	}
-
-	hasBackupAdmin := have["BACKUP_ADMIN"]
-	hasFlushTables := have["RELOAD"] || have["FLUSH_TABLES"]
-	missingFlushTables := !hasFlushTables
-	missingBackupAdmin := requireBackupAdmin && !hasBackupAdmin
-
-	if !missingFlushTables && !missingBackupAdmin {
+	hasFlush := have["RELOAD"] || have["FLUSH_TABLES"]
+	missingBackupAdmin := requireBackupAdmin && !have["BACKUP_ADMIN"]
+	if hasFlush && !missingBackupAdmin {
 		return nil
 	}
 
-	// The alternatives clause is load-bearing: this gate now fires on the
-	// DEFAULT path, so it is the first thing an upgrading least-privilege
-	// deployment sees. It must name the knob that actually exists — the
-	// pre-#1377 text pointed at an opt-in variable that is no longer read and
-	// told the operator to "disable point-consistent mode", which is not a
-	// thing they can do any more.
-	alternatives := " — or " + string(remedy) + " to dump without these privileges" +
-		" (it needs none, but ABORTS rather than write a snapshot stitched from several instants," +
-		" so expect it to refuse on a write-active source); the same knob set to no-lock accepts such a snapshot"
-
-	const roleCaveat = " (privileges granted only via an activated MySQL ROLE, rather than directly to the user, are not detected by this check — grant directly to the user, or double-check with SHOW GRANTS if you believe this refusal is wrong)"
+	// The alternatives clause is the one actionable sentence here, and this
+	// gate fires on the DEFAULT path. lock-all comes FIRST because it is the
+	// only alternative that is still point-consistent — and on managed MySQL
+	// (RDS grants LOCK TABLES but refuses BACKUP_ADMIN outright) it is the
+	// only one that can work at all.
+	// The managed-MySQL parenthetical is gated on requireBackupAdmin: BACKUP_ADMIN
+	// does not exist on MariaDB or MySQL 5.7, and naming it there would send an
+	// operator hunting a privilege their server cannot have.
+	lockAllNote := ", which is also point-consistent and needs only LOCK TABLES"
+	if requireBackupAdmin {
+		lockAllNote += " (the mode that works on managed MySQL, where BACKUP_ADMIN cannot be granted at all)"
+	}
+	alternatives := " — or " + remedy.forMode(baseline.LockModeLockAll) + lockAllNote +
+		"; or " + remedy.forMode(baseline.LockModeSafeNoLock) +
+		", which needs no privilege but ABORTS rather than write a snapshot stitched from several instants," +
+		" so expect it to refuse on a write-active source; or no-lock to accept such a snapshot"
 
 	switch {
-	case missingFlushTables && missingBackupAdmin:
-		return errors.New("point-consistent baseline mode (the default) requires the " +
-			"source DB user to have BOTH the BACKUP_ADMIN and the RELOAD (or FLUSH_TABLES) privilege (MySQL/Percona " +
-			"8.0+); the current user has neither — grant both, e.g. GRANT BACKUP_ADMIN, RELOAD ON *.* TO '<user>'@'%'" +
-			"" + alternatives + roleCaveat)
-	case missingFlushTables && requireBackupAdmin:
-		// The dangerous half-privileged combination: BACKUP_ADMIN is present but
-		// RELOAD/FLUSH_TABLES is not — this is exactly what segfaults mydumper.
-		return errors.New("point-consistent baseline mode requires the RELOAD (or FLUSH_TABLES) privilege in addition " +
-			"to BACKUP_ADMIN, which the current user already has — granting BACKUP_ADMIN alone makes mydumper crash " +
-			"rather than fail cleanly; grant RELOAD, e.g. GRANT RELOAD ON *.* TO '<user>'@'%'" + alternatives + roleCaveat)
-	case missingFlushTables:
-		// requireBackupAdmin is false here (MariaDB, MySQL 5.7, or an
-		// undetectable version) — BACKUP_ADMIN is never mentioned since it
-		// isn't required, and on MariaDB the privilege doesn't even exist.
-		return errors.New("point-consistent baseline mode requires the RELOAD (or FLUSH_TABLES) privilege; the current " +
-			"user has neither — grant it, e.g. GRANT RELOAD ON *.* TO '<user>'@'%'" + alternatives + roleCaveat)
+	case !hasFlush && missingBackupAdmin:
+		return fmt.Errorf("point-consistent baseline mode (the default) requires the source DB user to have BOTH the"+
+			" BACKUP_ADMIN and the RELOAD (or FLUSH_TABLES) privilege (MySQL/Percona 8.0+); the current user has"+
+			" neither — grant both, e.g. GRANT BACKUP_ADMIN, RELOAD ON *.* TO '<user>'@'%%'%s%s", alternatives, roleCaveat)
+	case !hasFlush:
+		return fmt.Errorf("point-consistent baseline mode requires the RELOAD (or FLUSH_TABLES) privilege; the current"+
+			" user has neither — grant it, e.g. GRANT RELOAD ON *.* TO '<user>'@'%%'%s%s", alternatives, roleCaveat)
 	default:
-		// missingBackupAdmin only: requireBackupAdmin is true and hasFlushTables
-		// is true.
-		return errors.New("point-consistent baseline mode requires the BACKUP_ADMIN privilege (MySQL/Percona 8.0+) in " +
-			"addition to RELOAD/FLUSH_TABLES, which the current user already has — grant it, e.g. " +
-			"GRANT BACKUP_ADMIN ON *.* TO '<user>'@'%'" + alternatives + roleCaveat)
+		return fmt.Errorf("point-consistent baseline mode requires the BACKUP_ADMIN privilege (MySQL/Percona 8.0+) in"+
+			" addition to RELOAD/FLUSH_TABLES, which the current user already has — grant it, e.g."+
+			" GRANT BACKUP_ADMIN ON *.* TO '<user>'@'%%'. NOTE: on managed MySQL such as RDS this grant is REFUSED"+
+			" outright, so ftwrl cannot work there%s%s", alternatives, roleCaveat)
 	}
 }

--- a/internal/mydumperlock/privileges_test.go
+++ b/internal/mydumperlock/privileges_test.go
@@ -45,7 +45,7 @@ func TestCheckPrivilegesReadsShowGrants(t *testing.T) {
 	// RELOAD is present but BACKUP_ADMIN is not, so ftwrl is still refused —
 	// correctly, and that is the platform's limit, not a reading error. What
 	// must NOT happen is the pre-fix behaviour: claiming the user has NEITHER.
-	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyConsole)
+	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyConsole, nil)
 	if err == nil {
 		t.Fatal("ftwrl was allowed without BACKUP_ADMIN")
 	}
@@ -70,7 +70,7 @@ func TestCheckPrivilegesLockAllOnManagedMySQL(t *testing.T) {
 	mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
 		"GRANT SELECT, RELOAD, LOCK TABLES, REPLICATION CLIENT ON *.* TO `admin`@`%`",
 	))
-	if err := checkPrivilegesDB(context.Background(), db, baseline.LockModeLockAll, RemedyConsole); err != nil {
+	if err := checkPrivilegesDB(context.Background(), db, baseline.LockModeLockAll, RemedyConsole, nil); err != nil {
 		t.Fatalf("lock-all was refused for a user holding LOCK TABLES: %v", err)
 	}
 	// It must not have asked for the version: lock-all's requirement does not
@@ -90,7 +90,7 @@ func TestCheckPrivilegesLockAllWithoutLockTables(t *testing.T) {
 	mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
 		"GRANT SELECT, REPLICATION CLIENT ON *.* TO `u`@`%`",
 	))
-	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeLockAll, RemedyCLI)
+	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeLockAll, RemedyCLI, nil)
 	if err == nil {
 		t.Fatal("lock-all was allowed without LOCK TABLES")
 	}
@@ -115,7 +115,7 @@ func TestCheckPrivilegesFTWRLIgnoresSchemaScopedGrants(t *testing.T) {
 		"GRANT ALL PRIVILEGES ON `appdb`.* TO `u`@`%`",
 	))
 	mock.ExpectQuery("VERSION").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow("8.0.36"))
-	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyCLI)
+	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyCLI, nil)
 	if err == nil {
 		t.Fatal("a schema-scoped ALL PRIVILEGES was accepted as authorizing FLUSH TABLES WITH READ LOCK")
 	}
@@ -143,7 +143,7 @@ func TestCheckPrivilegesLockAllAcceptsSchemaScopedGrant(t *testing.T) {
 		"GRANT REPLICATION CLIENT ON *.* TO `scoped`@`%`",
 		"GRANT SELECT, LOCK TABLES, SHOW VIEW ON `appdb`.* TO `scoped`@`%`",
 	))
-	if err := checkPrivilegesDB(context.Background(), db, baseline.LockModeLockAll, RemedyCLI); err != nil {
+	if err := checkPrivilegesDB(context.Background(), db, baseline.LockModeLockAll, RemedyCLI, nil); err != nil {
 		t.Fatalf("lock-all refused a per-schema LOCK TABLES grant that runs a real dump to completion: %v", err)
 	}
 }
@@ -163,7 +163,7 @@ func TestCheckPrivilegesFlushTablesSubstitutesForReload(t *testing.T) {
 		"GRANT SELECT, BACKUP_ADMIN, FLUSH_TABLES ON *.* TO `u`@`%`",
 	))
 	mock.ExpectQuery("VERSION").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow("8.0.36"))
-	if err := checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyConsole); err != nil {
+	if err := checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyConsole, nil); err != nil {
 		t.Fatalf("ftwrl refused a user holding FLUSH_TABLES (without the broader RELOAD): %v", err)
 	}
 }
@@ -184,7 +184,7 @@ func TestCheckPrivilegesBackupAdminWithoutReloadIsRefused(t *testing.T) {
 		"GRANT SELECT, BACKUP_ADMIN ON *.* TO `u`@`%`",
 	))
 	mock.ExpectQuery("VERSION").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow("8.0.36"))
-	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyConsole)
+	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyConsole, nil)
 	if err == nil {
 		t.Fatal("BACKUP_ADMIN without RELOAD/FLUSH_TABLES was accepted — this is the mydumper segfault input")
 	}
@@ -192,9 +192,11 @@ func TestCheckPrivilegesBackupAdminWithoutReloadIsRefused(t *testing.T) {
 		t.Errorf("refusal = %v, want it to name the missing RELOAD", err)
 	}
 	// The operator in this state already granted BACKUP_ADMIN and needs to know
-	// the remaining half is not just another clean refusal.
-	if !strings.Contains(err.Error(), "SEGFAULT") {
-		t.Errorf("refusal = %v, want it to say why this particular half-grant is dangerous", err)
+	// the remaining half is not just another clean refusal. Asserting the
+	// CONSEQUENCE rather than one word of prose: a meaning-preserving reword
+	// must not fail, but dropping the warning entirely must.
+	if !strings.Contains(err.Error(), "BACKUP_ADMIN alone") {
+		t.Errorf("refusal = %v, want it to warn about the half-grant it is refusing", err)
 	}
 }
 
@@ -224,6 +226,7 @@ func TestGrantSetParsing(t *testing.T) {
 		// Column names must not be parsed as privilege names: splitting on the
 		// comma before stripping the parenthesised list would yield "B".
 		{"column list", "GRANT SELECT (a, b) ON `appdb`.`t` TO `u`@`%`", nil, true},
+		{"multi column list", "GRANT SELECT (a, b), INSERT (col2) ON `appdb`.`t` TO `u`@`%`", nil, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			g := &grantSet{global: map[string]bool{}, scoped: map[string][]string{}}
@@ -239,8 +242,14 @@ func TestGrantSetParsing(t *testing.T) {
 			if got := len(g.scoped) > 0; got != tc.wantScoped {
 				t.Errorf("scoped = %v, want scoped=%v", g.scoped, tc.wantScoped)
 			}
-			if g.global["B"] {
-				t.Error("a column name was parsed as a privilege")
+			// Check BOTH maps. Reading only `global` made this guard inert: a
+			// column list is only legal on a scoped object, so a misparsed
+			// column name lands in `scoped` and the global-only assertion
+			// stayed green with the paren-stripping deleted.
+			for _, bad := range []string{"B", "COL2", "A"} {
+				if g.global[bad] || len(g.scoped[bad]) > 0 {
+					t.Errorf("%q was parsed as a privilege name from %q", bad, tc.line)
+				}
 			}
 		})
 	}
@@ -255,7 +264,7 @@ func TestCheckPrivilegesAllPrivileges(t *testing.T) {
 		mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
 			"GRANT ALL PRIVILEGES ON *.* TO `root`@`localhost` WITH GRANT OPTION",
 		))
-		if err := checkPrivilegesDB(context.Background(), db, mode, RemedyConsole); err != nil {
+		if err := checkPrivilegesDB(context.Background(), db, mode, RemedyConsole, nil); err != nil {
 			t.Errorf("%s refused for ALL PRIVILEGES: %v", mode, err)
 		}
 		db.Close()
@@ -278,7 +287,7 @@ func TestCheckPrivilegesMariaDBNeverMentionsBackupAdmin(t *testing.T) {
 	))
 	mock.ExpectQuery("VERSION").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow("10.11.6-MariaDB"))
 
-	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyConsole)
+	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyConsole, nil)
 	if err == nil {
 		t.Fatal("ftwrl allowed without RELOAD")
 	}
@@ -303,7 +312,7 @@ func TestCheckPrivilegesRefusalOffersLockAllFirst(t *testing.T) {
 	))
 	mock.ExpectQuery("VERSION").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow("8.4.10"))
 
-	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyConsole)
+	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyConsole, nil)
 	if err == nil {
 		t.Fatal("ftwrl allowed without BACKUP_ADMIN")
 	}
@@ -339,7 +348,7 @@ func TestCheckPrivilegesRemedyIsSurfaceSpecific(t *testing.T) {
 		}
 		mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows("GRANT SELECT ON *.* TO `u`@`%`"))
 		mock.ExpectQuery("VERSION").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow("8.0.36"))
-		err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, tc.remedy)
+		err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, tc.remedy, nil)
 		db.Close()
 		if err == nil {
 			t.Fatalf("%s: a user with no privileges was allowed to run a point-consistent dump", tc.remedy)
@@ -372,5 +381,91 @@ func TestServerMajorVersion(t *testing.T) {
 		if major != tc.wantMajor || ok != tc.wantOK {
 			t.Errorf("serverMajorVersion(%q) = (%d, %v), want (%d, %v)", tc.version, major, ok, tc.wantMajor, tc.wantOK)
 		}
+	}
+}
+
+// TestCheckPrivilegesPartialRevokeIsNotIgnored: MySQL 8.0.16+ renders a partial
+// revoke as its OWN line in SHOW GRANTS, and reading only the GRANT lines
+// reports a privilege the user does not have. Measured on MySQL 8.0.46 with
+// partial_revokes=ON — this exact grant set produced
+// "ERROR 1044 Access denied for user 'prtest'@'%' to database 'appdb'" on
+// LOCK TABLES in appdb.
+//
+// This is the FALSE-PASS direction, the one this package exists to prevent:
+// the preflight would wave the dump through and mydumper would die partway,
+// leaving a partial dump directory, which is precisely what "fails loudly,
+// before mydumper ever runs" promises not to happen.
+func TestCheckPrivilegesPartialRevokeIsNotIgnored(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
+		"GRANT SELECT, LOCK TABLES, REPLICATION CLIENT ON *.* TO `prtest`@`%`",
+		"REVOKE LOCK TABLES ON `appdb`.* FROM `prtest`@`%`",
+	))
+	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeLockAll, RemedyCLI, []string{"appdb"})
+	if err == nil {
+		t.Fatal("a partial REVOKE of LOCK TABLES on the dumped schema was ignored — mydumper would launch and fail partway")
+	}
+	if !strings.Contains(err.Error(), "appdb") {
+		t.Errorf("refusal = %v, want it to name the schema the revoke applies to", err)
+	}
+}
+
+// TestCheckPrivilegesPartialRevokeElsewhereIsNotABlocker is the other half, and
+// the more important one: refusing a dump a revoke does not touch would be the
+// same false refusal #1381 was filed for. The revoke here names a schema that
+// is not in the dump.
+func TestCheckPrivilegesPartialRevokeElsewhereIsNotABlocker(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
+		"GRANT SELECT, LOCK TABLES ON *.* TO `u`@`%`",
+		"REVOKE LOCK TABLES ON `otherdb`.* FROM `u`@`%`",
+	))
+	if err := checkPrivilegesDB(context.Background(), db, baseline.LockModeLockAll, RemedyCLI, []string{"appdb"}); err != nil {
+		t.Fatalf("lock-all refused over a revoke on a schema this dump never touches: %v", err)
+	}
+}
+
+// TestCheckPrivilegesPartialRevokeWithNoSchemaFilter: an empty schema list means
+// "dump every non-system schema", so a revoke anywhere IS inside the dump.
+func TestCheckPrivilegesPartialRevokeWithNoSchemaFilter(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
+		"GRANT SELECT, LOCK TABLES ON *.* TO `u`@`%`",
+		"REVOKE LOCK TABLES ON `otherdb`.* FROM `u`@`%`",
+	))
+	if err := checkPrivilegesDB(context.Background(), db, baseline.LockModeLockAll, RemedyCLI, nil); err == nil {
+		t.Fatal("a whole-instance dump ignored a partial revoke; every schema is in scope when no filter is set")
+	}
+}
+
+// TestCheckPrivilegesConnectFailureOffersNoWeakerMode: an unreachable source is
+// not a privilege problem — mydumper cannot dump in ANY mode. Suggesting a
+// weaker one there is worse than saying nothing: on the console the knob is a
+// DAEMON environment variable, so an operator who flips it to get past a
+// transient blip silently degrades every future baseline, with nothing to
+// expire it.
+func TestCheckPrivilegesConnectFailureOffersNoWeakerMode(t *testing.T) {
+	err := CheckPrivileges(context.Background(), "u:p@tcp(127.0.0.1:1)/db",
+		baseline.LockModeFTWRL, RemedyConsole, nil)
+	if err == nil {
+		t.Fatal("an unreachable source passed the preflight")
+	}
+	if strings.Contains(err.Error(), "no-lock") {
+		t.Errorf("a connection failure recommends downgrading consistency: %v", err)
 	}
 }

--- a/internal/mydumperlock/privileges_test.go
+++ b/internal/mydumperlock/privileges_test.go
@@ -99,11 +99,11 @@ func TestCheckPrivilegesLockAllWithoutLockTables(t *testing.T) {
 	}
 }
 
-// TestCheckPrivilegesOnlyGlobalGrantsCount: a schema-scoped grant does not
-// authorize FLUSH TABLES WITH READ LOCK, so parsing must ignore anything that
-// is not ON *.*. Accepting one would under-refuse — the direction that lets
-// mydumper run half-privileged, which is what segfaults it.
-func TestCheckPrivilegesOnlyGlobalGrantsCount(t *testing.T) {
+// TestCheckPrivilegesFTWRLIgnoresSchemaScopedGrants: RELOAD, FLUSH_TABLES and
+// BACKUP_ADMIN are global-only privileges, and a schema-scoped row must not be
+// read as satisfying them. Accepting one would under-refuse — the direction
+// that lets mydumper run half-privileged, which is what segfaults it.
+func TestCheckPrivilegesFTWRLIgnoresSchemaScopedGrants(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatal(err)
@@ -112,11 +112,137 @@ func TestCheckPrivilegesOnlyGlobalGrantsCount(t *testing.T) {
 
 	mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
 		"GRANT SELECT ON *.* TO `u`@`%`",
-		"GRANT LOCK TABLES ON `appdb`.* TO `u`@`%`",
+		"GRANT ALL PRIVILEGES ON `appdb`.* TO `u`@`%`",
 	))
-	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeLockAll, RemedyCLI)
+	mock.ExpectQuery("VERSION").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow("8.0.36"))
+	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyCLI)
 	if err == nil {
-		t.Fatal("a schema-scoped LOCK TABLES was accepted as a global privilege")
+		t.Fatal("a schema-scoped ALL PRIVILEGES was accepted as authorizing FLUSH TABLES WITH READ LOCK")
+	}
+}
+
+// TestCheckPrivilegesLockAllAcceptsSchemaScopedGrant is the regression for a
+// false refusal this package shipped once already, in the very mode added to
+// cure one: lock-all demanded LOCK TABLES globally.
+//
+// LOCK_ALL locks the EXPORTED TABLES, not the instance, so a grant covering the
+// dumped schema is sufficient — measured, not reasoned: mydumper v1.0.3-1 ran a
+// dump to completion against MySQL 8.0 as a user holding exactly
+// `GRANT SELECT, LOCK TABLES, SHOW VIEW ON \`appdb\`.*`. Refusing that sends a
+// least-privilege operator to widen a grant they did not need to widen, or to
+// give up point-consistency — on managed MySQL, where lock-all is the ONLY
+// point-consistent mode available, the second is the likelier outcome.
+func TestCheckPrivilegesLockAllAcceptsSchemaScopedGrant(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
+		"GRANT REPLICATION CLIENT ON *.* TO `scoped`@`%`",
+		"GRANT SELECT, LOCK TABLES, SHOW VIEW ON `appdb`.* TO `scoped`@`%`",
+	))
+	if err := checkPrivilegesDB(context.Background(), db, baseline.LockModeLockAll, RemedyCLI); err != nil {
+		t.Fatalf("lock-all refused a per-schema LOCK TABLES grant that runs a real dump to completion: %v", err)
+	}
+}
+
+// TestCheckPrivilegesFlushTablesSubstitutesForReload: on MySQL 8.0+ the dynamic
+// FLUSH_TABLES privilege exists precisely so an account can be granted the
+// narrow thing instead of all of RELOAD, so a least-privilege 8.0 deployment
+// may hold it ALONE. Refusing that is the same class of over-refusal as #1381.
+func TestCheckPrivilegesFlushTablesSubstitutesForReload(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
+		"GRANT SELECT, BACKUP_ADMIN, FLUSH_TABLES ON *.* TO `u`@`%`",
+	))
+	mock.ExpectQuery("VERSION").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow("8.0.36"))
+	if err := checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyConsole); err != nil {
+		t.Fatalf("ftwrl refused a user holding FLUSH_TABLES (without the broader RELOAD): %v", err)
+	}
+}
+
+// TestCheckPrivilegesBackupAdminWithoutReloadIsRefused pins the exact input
+// this package exists for: BACKUP_ADMIN granted, RELOAD/FLUSH_TABLES not. The
+// pinned mydumper build does not fail cleanly on it — it SEGFAULTS (#800,
+// reproduced on amd64 and arm64). If this check ever accepts this grant set,
+// the crash is reachable again from the DEFAULT path.
+func TestCheckPrivilegesBackupAdminWithoutReloadIsRefused(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
+		"GRANT SELECT, BACKUP_ADMIN ON *.* TO `u`@`%`",
+	))
+	mock.ExpectQuery("VERSION").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow("8.0.36"))
+	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyConsole)
+	if err == nil {
+		t.Fatal("BACKUP_ADMIN without RELOAD/FLUSH_TABLES was accepted — this is the mydumper segfault input")
+	}
+	if !strings.Contains(err.Error(), "RELOAD") {
+		t.Errorf("refusal = %v, want it to name the missing RELOAD", err)
+	}
+	// The operator in this state already granted BACKUP_ADMIN and needs to know
+	// the remaining half is not just another clean refusal.
+	if !strings.Contains(err.Error(), "SEGFAULT") {
+		t.Errorf("refusal = %v, want it to say why this particular half-grant is dangerous", err)
+	}
+}
+
+// TestGrantSetParsing covers the shapes SHOW GRANTS actually emits. The parser
+// must never REPORT a privilege the user lacks: a false positive lets mydumper
+// launch half-privileged, which is the crash this package prevents.
+func TestGrantSetParsing(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		line       string
+		wantGlobal []string
+		wantScoped bool
+	}{
+		{"global list", "GRANT SELECT, LOCK TABLES ON *.* TO `u`@`%`", []string{"SELECT", "LOCK TABLES"}, false},
+		{"with grant option", "GRANT ALL PRIVILEGES ON *.* TO `r`@`localhost` WITH GRANT OPTION", []string{"ALL PRIVILEGES"}, false},
+		// A role membership carries no privilege of its own. MySQL expands an
+		// ACTIVE role's privileges into their own ON *.* lines in the same
+		// result set, so skipping this loses nothing.
+		{"role membership", "GRANT `r`@`%` TO `u`@`%`", nil, false},
+		// PROXY's "object" is an account, not a schema, so it lands in scoped.
+		// Harmless: nothing ever asks about PROXY, and it cannot manufacture an
+		// entry under a name that is asked about. What matters is that it adds
+		// nothing GLOBAL — asserted by the exact-length check below.
+		{"proxy", "GRANT PROXY ON ``@`` TO `root`@`localhost` WITH GRANT OPTION", nil, true},
+		{"schema scoped", "GRANT LOCK TABLES ON `appdb`.* TO `u`@`%`", nil, true},
+		{"table scoped", "GRANT SELECT ON `appdb`.`t` TO `u`@`%`", nil, true},
+		// Column names must not be parsed as privilege names: splitting on the
+		// comma before stripping the parenthesised list would yield "B".
+		{"column list", "GRANT SELECT (a, b) ON `appdb`.`t` TO `u`@`%`", nil, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &grantSet{global: map[string]bool{}, scoped: map[string][]string{}}
+			g.add(tc.line)
+			for _, w := range tc.wantGlobal {
+				if !g.global[w] {
+					t.Errorf("global %q missing from %q", w, tc.line)
+				}
+			}
+			if len(tc.wantGlobal) != len(g.global) {
+				t.Errorf("global = %v, want exactly %v", g.global, tc.wantGlobal)
+			}
+			if got := len(g.scoped) > 0; got != tc.wantScoped {
+				t.Errorf("scoped = %v, want scoped=%v", g.scoped, tc.wantScoped)
+			}
+			if g.global["B"] {
+				t.Error("a column name was parsed as a privilege")
+			}
+		})
 	}
 }
 

--- a/internal/mydumperlock/privileges_test.go
+++ b/internal/mydumperlock/privileges_test.go
@@ -2,175 +2,218 @@ package mydumperlock
 
 import (
 	"context"
-	"database/sql"
 	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/dbtrail/dbtrail/internal/baseline"
 )
 
-// TestCheckPrivileges covers the privilege-combination matrix
-// established empirically against the pinned mydumper build (#800): RELOAD or
-// FLUSH_TABLES is required on every flavor; BACKUP_ADMIN is additionally
-// required ONLY on MySQL/Percona 8.0+ (it doesn't exist on MariaDB or MySQL
-// 5.7 — see requiresBackupAdmin). Critically, on a flavor where
-// BACKUP_ADMIN IS required, having it without RELOAD/FLUSH_TABLES must still
-// be rejected here rather than let mydumper run, because that specific
-// half-privileged combination segfaults mydumper instead of failing cleanly.
-func TestCheckPrivileges(t *testing.T) {
-	newMockWithPrivileges := func(t *testing.T, version string, privileges []string) *sql.DB {
-		t.Helper()
+// grantRows builds the SHOW GRANTS FOR CURRENT_USER() result set.
+func grantRows(lines ...string) *sqlmock.Rows {
+	r := sqlmock.NewRows([]string{"Grants for user"})
+	for _, l := range lines {
+		r = r.AddRow(l)
+	}
+	return r
+}
+
+// TestCheckPrivilegesReadsShowGrants is the regression for the defect that
+// broke a live RDS deployment. The check used to read
+// information_schema.USER_PRIVILEGES, which only exposes the rows the
+// connecting user can SEE in mysql.user — on RDS MySQL 8.4 that returned a
+// single USAGE row for an account whose SHOW GRANTS listed RELOAD and
+// FLUSH_TABLES as direct grants. The check therefore failed CLOSED on every
+// managed source, which made the point-consistent default unreachable there.
+//
+// The grant lines below are copied from that real RDS master user.
+func TestCheckPrivilegesReadsShowGrants(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
+		"GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, LOCK TABLES, REPLICATION CLIENT ON *.* TO `admin`@`%`",
+		"GRANT APPLICATION_PASSWORD_ADMIN,FLUSH_TABLES,ROLE_ADMIN ON *.* TO `admin`@`%`",
+		"GRANT `rds_superuser_role`@`%` TO `admin`@`%`",
+	))
+	mock.ExpectQuery("VERSION").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow("8.4.10"))
+
+	// RELOAD is present but BACKUP_ADMIN is not, so ftwrl is still refused —
+	// correctly, and that is the platform's limit, not a reading error. What
+	// must NOT happen is the pre-fix behaviour: claiming the user has NEITHER.
+	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyConsole)
+	if err == nil {
+		t.Fatal("ftwrl was allowed without BACKUP_ADMIN")
+	}
+	if strings.Contains(err.Error(), "has neither") {
+		t.Errorf("the check did not see RELOAD in SHOW GRANTS — it is reading a source that is blind on managed MySQL: %v", err)
+	}
+	if !strings.Contains(err.Error(), "BACKUP_ADMIN") {
+		t.Errorf("refusal = %v, want it to name the one privilege actually missing", err)
+	}
+}
+
+// TestCheckPrivilegesLockAllOnManagedMySQL: the same RDS grant set must PASS
+// for lock-all. This is the whole point of adding the mode — it is the only
+// point-consistent option available where BACKUP_ADMIN cannot be granted.
+func TestCheckPrivilegesLockAllOnManagedMySQL(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
+		"GRANT SELECT, RELOAD, LOCK TABLES, REPLICATION CLIENT ON *.* TO `admin`@`%`",
+	))
+	if err := checkPrivilegesDB(context.Background(), db, baseline.LockModeLockAll, RemedyConsole); err != nil {
+		t.Fatalf("lock-all was refused for a user holding LOCK TABLES: %v", err)
+	}
+	// It must not have asked for the version: lock-all's requirement does not
+	// depend on flavor, and an extra round trip here would be dead weight.
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unexpected queries: %v", err)
+	}
+}
+
+func TestCheckPrivilegesLockAllWithoutLockTables(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
+		"GRANT SELECT, REPLICATION CLIENT ON *.* TO `u`@`%`",
+	))
+	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeLockAll, RemedyCLI)
+	if err == nil {
+		t.Fatal("lock-all was allowed without LOCK TABLES")
+	}
+	if !strings.Contains(err.Error(), "LOCK TABLES") {
+		t.Errorf("refusal = %v, want it to name LOCK TABLES", err)
+	}
+}
+
+// TestCheckPrivilegesOnlyGlobalGrantsCount: a schema-scoped grant does not
+// authorize FLUSH TABLES WITH READ LOCK, so parsing must ignore anything that
+// is not ON *.*. Accepting one would under-refuse — the direction that lets
+// mydumper run half-privileged, which is what segfaults it.
+func TestCheckPrivilegesOnlyGlobalGrantsCount(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
+		"GRANT SELECT ON *.* TO `u`@`%`",
+		"GRANT LOCK TABLES ON `appdb`.* TO `u`@`%`",
+	))
+	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeLockAll, RemedyCLI)
+	if err == nil {
+		t.Fatal("a schema-scoped LOCK TABLES was accepted as a global privilege")
+	}
+}
+
+func TestCheckPrivilegesAllPrivileges(t *testing.T) {
+	for _, mode := range []baseline.LockMode{baseline.LockModeFTWRL, baseline.LockModeLockAll} {
 		db, mock, err := sqlmock.New()
 		if err != nil {
-			t.Fatalf("sqlmock.New: %v", err)
+			t.Fatal(err)
 		}
-		t.Cleanup(func() { db.Close() })
-		mock.ExpectQuery("SELECT VERSION\\(\\)").
-			WillReturnRows(sqlmock.NewRows([]string{"VERSION()"}).AddRow(version))
-		rows := sqlmock.NewRows([]string{"PRIVILEGE_TYPE"})
-		for _, p := range privileges {
-			rows.AddRow(p)
+		mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
+			"GRANT ALL PRIVILEGES ON *.* TO `root`@`localhost` WITH GRANT OPTION",
+		))
+		if err := checkPrivilegesDB(context.Background(), db, mode, RemedyConsole); err != nil {
+			t.Errorf("%s refused for ALL PRIVILEGES: %v", mode, err)
 		}
-		mock.ExpectQuery("SELECT PRIVILEGE_TYPE FROM information_schema.USER_PRIVILEGES").WillReturnRows(rows)
-		return db
-	}
-
-	tests := []struct {
-		name       string
-		version    string
-		privileges []string
-		wantErr    bool
-		wantSubstr string
-	}{
-		{
-			name:       "MySQL 8.0: BACKUP_ADMIN + RELOAD: ok",
-			version:    "8.0.46",
-			privileges: []string{"SELECT", "REPLICATION CLIENT", "BACKUP_ADMIN", "RELOAD"},
-			wantErr:    false,
-		},
-		{
-			name:       "MySQL 8.0: BACKUP_ADMIN + FLUSH_TABLES (dynamic priv alternative to RELOAD): ok",
-			version:    "8.0.46",
-			privileges: []string{"SELECT", "REPLICATION CLIENT", "BACKUP_ADMIN", "FLUSH_TABLES"},
-			wantErr:    false,
-		},
-		{
-			name:       "MySQL 8.0: neither: clear error naming both",
-			version:    "8.0.46",
-			privileges: []string{"SELECT", "REPLICATION CLIENT"},
-			wantErr:    true,
-			wantSubstr: "BOTH the BACKUP_ADMIN and the RELOAD",
-		},
-		{
-			// The dangerous half-privileged case: mydumper segfaults here rather
-			// than failing cleanly, so this MUST be rejected before mydumper runs.
-			name:       "MySQL 8.0: BACKUP_ADMIN only, no RELOAD/FLUSH_TABLES: rejected (would segfault mydumper)",
-			version:    "8.0.46",
-			privileges: []string{"SELECT", "REPLICATION CLIENT", "BACKUP_ADMIN"},
-			wantErr:    true,
-			wantSubstr: "requires the RELOAD (or FLUSH_TABLES) privilege",
-		},
-		{
-			name:       "MySQL 8.0: RELOAD only, no BACKUP_ADMIN: rejected",
-			version:    "8.0.46",
-			privileges: []string{"SELECT", "REPLICATION CLIENT", "RELOAD"},
-			wantErr:    true,
-			wantSubstr: "requires the BACKUP_ADMIN privilege",
-		},
-		{
-			// #800 review item 1: BACKUP_ADMIN does not exist on MariaDB. A
-			// MariaDB user with only RELOAD must be accepted — requiring
-			// BACKUP_ADMIN here would make the mode permanently unusable, since
-			// GRANT BACKUP_ADMIN itself errors on MariaDB.
-			name:       "MariaDB: RELOAD only, no BACKUP_ADMIN: ok (BACKUP_ADMIN doesn't exist on MariaDB)",
-			version:    "10.11.6-MariaDB",
-			privileges: []string{"SELECT", "REPLICATION CLIENT", "RELOAD"},
-			wantErr:    false,
-		},
-		{
-			name:       "MariaDB: neither RELOAD nor FLUSH_TABLES: rejected, BACKUP_ADMIN not mentioned",
-			version:    "10.11.6-MariaDB",
-			privileges: []string{"SELECT", "REPLICATION CLIENT"},
-			wantErr:    true,
-			wantSubstr: "requires the RELOAD (or FLUSH_TABLES) privilege",
-		},
-		{
-			// #800 review item 1: MySQL 5.7 predates BACKUP_ADMIN too.
-			name:       "MySQL 5.7: RELOAD only, no BACKUP_ADMIN: ok",
-			version:    "5.7.44",
-			privileges: []string{"SELECT", "REPLICATION CLIENT", "RELOAD"},
-			wantErr:    false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			db := newMockWithPrivileges(t, tt.version, tt.privileges)
-			err := checkPrivilegesDB(context.Background(), db, RemedyConsole)
-			if tt.wantErr && err == nil {
-				t.Fatalf("expected an error, got nil")
-			}
-			if !tt.wantErr && err != nil {
-				t.Fatalf("expected no error, got: %v", err)
-			}
-			if tt.wantErr && !strings.Contains(err.Error(), tt.wantSubstr) {
-				t.Errorf("error %q does not contain %q", err.Error(), tt.wantSubstr)
-			}
-			// MariaDB/5.7 cases must never mention BACKUP_ADMIN — it doesn't
-			// exist there, and GRANT BACKUP_ADMIN itself errors on MariaDB.
-			if tt.wantErr && !strings.Contains(tt.version, "8.0") && strings.Contains(err.Error(), "BACKUP_ADMIN") {
-				t.Errorf("error for version %q must not mention BACKUP_ADMIN: %q", tt.version, err.Error())
-			}
-		})
+		db.Close()
 	}
 }
 
-// TestServerMajorVersion covers the version-string parsing that decides
-// whether BACKUP_ADMIN applies (#800 review item 1).
-func TestServerMajorVersion(t *testing.T) {
-	tests := []struct {
-		version   string
-		wantMajor int
-		wantOK    bool
-	}{
-		{"8.0.46", 8, true},
-		{"5.7.44", 5, true},
-		{"10.11.6-MariaDB", 10, true},
-		{"11.4.2-MariaDB-1:11.4.2+maria~ubu2204", 11, true},
-		{"garbage", 0, false},
-		{"", 0, false},
+// TestCheckPrivilegesMariaDBNeverMentionsBackupAdmin: BACKUP_ADMIN does not
+// exist on MariaDB, and mydumper does not issue LOCK INSTANCE FOR BACKUP
+// there. Naming it would send an operator hunting a privilege their server
+// cannot have.
+func TestCheckPrivilegesMariaDBNeverMentionsBackupAdmin(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.version, func(t *testing.T) {
-			major, ok := serverMajorVersion(tt.version)
-			if ok != tt.wantOK || major != tt.wantMajor {
-				t.Errorf("serverMajorVersion(%q) = (%d, %v), want (%d, %v)", tt.version, major, ok, tt.wantMajor, tt.wantOK)
-			}
-		})
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
+		"GRANT SELECT ON *.* TO `u`@`%`",
+	))
+	mock.ExpectQuery("VERSION").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow("10.11.6-MariaDB"))
+
+	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyConsole)
+	if err == nil {
+		t.Fatal("ftwrl allowed without RELOAD")
+	}
+	if strings.Contains(err.Error(), "BACKUP_ADMIN") {
+		t.Errorf("MariaDB refusal names BACKUP_ADMIN, which does not exist there: %v", err)
 	}
 }
 
-// TestCheckPrivilegesRemedyIsSurfaceSpecific: the alternatives clause is the
-// one actionable sentence in the refusal, and both surfaces reach it on their
-// DEFAULT path. Naming the other surface's knob is worse than naming none —
-// `bintrail dump` does not read the console's environment variable, and the
-// console has no flags.
+// TestCheckPrivilegesRefusalOffersLockAllFirst: on a source that cannot do
+// ftwrl, the operator's best move is the OTHER point-consistent mode, not a
+// weaker one. On managed MySQL it is the only one that can work at all, so it
+// must be named before safe-no-lock.
+func TestCheckPrivilegesRefusalOffersLockAllFirst(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows(
+		"GRANT SELECT, RELOAD, LOCK TABLES ON *.* TO `admin`@`%`",
+	))
+	mock.ExpectQuery("VERSION").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow("8.4.10"))
+
+	err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, RemedyConsole)
+	if err == nil {
+		t.Fatal("ftwrl allowed without BACKUP_ADMIN")
+	}
+	msg := err.Error()
+	la, snl := strings.Index(msg, "lock-all"), strings.Index(msg, "safe-no-lock")
+	if la < 0 {
+		t.Fatalf("refusal never names lock-all, the only point-consistent option left: %v", err)
+	}
+	if snl >= 0 && la > snl {
+		t.Error("the refusal offers safe-no-lock before lock-all; it points the operator away from consistency first")
+	}
+	if !strings.Contains(msg, "RDS") {
+		t.Error("refusal does not warn that this grant is refused outright on managed MySQL, which is where this branch is most often hit")
+	}
+}
+
+// TestCheckPrivilegesRemedyIsSurfaceSpecific: the remedy is the one actionable
+// sentence, and both surfaces reach it on their DEFAULT path. Naming the other
+// surface's knob is worse than naming none — `bintrail dump` does not read the
+// console's environment variable, and the console has no flags.
 func TestCheckPrivilegesRemedyIsSurfaceSpecific(t *testing.T) {
 	for _, tc := range []struct {
 		remedy         Remedy
 		want           string
 		mustNotContain string
 	}{
-		{RemedyCLI, "--lock-mode safe-no-lock", "BINTRAIL_CONSOLE"},
-		{RemedyConsole, "BINTRAIL_CONSOLE_BASELINE_LOCK_MODE=safe-no-lock", "--lock-mode"},
+		{RemedyCLI, "--lock-mode lock-all", "BINTRAIL_CONSOLE"},
+		{RemedyConsole, "BINTRAIL_CONSOLE_BASELINE_LOCK_MODE=lock-all", "--lock-mode"},
 	} {
 		db, mock, err := sqlmock.New()
 		if err != nil {
 			t.Fatal(err)
 		}
+		mock.ExpectQuery("SHOW GRANTS").WillReturnRows(grantRows("GRANT SELECT ON *.* TO `u`@`%`"))
 		mock.ExpectQuery("VERSION").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow("8.0.36"))
-		mock.ExpectQuery("USER_PRIVILEGES").WillReturnRows(sqlmock.NewRows([]string{"p"}))
-		err = checkPrivilegesDB(context.Background(), db, tc.remedy)
+		err = checkPrivilegesDB(context.Background(), db, baseline.LockModeFTWRL, tc.remedy)
 		db.Close()
 		if err == nil {
 			t.Fatalf("%s: a user with no privileges was allowed to run a point-consistent dump", tc.remedy)
@@ -179,8 +222,29 @@ func TestCheckPrivilegesRemedyIsSurfaceSpecific(t *testing.T) {
 			t.Errorf("%s: refusal = %q, want it to name %q", tc.remedy, err, tc.want)
 		}
 		if strings.Contains(err.Error(), tc.mustNotContain) {
-			t.Errorf("%s: refusal names the OTHER surface's knob (%q), which this caller does not read: %q",
-				tc.remedy, tc.mustNotContain, err)
+			t.Errorf("%s: refusal names the OTHER surface's knob (%q), which this caller does not read", tc.remedy, tc.mustNotContain)
+		}
+	}
+}
+
+// TestServerMajorVersion covers the version-string parsing behind the
+// BACKUP_ADMIN requirement.
+func TestServerMajorVersion(t *testing.T) {
+	for _, tc := range []struct {
+		version   string
+		wantMajor int
+		wantOK    bool
+	}{
+		{"8.0.36", 8, true},
+		{"8.4.10", 8, true},
+		{"5.7.44-log", 5, true},
+		{"10.11.6-MariaDB", 10, true},
+		{"", 0, false},
+		{"weird", 0, false},
+	} {
+		major, ok := serverMajorVersion(tc.version)
+		if major != tc.wantMajor || ok != tc.wantOK {
+			t.Errorf("serverMajorVersion(%q) = (%d, %v), want (%d, %v)", tc.version, major, ok, tc.wantMajor, tc.wantOK)
 		}
 	}
 }

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1900,14 +1900,17 @@ try {
     const closeBtn = t.querySelector(".toast-close");
     if (closeBtn) closeBtn.click();
     await sleep(50);
-    const closeDismisses = t.hidden && !t.classList.contains("toast-error");
+    // Only `hidden` decides visibility: #toast-error carries the toast-error
+    // class permanently in index.html now that failures have their own node,
+    // so asserting the class is absent would assert the markup is wrong.
+    const closeDismisses = t.hidden && t.textContent === "";
 
     // A repeat of a message already showing is counted, not dropped: several
     // failures carry no server name, so a second one would otherwise change
     // nothing on screen and read as success.
     toastError("Refusal four.");
     toastError("Refusal four.");
-    const counted = /\u00d74|×4|\(×2\)/.test(t.textContent) || /\(×2\)/.test(t.textContent);
+    const counted = /\(×2\)/.test(t.textContent);
     dismissToast();
 
     // A success notice still fades on its own.

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1850,8 +1850,9 @@ try {
   // that stops discriminating, cannot ship silently.
   const toastRun = await page.evaluate(async () => {
     const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-    const t = document.getElementById("toast");
-    const shown = () => !t.hidden && t.classList.contains("toast-error");
+    const t = document.getElementById("toast-error");
+    const transient = document.getElementById("toast");
+    const shown = () => !t.hidden;
 
     toastError("Refusal one: grant LOCK TABLES.");
     const immediately = shown();
@@ -1859,9 +1860,11 @@ try {
     await sleep(2600);
     const survivesAutoHide = shown();
 
-    // A success notice must not silently delete an unread failure.
+    // A success notice must not silently delete an unread failure — and must
+    // itself still render, which the shared-node version could not guarantee.
     toast("Baseline started…");
     const survivesSuccess = shown() && /Refusal one/.test(t.textContent);
+    const successStillRenders = !transient.hidden && /Baseline started/.test(transient.textContent);
 
     // A second failure stacks rather than overwrites.
     toastError("Refusal two: BACKUP_ADMIN cannot be granted on RDS.");
@@ -1876,6 +1879,17 @@ try {
     const survivesModalEsc = shown();
     modalMount.replaceChildren();
 
+    // Third door: the date picker renders into document.body, not #modal, and
+    // closes itself on ESC without stopping propagation. Enumerating #modal and
+    // #cmdk-mount was not enough — this is the case that got through.
+    const pop = document.createElement("div");
+    pop.className = "dt-pop";
+    document.body.append(pop);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await sleep(50);
+    const survivesDatePickerEsc = shown();
+    pop.remove();
+
     // With nothing else open, ESC dismisses it.
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     await sleep(50);
@@ -1888,29 +1902,40 @@ try {
     await sleep(50);
     const closeDismisses = t.hidden && !t.classList.contains("toast-error");
 
-    // A success notice still fades once no error is showing.
+    // A repeat of a message already showing is counted, not dropped: several
+    // failures carry no server name, so a second one would otherwise change
+    // nothing on screen and read as success.
+    toastError("Refusal four.");
+    toastError("Refusal four.");
+    const counted = /\u00d74|×4|\(×2\)/.test(t.textContent) || /\(×2\)/.test(t.textContent);
+    dismissToast();
+
+    // A success notice still fades on its own.
     toast("Done");
-    const successShown = !t.hidden;
+    const successShown = !transient.hidden;
     await sleep(2600);
     return {
-      immediately, survivesAutoHide, survivesSuccess, stacked,
-      survivesModalEsc, escDismisses, closeDismisses,
-      successShown, successFaded: t.hidden,
+      immediately, survivesAutoHide, survivesSuccess, successStillRenders, stacked, counted,
+      survivesModalEsc, survivesDatePickerEsc, escDismisses, closeDismisses,
+      successShown, successFaded: transient.hidden,
     };
   });
 
   (toastRun.immediately && toastRun.survivesAutoHide)
     ? ok("toast: a failure notice is still on screen well past the transient auto-hide")
     : bad("toast: a failure notice is still on screen well past the transient auto-hide", JSON.stringify(toastRun));
-  toastRun.survivesSuccess
-    ? ok("toast: a success notice does not overwrite an unread failure")
-    : bad("toast: a success notice does not overwrite an unread failure", JSON.stringify(toastRun));
+  (toastRun.survivesSuccess && toastRun.successStillRenders)
+    ? ok("toast: a success notice neither overwrites an unread failure nor is suppressed by it")
+    : bad("toast: a success notice neither overwrites an unread failure nor is suppressed by it", JSON.stringify(toastRun));
+  toastRun.counted
+    ? ok("toast: a repeated failure is counted rather than silently dropped")
+    : bad("toast: a repeated failure is counted rather than silently dropped", JSON.stringify(toastRun));
   toastRun.stacked
     ? ok("toast: concurrent failures stack instead of replacing each other")
     : bad("toast: concurrent failures stack instead of replacing each other", JSON.stringify(toastRun));
-  toastRun.survivesModalEsc
-    ? ok("toast: an ESC meant for an open dialog does not destroy the failure notice")
-    : bad("toast: an ESC meant for an open dialog does not destroy the failure notice", JSON.stringify(toastRun));
+  (toastRun.survivesModalEsc && toastRun.survivesDatePickerEsc)
+    ? ok("toast: an ESC meant for an open dialog or popover does not destroy the failure notice")
+    : bad("toast: an ESC meant for an open dialog or popover does not destroy the failure notice", JSON.stringify(toastRun));
   (toastRun.escDismisses && toastRun.closeDismisses)
     ? ok("toast: ESC and the close button both dismiss the failure notice")
     : bad("toast: ESC and the close button both dismiss the failure notice", JSON.stringify(toastRun));

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1841,6 +1841,82 @@ try {
   (busyRun.typed.submitted && busyRun.typed.panel)
     ? ok("restore combo: a typed table not in the listing still submits end-to-end")
     : bad("restore combo: a typed table not in the listing still submits end-to-end", JSON.stringify(busyRun.typed));
+
+  // ── persistent failure notices (#1381) ───────────────────────────────────
+  // A failure notice that fades is a failure nobody saw. The baseline privilege
+  // refusal is ~550 characters of remediation, and at the old 2.2s auto-hide it
+  // was unreadable and unrecoverable — it was reported from a screenshot caught
+  // by luck. These assertions exist so a re-added setTimeout, or an ESC handler
+  // that stops discriminating, cannot ship silently.
+  const toastRun = await page.evaluate(async () => {
+    const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+    const t = document.getElementById("toast");
+    const shown = () => !t.hidden && t.classList.contains("toast-error");
+
+    toastError("Refusal one: grant LOCK TABLES.");
+    const immediately = shown();
+    // Comfortably past the 2.2s auto-hide a transient toast would have used.
+    await sleep(2600);
+    const survivesAutoHide = shown();
+
+    // A success notice must not silently delete an unread failure.
+    toast("Baseline started…");
+    const survivesSuccess = shown() && /Refusal one/.test(t.textContent);
+
+    // A second failure stacks rather than overwrites.
+    toastError("Refusal two: BACKUP_ADMIN cannot be granted on RDS.");
+    const stacked = /Refusal one/.test(t.textContent) && /Refusal two/.test(t.textContent);
+
+    // ESC belongs to an open dialog first. Put something in the shared modal
+    // slot and confirm the notice survives that Escape.
+    const modalMount = document.getElementById("modal");
+    modalMount.append(document.createElement("div"));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await sleep(50);
+    const survivesModalEsc = shown();
+    modalMount.replaceChildren();
+
+    // With nothing else open, ESC dismisses it.
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await sleep(50);
+    const escDismisses = t.hidden;
+
+    // And so does the close button.
+    toastError("Refusal three.");
+    const closeBtn = t.querySelector(".toast-close");
+    if (closeBtn) closeBtn.click();
+    await sleep(50);
+    const closeDismisses = t.hidden && !t.classList.contains("toast-error");
+
+    // A success notice still fades once no error is showing.
+    toast("Done");
+    const successShown = !t.hidden;
+    await sleep(2600);
+    return {
+      immediately, survivesAutoHide, survivesSuccess, stacked,
+      survivesModalEsc, escDismisses, closeDismisses,
+      successShown, successFaded: t.hidden,
+    };
+  });
+
+  (toastRun.immediately && toastRun.survivesAutoHide)
+    ? ok("toast: a failure notice is still on screen well past the transient auto-hide")
+    : bad("toast: a failure notice is still on screen well past the transient auto-hide", JSON.stringify(toastRun));
+  toastRun.survivesSuccess
+    ? ok("toast: a success notice does not overwrite an unread failure")
+    : bad("toast: a success notice does not overwrite an unread failure", JSON.stringify(toastRun));
+  toastRun.stacked
+    ? ok("toast: concurrent failures stack instead of replacing each other")
+    : bad("toast: concurrent failures stack instead of replacing each other", JSON.stringify(toastRun));
+  toastRun.survivesModalEsc
+    ? ok("toast: an ESC meant for an open dialog does not destroy the failure notice")
+    : bad("toast: an ESC meant for an open dialog does not destroy the failure notice", JSON.stringify(toastRun));
+  (toastRun.escDismisses && toastRun.closeDismisses)
+    ? ok("toast: ESC and the close button both dismiss the failure notice")
+    : bad("toast: ESC and the close button both dismiss the failure notice", JSON.stringify(toastRun));
+  (toastRun.successShown && toastRun.successFaded)
+    ? ok("toast: success notices still fade on their own")
+    : bad("toast: success notices still fade on their own", JSON.stringify(toastRun));
   (busyRun.previewBusy.modalOpen && /Previewing affected rows/.test(busyRun.previewBusy.title))
     ? ok("busy modal: Preview rows adopts the same busy affordance")
     : bad("busy modal: Preview rows adopts the same busy affordance", JSON.stringify(busyRun.previewBusy).slice(0, 200));


### PR DESCRIPTION
Closes #1381.

## What broke

v0.58.0 made point-consistent baselines the default. On RDS that made the
Create-baseline button fail for everyone, and the message it printed was wrong
about why. Both causes were found on a live source and measured, not inferred.

**The privilege preflight is blind on managed MySQL.** It read
`information_schema.USER_PRIVILEGES`, which exposes only rows the connecting
user can SEE in `mysql.user`. On RDS MySQL 8.4, same session:

```
SHOW GRANTS FOR CURRENT_USER()   -> ... RELOAD ... LOCK TABLES ... FLUSH_TABLES ...
USER_PRIVILEGES WHERE GRANTEE='admin'@'%'  -> 1 row: USAGE
```

The GRANTEE matched; the privileges were simply absent from the view. The check
failed **closed** and reported *"the current user has neither"* about
privileges the user held. Now it parses `SHOW GRANTS FOR CURRENT_USER()`, which
needs no privilege and reflects active roles — closing the role gap the old
code documented as a known limitation instead of only working around it.

**`ftwrl` cannot run on RDS at all.** `BACKUP_ADMIN` is ungrantable there
(`ERROR 1227 ... you need the RDSADMIN USER privilege`) and mydumper issues
`LOCK INSTANCE FOR BACKUP` first. Confirmed with a user holding
`RELOAD`+`FLUSH_TABLES` but not `BACKUP_ADMIN`: exit 1 on that statement.

## The fix: `lock-all`

mydumper's fourth sync mode, which #1377 dismissed without testing. It
synchronizes workers by locking the **exported tables** rather than the
instance — mydumper's documented option for "when FLUSH TABLE WITH READ LOCK is
not available". Needs only `LOCK TABLES`, which the RDS master user already
holds, and is equally point-consistent.

Measured against the identical RDS-shaped privilege set:

| mode | result |
|---|---|
| `FTWRL` | exit 1 — `Couldn't acquire LOCK INSTANCE FOR BACKUP` |
| `LOCK_ALL` | exit 0, metadata written |

Requirements are now evaluated **per mode**, and an `ftwrl` refusal names
`lock-all` before the weaker modes: it is the only alternative still
point-consistent, and on managed MySQL the only one that can work.

## Also: console failures stopped disappearing

Every failure notice was a toast that auto-hid after 2.2s. The privilege
refusal is ~550 characters of remediation — which privilege, the exact `GRANT`,
the alternatives — so at that duration it was not merely easy to miss, it was
unreadable, with no way to recover the reason. It was reported from a
screenshot caught by luck. Failures now stay until dismissed (close button or
ESC) and scroll when long; successes still fade.

## Verification

- `go vet ./...` clean, `go test ./...` 0 FAIL, `node --check` on the JS.
- Mutation-verified: reverting the query to `USER_PRIVILEGES`, dropping
  `lock-all`'s `LOCK TABLES` check, and letting `lock-all` fall through to
  `FTWRL` in the argv each fail the test that names the operator consequence.
- The MariaDB leak was caught by the new tests, not by review: the
  managed-MySQL note mentioned `BACKUP_ADMIN` on a flavor where it does not
  exist. It is now gated on the flavor.
