### PR TITLE
docs: the documented source user could not take a baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,8 @@
 
 # OPTIONAL — a source MySQL to start watching immediately at boot.
 # Leave unset and add servers from the console UI instead (zero-config path).
-# The user needs REPLICATION SLAVE, REPLICATION CLIENT, and SELECT.
+# The user needs REPLICATION SLAVE, REPLICATION CLIENT, and SELECT — plus
+# LOCK TABLES if you want baselines (see BASELINE_LOCK_MODE below).
 # Baselines additionally need RELOAD (or FLUSH_TABLES), plus BACKUP_ADMIN on
 # MySQL/Percona 8.0+, because the snapshot is point-consistent by default.
 # On managed MySQL (RDS/Aurora) BACKUP_ADMIN CANNOT be granted at all: grant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The documented source user could not take a baseline.** Every place that
+  spells out the source grants — `streaming.md`, `quickstart.md`, `install.md`,
+  `console.md`, `docker.md`, `guide.md`, `mariadb.md`, `deployment.md`,
+  `.env.example`, and the console's own "+ Add server" form — listed
+  `REPLICATION SLAVE, REPLICATION CLIENT, SELECT` and nothing else. Since
+  baselines became point-consistent by default in 0.58.0, that user is refused
+  by **every** consistent lock mode, so an operator who followed the docs
+  exactly hit a wall at the Create-baseline button. `streaming.md` additionally
+  asserted dbtrail "does not need `RELOAD`, `LOCK TABLES`…", which stopped being
+  true for the baseline path.
+
+  The grant lists now separate the two: capture needs the original three and
+  still never locks the source; a baseline needs `LOCK TABLES` on top, and says
+  so where the list is read. Omitting it is a DELAYED failure — capture starts
+  clean and only the snapshot is refused — which is why the console form now
+  carries the line too. `streaming.md` gained a section covering both
+  point-consistent modes and why RDS/Aurora must use `lock-all`.
+
 ## [0.59.0] - 2026-08-17
 
 ### Fixed

--- a/docs/console.md
+++ b/docs/console.md
@@ -237,9 +237,14 @@ immediately; warnings (e.g. short binlog retention) show but don't block.
 
 The **source user** you paste into the form needs `REPLICATION SLAVE,
 REPLICATION CLIENT, SELECT` on the source MySQL — the form spells out the
-exact `CREATE USER` / `GRANT` to copy. dbtrail never writes to or locks the
-source. Full per-privilege breakdown and the least-privilege (schema-scoped
-`SELECT`) variant: [streaming.md](streaming.md#the-source-mysql-user).
+exact `CREATE USER` / `GRANT` to copy. dbtrail never writes to the source, and
+capture never locks it. The **Create baseline** button needs one privilege
+more, `LOCK TABLES`, because a baseline is point-consistent by default; without
+it capture keeps running and only the baseline is refused, naming the exact
+`GRANT`. On RDS/Aurora set `BINTRAIL_CONSOLE_BASELINE_LOCK_MODE=lock-all` —
+`ftwrl` needs `BACKUP_ADMIN`, which managed MySQL will not grant. Full
+per-privilege breakdown and the least-privilege (schema-scoped `SELECT`)
+variant: [streaming.md](streaming.md#the-source-mysql-user).
 
 - Each monitored source gets **its own index database** — per-source state
   (checkpoints, snapshots) stays structurally isolated, and the server

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -78,7 +78,7 @@ On-demand (DBA workstation):
 
 ### Replication user
 
-`bintrail` connects to the source as a replication client. The required grants (`REPLICATION SLAVE`, `REPLICATION CLIENT`, plus `SELECT` for schema snapshots and preflight checks) and the minimal-permissions guidance are in [streaming.md → The Source MySQL User](streaming.md#the-source-mysql-user).
+`bintrail` connects to the source as a replication client. The required grants (`REPLICATION SLAVE`, `REPLICATION CLIENT`, plus `SELECT` for schema snapshots and preflight checks) and the minimal-permissions guidance are in [streaming.md → The Source MySQL User](streaming.md#the-source-mysql-user). Baselines need `LOCK TABLES` on top of those — capture works without it, only the snapshot is refused.
 
 ### Managed MySQL (RDS / Aurora / Cloud SQL)
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -175,7 +175,9 @@ annotated template.)
 Notes:
 
 - `SOURCE_DSN` is the MySQL you want to watch. The user needs
-  `REPLICATION SLAVE`, `REPLICATION CLIENT`, and `SELECT`. A MySQL on the
+  `REPLICATION SLAVE`, `REPLICATION CLIENT`, and `SELECT`, plus `LOCK TABLES`
+  if you want baselines (point-consistent by default; on RDS/Aurora also set
+  `BASELINE_LOCK_MODE=lock-all`). A MySQL on the
   same machine is reachable from inside Docker as `host.docker.internal`.
 - The console is published on the **host loopback only** (`127.0.0.1:8090`),
   which is why first-run browser setup is allowed (the compose sets

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -36,7 +36,7 @@ Before you start:
 
 **If you are using managed MySQL** (RDS, Aurora, Cloud SQL — no binlog file access):
 - [ ] Use `bintrail stream` instead of `bintrail index` — it connects over the replication protocol
-- [ ] Replication user with `REPLICATION SLAVE` and `REPLICATION CLIENT` privileges on the source
+- [ ] Replication user with `REPLICATION SLAVE` and `REPLICATION CLIENT` privileges on the source (plus `LOCK TABLES` for baselines; on RDS/Aurora use `--lock-mode lock-all`, since `BACKUP_ADMIN` cannot be granted there)
 - [ ] Source DSN uses TCP: `user:pass@tcp(host:3306)/` (unix socket is not supported for replication)
 
 ---

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,7 +15,9 @@ it's the first section — the same four lines as the README.
   `binlog_row_image = FULL`. Don't guess: `bintrail doctor` checks everything
   and prints copy-pasteable remediation for whatever is missing.
 - A MySQL user on the source with `REPLICATION SLAVE`, `REPLICATION CLIENT`,
-  and `SELECT`.
+  and `SELECT` — plus `LOCK TABLES` if you want baselines (they are
+  point-consistent by default; see
+  [streaming.md](./streaming.md#if-you-also-want-baselines-add-lock-tables)).
 - An **index MySQL 8.0+** database for dbtrail's data (the Compose stack
   bundles one).
 - **Other sources:** besides MySQL, dbtrail can also capture from **MariaDB**

--- a/docs/mariadb.md
+++ b/docs/mariadb.md
@@ -53,7 +53,7 @@ Identical to a MySQL source (see [Streaming → The Source MySQL User](streaming
 | `binlog_format = ROW` | Validated at preflight; `bintrail` refuses to start otherwise. |
 | `binlog_row_image = FULL` | Set it **server-wide** (`SHOW VARIABLES LIKE 'binlog_row_image';`). MariaDB defaults to `FULL`, but verify. |
 | `log_bin = ON` | Binary logging must be enabled. |
-| Source user grants | `REPLICATION SLAVE, REPLICATION CLIENT, SELECT` — the same set as MySQL. |
+| Source user grants | `REPLICATION SLAVE, REPLICATION CLIENT, SELECT` — the same set as MySQL. Add `LOCK TABLES` for baselines. MariaDB has no `BACKUP_ADMIN` and never issues `LOCK INSTANCE FOR BACKUP`, so the default `ftwrl` mode needs only `RELOAD`/`FLUSH_TABLES` there. |
 
 > MariaDB does not have a `server_uuid` system variable. bintrail detects this
 > and emits a benign `WARN … MariaDB source has no @@server_uuid; synthesized a

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,6 +18,9 @@ the **command line**. Both need a source MySQL user first.
   ```sql
   CREATE USER 'dbtrail'@'%' IDENTIFIED BY 'strong-password';
   GRANT REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'dbtrail'@'%';
+  -- Only if you want baselines (Time-travel / reconstruct): they are
+  -- point-consistent by default, and that guarantee needs a lock.
+  GRANT LOCK TABLES ON *.* TO 'dbtrail'@'%';
   -- Baselines are point-consistent by default and need these too.
   -- BACKUP_ADMIN is MySQL/Percona 8.0+ only; omit it on MariaDB and MySQL 5.7.
   GRANT RELOAD, BACKUP_ADMIN ON *.* TO 'dbtrail'@'%';

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -21,7 +21,47 @@ That is the complete, minimal set. Each privilege maps to exactly one thing dbtr
 | `REPLICATION CLIENT` | Discover the start position and detect gaps: `SHOW BINARY LOG STATUS` / `SHOW MASTER STATUS`, `SHOW BINARY LOGS`, `@@gtid_purged`, `@@gtid_executed`. |
 | `SELECT` | Snapshot the schema (column types, primary keys, foreign keys) from `information_schema`, and run the preflight checks. |
 
-dbtrail **never** writes to the source and never locks it. It does not need `RELOAD`, `LOCK TABLES`, `PROCESS`, `SHOW VIEW`, or `EXECUTE`.
+dbtrail **never writes to the source**, and nothing on the capture path ever locks it. Capture does not need `RELOAD`, `LOCK TABLES`, `PROCESS`, `SHOW VIEW`, or `EXECUTE`.
+
+### If you also want baselines: add `LOCK TABLES`
+
+Capture alone gives you the change history. A **baseline** — the full-table
+snapshot that `reconstruct`, Time-travel and the console's **Create baseline**
+button merge those changes onto — is a `mydumper` run, and it needs one more
+privilege:
+
+```sql
+GRANT LOCK TABLES ON *.* TO 'dbtrail'@'%';   -- only if you want baselines
+```
+
+Baselines are **point-consistent by default**: every worker thread opens its
+snapshot at the same instant, so the result represents one moment rather than a
+table stitched together from several. That guarantee is what needs a lock, held
+only for the moment the threads synchronize — never for the duration of the
+dump. A baseline that is not point-consistent yields a table state that never
+existed, and every answer reconstructed from it inherits that silently.
+
+Two ways to satisfy it, both point-consistent:
+
+| Lock mode | Privileges | Use when |
+|---|---|---|
+| `lock-all` | `LOCK TABLES` (global, or on the dumped schemas) | **Anywhere.** The only option on RDS/Aurora — see below. |
+| `ftwrl` (default) | `RELOAD` or `FLUSH_TABLES`, **plus** `BACKUP_ADMIN` on MySQL/Percona 8.0+ | Self-hosted, when you would rather not grant `LOCK TABLES`. |
+
+**On Amazon RDS and Aurora, use `lock-all`.** `BACKUP_ADMIN` cannot be granted
+there at all (`GRANT BACKUP_ADMIN` fails with *"ERROR 1227 … you need the
+RDSADMIN USER privilege"*), and `ftwrl` issues `LOCK INSTANCE FOR BACKUP` first,
+so it cannot work no matter what else you grant. mydumper says so itself: *"We
+support LOCK_ALL and SAFE_NO_LOCK modes for RDS/Aurora."* Select it with
+`bintrail dump --lock-mode lock-all`, or
+`BINTRAIL_CONSOLE_BASELINE_LOCK_MODE=lock-all` for the console.
+
+If you grant neither, capture keeps working normally and only the baseline is
+refused — with a message naming the exact `GRANT` to run. It never quietly falls
+back to a snapshot it cannot vouch for. The low-privilege escape hatches are
+`safe-no-lock` (needs nothing extra, but **aborts** rather than write a torn
+snapshot, so expect it to refuse on a write-active source) and `no-lock` (accepts
+a torn snapshot — see [dump-and-baseline.md](dump-and-baseline.md)).
 
 **Least-privilege variant** — `SELECT` is the only privilege you can scope to specific schemas (the two `REPLICATION` grants are global-only in MySQL):
 

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4932,14 +4932,25 @@ function buildServerForm() {
   // The source user is the #1 friction point — spell out the grant inline,
   // never behind a <details>. REPLICATION SLAVE/CLIENT drive the stream;
   // SELECT covers the information_schema snapshot of columns/PKs/FKs.
+  //
+  // LOCK TABLES is listed here too, commented, because omitting it is a
+  // DELAYED failure: capture starts clean and only Create baseline refuses,
+  // hours or days later. The form is the last place anyone reads a grant list
+  // before pasting it, so the line has to exist here even though the stream
+  // does not need it.
   const grantHint = tagFlavor(el("p", { class: "form-hint", style: "margin-top:10px" }), "mysql mariadb");
   grantHint.append("Source user needs ");
   grantHint.append(el("code", { text: "REPLICATION SLAVE, REPLICATION CLIENT, SELECT" }));
-  grantHint.append(". Create one on the source MySQL — copy and run:");
+  grantHint.append(" to capture, plus ");
+  grantHint.append(el("code", { text: "LOCK TABLES" }));
+  grantHint.append(" if you want baselines. Create one on the source MySQL — copy and run:");
   mon.append(grantHint);
   mon.append(tagFlavor(el("pre", { class: "form-code", text:
     "CREATE USER 'dbtrail'@'%' IDENTIFIED BY 'strong-password';\n" +
-    "GRANT REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'dbtrail'@'%';" }), "mysql mariadb"));
+    "GRANT REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'dbtrail'@'%';\n" +
+    "-- Baselines only (point-consistent by default). On RDS/Aurora also set\n" +
+    "-- BINTRAIL_CONSOLE_BASELINE_LOCK_MODE=lock-all.\n" +
+    "GRANT LOCK TABLES ON *.* TO 'dbtrail'@'%';" }), "mysql mariadb"));
   // PostgreSQL prerequisites — the console reads them, it never runs CREATE
   // PUBLICATION / ALTER SYSTEM (validate-don't-create; capture is pgoutput-only).
   const pgHint = tagFlavor(el("p", { class: "form-hint", style: "margin-top:10px" }), "postgres");


### PR DESCRIPTION
## The problem

Every doc that spells out the source-user grants listed exactly:

```sql
GRANT REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'dbtrail'@'%';
```

Since #1377 made baselines **point-consistent by default** in 0.58.0, that
user is refused by *every* consistent lock mode:

| mode | needs | that user has it? |
|---|---|---|
| `ftwrl` (default) | `RELOAD`/`FLUSH_TABLES` + `BACKUP_ADMIN` on 8.0+ | no |
| `lock-all` | `LOCK TABLES` | no |

So following the docs verbatim gives you a working capture and a
**Create baseline button that can never succeed**. Found on a real
deployment: source user created from `quickstart.md`, refused at the button.
The refusal was correct — the documentation was not.

`streaming.md` made it worse by asserting the opposite outright:

> dbtrail **never** writes to the source and never locks it. It does not need
> `RELOAD`, `LOCK TABLES`, `PROCESS`, `SHOW VIEW`, or `EXECUTE`.

True of capture, false of baselines — on the page every other doc links to
for the grant list.

## The change

The grant lists now separate the two paths rather than merging them. Capture
needs the original three and genuinely never locks the source; a baseline
needs `LOCK TABLES` on top, stated where the list is actually read.

`streaming.md` gains a section that covers both point-consistent modes, what
the lock is *for* (held only while worker threads synchronize onto one
instant — not for the duration of the dump), and why RDS/Aurora must use
`lock-all`: `BACKUP_ADMIN` cannot be granted there at all, and mydumper's own
help says *"We support LOCK_ALL and SAFE_NO_LOCK modes for RDS/Aurora"*.

Also updated: `quickstart.md`, `install.md`, `console.md`, `docker.md`,
`guide.md`, `mariadb.md`, `deployment.md`, `.env.example`, and the console's
**+ Add server** form.

The form matters disproportionately: omitting `LOCK TABLES` is a **delayed**
failure — capture starts clean and only the snapshot is refused, possibly days
later — and that form is the last place anyone reads a grant list before
pasting it.

## Note on MariaDB

`BACKUP_ADMIN` does not exist there and MariaDB never issues
`LOCK INSTANCE FOR BACKUP`, so `ftwrl` needs only `RELOAD`/`FLUSH_TABLES` —
called out in `mariadb.md` so nobody goes hunting a privilege their server
cannot have.
