### PR TITLE
console: the Undo banner states the window it reverses, not a target state

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -131,7 +131,10 @@ and searching events:
 4. **Recover** — filter schema / table / PK / time, preview the affected rows
    with before→after diffs, then **Generate undo SQL** and copy/download the
    script. Arriving via an **Undo** action scopes it to that row and shows a
-   context banner. When you undo a `DELETE` on a foreign-key **parent** whose
+   context banner; it fills in **Until** from the event you clicked and leaves
+   **Since** open, so every change to that row up to that point is reversed —
+   not only the event you clicked. Set **Since** to narrow the window.
+   When you undo a `DELETE` on a foreign-key **parent** whose
    children InnoDB cascade-deleted *below* the binlog (MySQL ≤ 8.x / MariaDB) —
    or an `UPDATE` of a referenced key whose `ON UPDATE` cascade rewrote them just
    as invisibly —

--- a/docs/console.md
+++ b/docs/console.md
@@ -132,8 +132,12 @@ and searching events:
    with before→after diffs, then **Generate undo SQL** and copy/download the
    script. Arriving via an **Undo** action scopes it to that row and shows a
    context banner; it fills in **Until** from the event you clicked and leaves
-   **Since** open, so every change to that row up to that point is reversed —
-   not only the event you clicked. Set **Since** to narrow the window.
+   **Since** open. Timestamps are second-granular and the bound is inclusive,
+   so the window closes at the **end of that event's second**: every change to
+   the row up to there is reversed — including events that happened *after*
+   the one you clicked, inside the same second — not only the event you
+   clicked. **Since** narrows the window but cannot split events within a
+   single second; use `--limit-per-pk` for that.
    When you undo a `DELETE` on a foreign-key **parent** whose
    children InnoDB cascade-deleted *below* the binlog (MySQL ≤ 8.x / MariaDB) —
    or an `UPDATE` of a referenced key whose `ON UPDATE` cascade rewrote them just

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2037,9 +2037,19 @@ function renderRecover(params) {
     const banner = el("div", { class: "ctx-banner" });
     banner.append(el("span", { class: "badge " + badgeClass(ctx.type), text: ctx.type }));
     banner.append(el("div", { class: "ctx-main" },
-      el("span", { class: "ctx-eyebrow", text: "Reverting this row to before this point" }),
+      // Scope, not target state. The prefill below sets `until` and never
+      // `since`, so this reverses EVERY event on the row in an unbounded
+      // window — the row lands where it was when the window opened, which is
+      // only "the state just before this event" when that event is the sole
+      // one in range. The old wording ("reverting this row to before this
+      // point") promised the latter and quietly delivered the former: on a
+      // row inserted and deleted inside the same second, undoing both leaves
+      // no row at all. If the prefill ever bounds the window, revisit this
+      // text — TestAppJSUndoBannerStatesWindowScope pins the pairing.
+      el("span", { class: "ctx-eyebrow", text: "Undoing every change up to this point" }),
       el("span", { class: "ctx-title", text: ctx.schema + "." + ctx.table + " · pk " + ctx.pk }),
-      el("span", { class: "ctx-detail", text: "undoing changes up to " + ctx.type + " at " + ctx.time + " UTC" })));
+      el("span", { class: "ctx-detail", text: "reverses all events on this row through " + ctx.type
+        + " at " + ctx.time + " UTC, not only that one — set Since to narrow the window" })));
     banner.append(el("span", { class: "spacer" }));
     banner.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Clear",
       onclick: () => { pendingRecover = null; navigate("recover"); } }));

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2037,19 +2037,30 @@ function renderRecover(params) {
     const banner = el("div", { class: "ctx-banner" });
     banner.append(el("span", { class: "badge " + badgeClass(ctx.type), text: ctx.type }));
     banner.append(el("div", { class: "ctx-main" },
-      // Scope, not target state. The prefill below sets `until` and never
-      // `since`, so this reverses EVERY event on the row in an unbounded
-      // window — the row lands where it was when the window opened, which is
-      // only "the state just before this event" when that event is the sole
-      // one in range. The old wording ("reverting this row to before this
-      // point") promised the latter and quietly delivered the former: on a
-      // row inserted and deleted inside the same second, undoing both leaves
-      // no row at all. If the prefill ever bounds the window, revisit this
-      // text — TestAppJSUndoBannerStatesWindowScope pins the pairing.
-      el("span", { class: "ctx-eyebrow", text: "Undoing every change up to this point" }),
+      // Scope, not target state — and the scope is a WINDOW OF TIME, not an
+      // event. The prefill sets `until` from ctx.time and never `since`;
+      // ctx.time is second-granular (consoleTSFormat) and the predicate is
+      // `event_timestamp <= ?`, so the ceiling is the END OF THAT SECOND, not
+      // the clicked event. Everything on the row up to there is reversed,
+      // including events that happened AFTER the clicked one inside the same
+      // second.
+      //
+      // That is not a corner case, it is the case this wording exists for: on
+      // a row inserted and deleted inside one second, undoing from EITHER
+      // event reverses both and leaves no row at all. An earlier draft said
+      // "up to this point", which named the event as the boundary and was
+      // wrong the same way the phrasing it replaced was wrong, one revision
+      // later.
+      //
+      // Since is offered AND its limit is stated: it parses at the same
+      // granularity, so it cannot split events inside one second. Naming a
+      // control without saying where it stops working is how an operator ends
+      // up believing they narrowed something they did not.
+      el("span", { class: "ctx-eyebrow", text: "Undoing every change in this window" }),
       el("span", { class: "ctx-title", text: ctx.schema + "." + ctx.table + " · pk " + ctx.pk }),
-      el("span", { class: "ctx-detail", text: "reverses all events on this row through " + ctx.type
-        + " at " + ctx.time + " UTC, not only that one — set Since to narrow the window" })));
+      el("span", { class: "ctx-detail", text: "reverses all events on this row through the end of the second holding this "
+        + ctx.type + " (" + ctx.time + " UTC), not only that one" }),
+      el("span", { class: "ctx-detail", text: "Set Since to narrow the window — timestamps are second-granular, so it cannot split events inside one second." })));
     banner.append(el("span", { class: "spacer" }));
     banner.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Clear",
       onclick: () => { pendingRecover = null; navigate("recover"); } }));

--- a/internal/console/assets_recover_banner_test.go
+++ b/internal/console/assets_recover_banner_test.go
@@ -6,82 +6,131 @@ import (
 	"testing"
 )
 
-// The Restore "Undo" banner must describe the SCOPE of the reversal, never a
-// target state. renderRecover's prefill sets `until` from the clicked event
-// and never `since`, so generateUndo reverses every event on that row in an
-// unbounded window: the row lands where it was when the window opened. That
-// equals "the state just before this event" only when the event is the sole
-// one in range.
+// The Restore "Undo" banner must describe the WINDOW it reverses, never a
+// target state and never a single event.
 //
-// The wording this pins replaced "Reverting this row to before this point",
-// which promised the single-event reading. The failure it hid is not
-// hypothetical: a row INSERTed and DELETEd inside the same second (WordPress
-// `_transient_doing_cron`) yields two reversals whose net effect is no row at
-// all — correct for the window, the opposite of what the banner announced.
-// Timestamps cannot separate same-second events, so `since` is no remedy
-// there; that is what exposing limit-per-pk on this surface is for.
+// renderRecover's prefill sets `until` from the clicked event and never
+// `since`. `ctx.time` is second-granular (consoleTSFormat) and the predicate
+// is `event_timestamp <= ?`, so the ceiling is the END OF THAT SECOND: every
+// event on the row up to there is reversed, including ones that happened
+// AFTER the clicked event inside the same second.
 //
-// Comments are stripped before matching. The explanation above the banner in
-// app.js quotes the old wording, and served bytes include comments — matching
-// raw source would let the retired phrasing pass as long as someone left it in
-// a comment, and would fire on the explanation itself.
+// The failure is not hypothetical and not a corner case. A row INSERTed and
+// DELETEd inside one second (WordPress `_transient_doing_cron`) reverses BOTH
+// from either entry point, and the net effect is no row at all — correct for
+// the window, the opposite of what a banner naming one event announces.
+// `since` is no remedy there: it parses at the same granularity.
+//
+// Two earlier drafts got this wrong in the same direction — "Reverting this
+// row to before this point" named a target state, then "Undoing every change
+// up to this point" named the clicked event as the boundary. Hence a guard.
 func TestAppJSUndoBannerStatesWindowScope(t *testing.T) {
+	eyebrow, detail := undoBannerText(t)
+
+	// (a) The retired phrasings must not come back. Checked against the banner
+	// text ONLY — see undoBannerText: a needle in a comment can neither
+	// satisfy nor trip these.
+	for _, banned := range []string{
+		"Reverting this row to before this point",
+		"undoing changes up to ",
+		// Names the clicked event as the ceiling. It is not; the second is.
+		"up to this point",
+	} {
+		if strings.Contains(eyebrow+detail, banned) {
+			t.Errorf("the Undo banner reintroduces %q.\n"+
+				"That phrasing makes the clicked event (or the state before it) the boundary. The window "+
+				"actually closes at the END of that event's second, and every event on the row up to there "+
+				"is reversed. State the window.", banned)
+		}
+	}
+
+	// (b) The eyebrow names a window, not a point.
+	if !strings.Contains(eyebrow, "window") {
+		t.Errorf("the Undo banner eyebrow no longer says it is undoing a window (%q) — "+
+			"without that word it reads as a single-event reversal, which is not what generateUndo does", eyebrow)
+	}
+
+	// (c) The detail states the real ceiling and that the clicked event is not
+	// alone. Asserted as source fragments: the sentence is concatenated around
+	// ctx.type/ctx.time, so the rendered sentence never appears contiguously in
+	// the source and searching for it whole would fail on every run.
+	for _, want := range []string{"end of the second", "not only that one"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("the Undo banner detail dropped %q.\n"+
+				"Detail was: %s\nA reader cannot tell how far the reversal reaches without it.", want, detail)
+		}
+	}
+
+	// (d) Since is offered AND its limit is stated. Offering it alone is worse
+	// than silence on the motivating case: an operator narrows the window,
+	// gets the identical script, and concludes the tool is broken.
+	if !strings.Contains(detail, "Set Since to narrow the window") {
+		t.Error("the Undo banner no longer points at Since — stating the window is wide without naming " +
+			"the way to narrow it leaves the operator with a warning and no action")
+	}
+	if !strings.Contains(detail, "second-granular") {
+		t.Error("the Undo banner points at Since without saying it cannot split events inside one second. " +
+			"That is exactly the case this banner exists for, so the caveat is not optional.")
+	}
+}
+
+// undoBannerText returns the eyebrow text and the concatenated detail source
+// from the Undo banner in renderRecover.
+//
+// Scoped extraction rather than a file-wide substring search. A previous
+// version searched all 5000+ lines with `//` comments stripped, which was
+// vacuous in both directions: a required needle could be satisfied by a
+// TRAILING comment on a gutted line (the strip only dropped whole-line
+// comments), and the stated reason for stripping at all was false — the
+// explanation it claimed to avoid firing on is lowercase and line-split, so it
+// never matched. Reading the actual `el(...)` calls removes the whole class:
+// comments, block or line, are simply not in the haystack.
+func undoBannerText(t *testing.T) (eyebrow, detail string) {
+	t.Helper()
 	data, err := os.ReadFile("assets/app.js")
 	if err != nil {
 		t.Fatal(err)
 	}
-	js := stripLineComments(string(data))
+	js := string(data)
 
-	// (a) The retired promise must not come back. It is a single unsplit
-	// literal in the source it replaced, so this catches a straight revert.
-	for _, banned := range []string{
-		"Reverting this row to before this point",
-		"undoing changes up to ",
-	} {
-		if strings.Contains(js, banned) {
-			t.Errorf("assets/app.js reintroduces %q in the Undo banner.\n"+
-				"That phrasing promises the row is restored to its state just before the clicked event, "+
-				"but the prefill leaves `since` empty, so EVERY event on the row in the window is reversed. "+
-				"State the scope instead.", banned)
-		}
+	// The banner lives in renderRecover; bound the search there so the cascade
+	// panel's own ctx-eyebrow cannot be mistaken for it.
+	start := strings.Index(js, "function renderRecover(")
+	if start < 0 {
+		t.Fatal("renderRecover is gone from assets/app.js — this guard covers nothing")
 	}
+	end := strings.Index(js[start:], "\nfunction ")
+	if end < 0 {
+		end = len(js) - start
+	}
+	fn := js[start : start+end]
 
-	// (b) The eyebrow names the scope.
-	if !strings.Contains(js, "Undoing every change up to this point") {
-		t.Error("the Undo banner eyebrow no longer states that every change up to the clicked event is undone — " +
-			"without it the banner implies a single-event reversal that generateUndo does not perform")
+	eyebrow = spanText(t, fn, "ctx-eyebrow")
+	// The detail is two spans; take everything from the first to the end of
+	// the append so both are covered.
+	i := strings.Index(fn, `class: "ctx-detail"`)
+	if i < 0 {
+		t.Fatal("no ctx-detail span in renderRecover — the Undo banner lost its explanatory line")
 	}
-
-	// (c) The detail says the reversal is not limited to the clicked event.
-	// Asserted as the literal source fragment: the sentence is built by
-	// concatenation around ctx.type/ctx.time, so the whole sentence never
-	// appears contiguously and searching for it would pass vacuously.
-	if !strings.Contains(js, "not only that one") {
-		t.Error("the Undo banner detail dropped the clause distinguishing the whole window from the clicked event; " +
-			"a reader cannot tell how many events the generated script will reverse")
+	j := strings.Index(fn[i:], "})));")
+	if j < 0 {
+		t.Fatal("could not find the end of the Undo banner's append")
 	}
-
-	// (d) The remedy stays actionable and names a control that exists on this
-	// form. If the prefill ever bounds the window itself, this pairing is what
-	// should force the wording to be revisited.
-	if !strings.Contains(js, "set Since to narrow the window") {
-		t.Error("the Undo banner no longer points at Since — stating the window is wide without naming the way to narrow it " +
-			"leaves the operator with a warning and no action")
-	}
+	return eyebrow, fn[i : i+j]
 }
 
-// stripLineComments removes whole-line // comments, leaving code and string
-// literals intact. Deliberately not a JS parser: it only has to keep the
-// explanatory comments in app.js out of substring assertions, and a line whose
-// trimmed form starts with "//" is never code.
-func stripLineComments(js string) string {
-	lines := strings.Split(js, "\n")
-	kept := lines[:0]
-	for _, ln := range lines {
-		if strings.HasPrefix(strings.TrimSpace(ln), "//") {
-			continue
-		}
-		kept = append(kept, ln)
+// spanText pulls the literal text of `el("span", { class: "<cls>", text: "…" })`.
+func spanText(t *testing.T, fn, cls string) string {
+	t.Helper()
+	marker := `class: "` + cls + `", text: "`
+	i := strings.Index(fn, marker)
+	if i < 0 {
+		t.Fatalf("no %s span with a literal text in renderRecover", cls)
 	}
-	return strings.Join(kept, "\n")
+	rest := fn[i+len(marker):]
+	j := strings.Index(rest, `"`)
+	if j < 0 {
+		t.Fatalf("unterminated text literal on the %s span", cls)
+	}
+	return rest[:j]
 }

--- a/internal/console/assets_recover_banner_test.go
+++ b/internal/console/assets_recover_banner_test.go
@@ -1,0 +1,87 @@
+package console
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The Restore "Undo" banner must describe the SCOPE of the reversal, never a
+// target state. renderRecover's prefill sets `until` from the clicked event
+// and never `since`, so generateUndo reverses every event on that row in an
+// unbounded window: the row lands where it was when the window opened. That
+// equals "the state just before this event" only when the event is the sole
+// one in range.
+//
+// The wording this pins replaced "Reverting this row to before this point",
+// which promised the single-event reading. The failure it hid is not
+// hypothetical: a row INSERTed and DELETEd inside the same second (WordPress
+// `_transient_doing_cron`) yields two reversals whose net effect is no row at
+// all — correct for the window, the opposite of what the banner announced.
+// Timestamps cannot separate same-second events, so `since` is no remedy
+// there; that is what exposing limit-per-pk on this surface is for.
+//
+// Comments are stripped before matching. The explanation above the banner in
+// app.js quotes the old wording, and served bytes include comments — matching
+// raw source would let the retired phrasing pass as long as someone left it in
+// a comment, and would fire on the explanation itself.
+func TestAppJSUndoBannerStatesWindowScope(t *testing.T) {
+	data, err := os.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := stripLineComments(string(data))
+
+	// (a) The retired promise must not come back. It is a single unsplit
+	// literal in the source it replaced, so this catches a straight revert.
+	for _, banned := range []string{
+		"Reverting this row to before this point",
+		"undoing changes up to ",
+	} {
+		if strings.Contains(js, banned) {
+			t.Errorf("assets/app.js reintroduces %q in the Undo banner.\n"+
+				"That phrasing promises the row is restored to its state just before the clicked event, "+
+				"but the prefill leaves `since` empty, so EVERY event on the row in the window is reversed. "+
+				"State the scope instead.", banned)
+		}
+	}
+
+	// (b) The eyebrow names the scope.
+	if !strings.Contains(js, "Undoing every change up to this point") {
+		t.Error("the Undo banner eyebrow no longer states that every change up to the clicked event is undone — " +
+			"without it the banner implies a single-event reversal that generateUndo does not perform")
+	}
+
+	// (c) The detail says the reversal is not limited to the clicked event.
+	// Asserted as the literal source fragment: the sentence is built by
+	// concatenation around ctx.type/ctx.time, so the whole sentence never
+	// appears contiguously and searching for it would pass vacuously.
+	if !strings.Contains(js, "not only that one") {
+		t.Error("the Undo banner detail dropped the clause distinguishing the whole window from the clicked event; " +
+			"a reader cannot tell how many events the generated script will reverse")
+	}
+
+	// (d) The remedy stays actionable and names a control that exists on this
+	// form. If the prefill ever bounds the window itself, this pairing is what
+	// should force the wording to be revisited.
+	if !strings.Contains(js, "set Since to narrow the window") {
+		t.Error("the Undo banner no longer points at Since — stating the window is wide without naming the way to narrow it " +
+			"leaves the operator with a warning and no action")
+	}
+}
+
+// stripLineComments removes whole-line // comments, leaving code and string
+// literals intact. Deliberately not a JS parser: it only has to keep the
+// explanatory comments in app.js out of substring assertions, and a line whose
+// trimmed form starts with "//" is never code.
+func stripLineComments(js string) string {
+	lines := strings.Split(js, "\n")
+	kept := lines[:0]
+	for _, ln := range lines {
+		if strings.HasPrefix(strings.TrimSpace(ln), "//") {
+			continue
+		}
+		kept = append(kept, ln)
+	}
+	return strings.Join(kept, "\n")
+}


### PR DESCRIPTION
The Restore context banner read **"Reverting this row to before this point"**.
`renderRecover`'s prefill fills `until` from the clicked event and never
`since`, so `generateUndo` reverses **every** event on that row in an unbounded
window — the row lands where it was when the window opened.

That equals "the state just before this event" only when the clicked event is
the sole one in range, which is why the wording survived: in the common case
the two readings coincide.

### Where they diverge

A row INSERTed and DELETEd inside the same second (WordPress
`_transient_doing_cron`) produces two reversals:

```
[397051] reverse DELETE ... -> INSERT INTO wordpress.dbt_options ...
[397037] reverse INSERT ... -> DELETE FROM wordpress.dbt_options WHERE option_id = 93563;
```

Net effect: **no row at all** — correct for the window, the opposite of what
the banner announced. Timestamps cannot separate same-second events, so
`since` is no remedy there; that is what #1387 (expose `limit-per-pk`) is for.
This PR is only about not promising something the generated script does not do.

### Change

| | |
|---|---|
| eyebrow | `Undoing every change up to this point` |
| detail | `reverses all events on this row through DELETE at … UTC, not only that one — set Since to narrow the window` |

`docs/console.md` says the same thing about the Undo entry point.

This picks the *reword* option from #1387's open question and leaves Undo's
whole-window default alone — exposing the control there stays additive, and
the guard's comment tells anyone who later bounds the prefill to revisit this
text.

### Guard

`TestAppJSUndoBannerStatesWindowScope` pins the retired phrases out and the
scope/remedy clauses in. Comments are stripped before matching: the
explanation above the banner quotes the old wording, and served bytes include
comments — a raw-source match would fire on the explanation *and* let the old
wording pass if someone parked it in a comment.

Verified by mutation, each assertion on its own site:

| mutation | guard |
|---|---|
| revert eyebrow to retired wording | fails ✓ |
| retired phrase a1 alone (eyebrow intact) | fails ✓ |
| retired phrase a2 alone | fails ✓ |
| drop `not only that one` | fails ✓ |
| drop `set Since to narrow the window` | fails ✓ |
| retired phrase in a **comment** only | passes ✓ (correctly does not fire) |

`node --check` clean on every mutation; `go test ./internal/console/` green;
`go vet -tags integration` clean.
