### PR TITLE
console: give baselines and verification their own Protect section

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -342,6 +342,36 @@ editing flags or restarting:
 - The standalone `bintrail-console serve` hides the panel and refuses the write
   (HTTP 403) — only the daemon running the loop consumes the policy.
 
+### The Protect pages
+
+Under `watch` the sidebar carries a **Protect** group with two pages. They were
+part of the Storage page until they outgrew it: both are operations that
+produce and validate the artifacts a restore depends on, rather than settings,
+and the snapshot listing is unbounded in practice — it pushed verification, the
+panel that answers whether a restore would work, far below the fold.
+
+**Protect → Baselines**
+
+- A read-only listing of the **selected server's** baseline source
+  (`baseline_dir` / `baseline_s3`): each snapshot's timestamp, age, table
+  count, and (local sources) the binlog coordinates its deltas start from. The
+  empty states explain how to produce a first baseline (`bintrail dump` →
+  `bintrail baseline`). When the **Create baseline** button is enabled it sits
+  in this panel's header.
+- **Automatic baseline refresh** — when `--baseline-refresh-interval` is set,
+  the panel reports the daemon's last automatic refresh for the selected
+  server: how many tables it published, or that it published nothing and why.
+  A refusal there is the fail-closed contract working (a capture gap, a schema
+  change), not a broken daemon — nothing was overwritten and the next run
+  retries. The refresh is opt-in on its own: it does not require, and does not
+  enable, the **Create baseline** button.
+
+**Protect → Verification** carries the verification runner and the history of
+past runs for the selected server.
+
+The Storage page keeps a compact **Baselines** summary card (count and age)
+alongside the rest of the storage picture.
+
 ### The Storage page
 
 Under `watch` the sidebar grows a **Settings → Storage** page that gathers
@@ -355,19 +385,6 @@ compact baseline summary card and links onward:
 - **S3 archiving per source** — every monitored server with its
   `Archive to S3` destination (or `drop-only` when none), with a shortcut into
   that server's edit form. The boot (cli) index always rotates drop-only.
-- **Baseline snapshots** — a read-only listing of the **selected server's**
-  baseline source (`baseline_dir` / `baseline_s3`): each snapshot's timestamp,
-  age, table count, and (local sources) the binlog coordinates its deltas
-  start from. The empty states explain how to produce a first baseline
-  (`bintrail dump` → `bintrail baseline`). When the **Create baseline** button
-  is enabled (see below) it sits in this panel's header.
-- **Automatic baseline refresh** — when `--baseline-refresh-interval` is set,
-  the Baseline snapshots panel reports the daemon's last automatic refresh for
-  the selected server: how many tables it published, or that it published
-  nothing and why. A refusal there is the fail-closed contract working (a
-  capture gap, a schema change), not a broken daemon — nothing was overwritten
-  and the next run retries. The refresh is opt-in on its own — it does not
-  require, and does not enable, the **Create baseline** button.
 - **Query in DuckDB** — a one-click download of `views.sql`: a ready-made
   DuckDB schema over the selected server's own Parquet — an `events` view
   across every archive source registered in `archive_state`, plus one
@@ -632,7 +649,7 @@ see the metrics tables and example alert rules in
   the upload come from the ambient chain (`AWS_*` / `~/.aws` / role).
 - `BINTRAIL_CONSOLE_BASELINE_TRIGGER` (`watch` only) — `1`/`true` enables the
   **Create baseline** button (runs `mydumper` → convert → upload in-process;
-  see [The Storage page](#the-storage-page)). Off by default for a bare
+  see [Protect → Baselines](#the-protect-pages)). Off by default for a bare
   `watch` invocation; the bundled compose stack sets this on by default (see
   [docker.md](docker.md) — `BASELINE_TRIGGER=0` in `.env` opts out there).
 - `BINTRAIL_CONSOLE_BASELINE_STAGING` (`watch` only) — local staging dir for

--- a/docs/console.md
+++ b/docs/console.md
@@ -144,9 +144,14 @@ and searching events:
    permanently lost" record when an unfillable gap (or a lost PostgreSQL slot)
    was detected. Both fire for any source family. See
    [the continuity signal](rotation-and-status.md#stream-continuity-no-data-lost).
-6. **Settings** (under `watch` only) — **Storage** (rotation policy,
-   per-source S3 archiving, baseline snapshots, AWS credential signals, and a
-   usage-telemetry opt-out — see
+6. **Protect** (under `watch` only) — **Baselines** (the selected server's
+   snapshot listing, plus **Create baseline**) and **Verification** (run
+   `bintrail verify` and read past runs). These produce and validate the
+   artifacts a restore depends on, so they are operations rather than
+   settings; they lived on the Storage page until they outgrew it.
+7. **Settings** (under `watch` only) — **Storage** (rotation policy,
+   per-source S3 archiving, a baseline summary card, AWS credential signals,
+   and a usage-telemetry opt-out — see
    [The Storage page](#the-storage-page)) and **Rotation** (opens the
    rotation dialog).
 
@@ -340,8 +345,10 @@ editing flags or restarting:
 ### The Storage page
 
 Under `watch` the sidebar grows a **Settings → Storage** page that gathers
-everything S3/baseline-related in one place (it was previously scattered
-across the rotation dialog and the per-server edit form):
+storage policy in one place (it was previously scattered across the rotation
+dialog and the per-server edit form). The full baseline listing and the
+verification runner moved to their own **Protect** group; Storage keeps a
+compact baseline summary card and links onward:
 
 - **Rotation** — the effective policy (override vs daemon defaults) with an
   edit shortcut to the rotation dialog.
@@ -436,7 +443,7 @@ ambient credential chain, scoped to the allowed prefixes.
 By default the console only *lists* baselines — you produce them with the
 `bintrail dump` → `bintrail baseline` CLI (or the compose `baseline` profile).
 A **Create baseline** button can run that pipeline for a monitored server
-straight from the Storage page, and it only runs on the `watch` daemon:
+straight from the **Protect → Baselines** page, and it only runs on the `watch` daemon:
 
 - A bare `watch` invocation (no compose) has this **opt-in** and off by
   default — start it with `BINTRAIL_CONSOLE_BASELINE_TRIGGER=1`. The bundled
@@ -652,7 +659,7 @@ see the metrics tables and example alert rules in
   [Running verification from the console](#running-verification-from-the-console)).
 - `BINTRAIL_CONSOLE_VERIFY_TABLES` (`watch` only) — same as `--verify-tables`.
 - `BINTRAIL_CONSOLE_VERIFY_TRIGGER` (`watch` only) — `1`/`true` enables the
-  Storage page's **Verification** panel (runs `bintrail verify` in-process;
+  **Protect → Verification** page (runs `bintrail verify` in-process;
   see [Running verification from the console](#running-verification-from-the-console)).
   Off by default for a bare `watch` invocation; the bundled compose stack sets
   this on by default (see [docker.md](docker.md) — `VERIFY_TRIGGER=0` in

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -413,13 +413,13 @@ reconstruct knows where deltas begin. Then point the console at it:
   in `.env` and `docker compose up -d` again.
 
 The console also has an in-process **Create baseline** button (in the sidebar
-under Settings → Storage, for the selected server) that runs the same
+under Protect → Baselines, for the selected server) that runs the same
 dump→convert→upload pipeline without the CLI profile — it's on by default in this compose stack;
 set `BASELINE_TRIGGER=0` in `.env` to disable it. The button still needs a
 source DSN and a baseline dir/S3 configured on the server before it does
 anything.
 
-The same Storage page also has a **Verification** panel (also on by default;
+**Protect → Verification** carries the verification runner (also on by default;
 `VERIFY_TRIGGER=0` in `.env` to disable) that runs `bintrail verify` in-process
 for the selected server — trigger a run, watch per-table match/mismatch/
 inconclusive results land, and drill into a mismatch — see

--- a/docs/dump-and-baseline.md
+++ b/docs/dump-and-baseline.md
@@ -427,7 +427,7 @@ Four properties are deliberate:
 - **Isolated from capture.** A failure is logged and retried; it can never take down the stream or the supervisor. A baseline that stopped refreshing is a degradation, a daemon that stopped capturing is an outage, and the first must never cause the second.
 - **Nothing is uploaded, so nothing is pruned.** A refreshed snapshot is written locally only, and `bintrail baseline prune` reclaims a snapshot only once it has confirmed a durable S3 copy of it — so snapshots this loop publishes accumulate, whether or not an S3 destination is configured. The loop says so at startup. Upload and prune them on your own schedule (`bintrail upload --source <baseline-dir> --destination s3://…`), or size the disk for one full-table snapshot per interval.
 
-It shares its single-flight with the console's **Create baseline** button, so a refresh and a dump never run against the same server at once. The last outcome per server shows up in the console's Storage page and in `GET /api/baselines`.
+It shares its single-flight with the console's **Create baseline** button, so a refresh and a dump never run against the same server at once. The last outcome per server shows up on the console's **Protect → Baselines** page and in `GET /api/baselines`.
 
 
 An S3-only baseline destination is skipped with a warning: a refresh reads and writes snapshot files on disk, so there is nothing for it to refresh in place.

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -49,7 +49,13 @@ const EVENT_EXPORT_MAX = 1000;
 const BADGE_CLASS = { UPDATE: "b-update", INSERT: "b-insert", DELETE: "b-delete" };
 function badgeClass(t) { return BADGE_CLASS[t] || "b-baseline"; }
 
-const ROUTES = ["overview", "events", "timetravel", "recover", "sql", "status", "storage", "connect"];
+const ROUTES = ["overview", "events", "timetravel", "recover", "sql", "status", "storage", "connect",
+  // Protect (#1384): baselines and verification used to be two of three panels
+  // on Settings > Storage. They are operations that produce and validate
+  // recovery artifacts, not settings, and the snapshot list is unbounded in
+  // practice — it pushed verification, the panel that answers "are my backups
+  // restorable", roughly two screens below the fold.
+  "baselines", "verification"];
 
 const MON_STATE_TITLES = {
   failed: "connection is failing and retrying automatically; press Start for details",
@@ -810,6 +816,10 @@ function navigate(route, params, push = true) {
   if (route === "timetravel") route = "recover";
   // Storage is a watch-daemon surface (rotation + archiving live there).
   if (route === "storage" && !capsCache.monitor) route = "overview";
+  // Protect shares that gate: both routes read watch-daemon state (the
+  // snapshot listing and the verification runner). Same treatment, so a
+  // bookmark to either lands on Overview rather than an empty page.
+  if ((route === "baselines" || route === "verification") && !capsCache.monitor) route = "overview";
   // The SQL panel is opt-in (BINTRAIL_CONSOLE_SQL_PANEL) and per-server gated.
   if (route === "sql" && !capsCache.sql) route = "overview";
   const qs = params && Object.keys(params).length
@@ -855,6 +865,8 @@ function renderRoute() {
     case "sql": return renderSQL();
     case "status": return renderStatus();
     case "storage": return renderStorage();
+    case "baselines": return renderBaselines();
+    case "verification": return renderVerification();
     case "connect": return renderConnect();
     default: return renderOverview();
   }
@@ -3206,12 +3218,73 @@ function buildStorage(serversRes, rotation, storage, baselines, telemetry) {
   cards.append(baselineSummaryCard(baselines, cur));
   v.append(cards);
 
+  // Storage keeps storage POLICY. Baselines and verification moved to their
+  // own routes (#1384): the snapshot list is unbounded, so it used to push
+  // verification off the fold, and verifyPanel needed a both-columns override
+  // to escape a grid built for two panels. baselineSummaryCard stays as the
+  // pointer — the count and age belong on a storage overview, the full list
+  // does not.
   const grid = el("div", { class: "ov-grid", style: "margin-top:18px" });
   grid.append(archivingPanel(servers, serversErr));
-  grid.append(baselinesPanel(baselines, servers));
-  grid.append(verifyPanel(servers));
   v.append(grid);
   viewEnter();
+}
+
+// ── Protect: baselines and verification (#1384) ──
+//
+// Both gate on capsCache.monitor and both use the replaceState + re-dispatch
+// pattern renderStorage/renderTimetravel share: a direct URL or Back with the
+// capability off must REWRITE the URL before re-rendering, or the address bar
+// keeps pointing at a view the session cannot show.
+
+async function renderBaselines() {
+  if (!capsCache.monitor) { history.replaceState({}, "", "/overview"); renderRoute(); return; }
+  const gen = serverGen, vgen = viewGen;
+  viewLoading();
+  // Independent degradation, as on Storage: a panel renders its own failure
+  // note rather than one error blanking the page.
+  const asErr = (err) => ({ error: (err && err.message) || String(err) });
+  const [serversRes, baselines] = await Promise.all([
+    api("/api/servers").catch(asErr),
+    api("/api/baselines").catch(asErr),
+  ]);
+  if (gen !== serverGen || vgen !== viewGen) return;
+  try {
+    const servers = (serversRes && serversRes.servers) || [];
+    const v = VIEW(); clear(v);
+    v.append(pageHead("Baselines", el("p", { class: "page-sub" },
+      "Full-table snapshots Time-travel and full restores are built from. ",
+      el("b", { text: "Nothing is ever executed" }), " against your source by viewing this page.")));
+    const cards = el("div", { class: "cards" });
+    cards.append(baselineSummaryCard(baselines, servers.find((s) => s.id === (currentServer || defaultServerId))));
+    v.append(cards);
+    const grid = el("div", { class: "ov-grid", style: "margin-top:18px" });
+    grid.append(baselinesPanel(baselines, servers));
+    v.append(grid);
+    viewEnter();
+  } catch (err) {
+    const v = VIEW(); clear(v); v.append(pageHead("Baselines", null)); renderError(v, err);
+  }
+}
+
+async function renderVerification() {
+  if (!capsCache.monitor) { history.replaceState({}, "", "/overview"); renderRoute(); return; }
+  const gen = serverGen, vgen = viewGen;
+  viewLoading();
+  const serversRes = await api("/api/servers").catch((err) => ({ error: (err && err.message) || String(err) }));
+  if (gen !== serverGen || vgen !== viewGen) return;
+  try {
+    const servers = (serversRes && serversRes.servers) || [];
+    const v = VIEW(); clear(v);
+    v.append(pageHead("Verification", el("p", { class: "page-sub" },
+      "Prove a snapshot still reconstructs what it claims — the check that answers whether a restore would actually work.")));
+    const grid = el("div", { class: "ov-grid", style: "margin-top:18px" });
+    grid.append(verifyPanel(servers));
+    v.append(grid);
+    viewEnter();
+  } catch (err) {
+    const v = VIEW(); clear(v); v.append(pageHead("Verification", null)); renderError(v, err);
+  }
 }
 
 function kvRow(card, k, val) {
@@ -3636,7 +3709,12 @@ async function createBaseline(id, btn) {
   } else {
     toast("Baseline still running — check back shortly.");
   }
-  if (location.pathname === "/storage") renderStorage();
+  // Create baseline now lives on /baselines (#1384) while the summary card
+  // still appears on /storage, so refresh whichever is on screen. Hardcoding
+  // /storage would leave the page that OWNS the button showing a stale list
+  // right after the run it started.
+  if (location.pathname === "/baselines") renderBaselines();
+  else if (location.pathname === "/storage") renderStorage();
 }
 
 // pollBaseline polls the per-server baseline status until it leaves "running"
@@ -3664,12 +3742,12 @@ async function pollBaseline(id) {
 // configured; verify_live_source: a source DSN is also configured), both
 // re-enforced server-side so this gating is UX only.
 function verifyPanel(servers) {
-  // Full-width: ov-grid is a 2-column grid (archiving | baselines) with
-  // align-items:start, and Baseline snapshots routinely runs much taller
-  // than S3 archiving (one row per snapshot) — a 3rd item left to the grid's
-  // normal auto-placement lands in row 2 col 1, floating under the SHORT
-  // sibling with a large dead gap to its right where the tall one still
-  // extends. Spanning both columns puts it in its own row instead.
+  // Full-width. This override was originally a workaround: verification was a
+  // third panel in a 2-column grid built for archiving | baselines, and with
+  // align-items:start it landed under the SHORT sibling with a dead gap beside
+  // the tall one. #1384 moved it to its own route, where it is the only panel,
+  // so the span is no longer compensating for anything — it is simply what a
+  // sole panel should do. Kept because the grid is still 2-column.
   const panel = el("section", { class: "ov-panel vfy-panel-full" });
   const cur = (servers || []).find((s) => s.id === (currentServer || defaultServerId));
   const head = el("div", { class: "ov-panel-head" }, el("h2", { class: "ov-panel-title", text: "Verification" }));

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -3168,7 +3168,7 @@ function updateSideMeta(status) {
   }
 }
 
-// ── Storage (rotation · S3 archiving · baselines · credentials) ──────────────
+// ── Storage (rotation · S3 archiving · credentials · telemetry) ──────────────
 
 async function renderStorage() {
   // Gated like Time-travel: a direct URL / Back with the capability off must
@@ -3215,7 +3215,7 @@ function buildStorage(serversRes, rotation, storage, baselines, telemetry) {
   cards.append(credentialsCard(storage));
   cards.append(telemetryCard(telemetry));
   if (capsCache.views) cards.append(duckdbCard());
-  cards.append(baselineSummaryCard(baselines, cur));
+  cards.append(baselineSummaryCard(baselines, cur, { linkOnward: true }));
   v.append(cards);
 
   // Storage keeps storage POLICY. Baselines and verification moved to their
@@ -3251,6 +3251,11 @@ async function renderBaselines() {
   if (gen !== serverGen || vgen !== viewGen) return;
   try {
     const servers = (serversRes && serversRes.servers) || [];
+    // A failed /api/servers must be REPORTED, not absorbed into an empty list:
+    // with servers=[] the Create baseline button silently disappears and the
+    // empty state advises "Add a server first" — on the page that owns the
+    // button. buildStorage keeps serversErr for the same reason.
+    const serversErr = serversRes && serversRes.error;
     const v = VIEW(); clear(v);
     v.append(pageHead("Baselines", el("p", { class: "page-sub" },
       "Full-table snapshots Time-travel and full restores are built from. ",
@@ -3258,6 +3263,7 @@ async function renderBaselines() {
     const cards = el("div", { class: "cards" });
     cards.append(baselineSummaryCard(baselines, servers.find((s) => s.id === (currentServer || defaultServerId))));
     v.append(cards);
+    if (serversErr) v.append(el("div", { class: "error-box", text: "Could not load servers: " + serversErr }));
     const grid = el("div", { class: "ov-grid", style: "margin-top:18px" });
     grid.append(baselinesPanel(baselines, servers));
     v.append(grid);
@@ -3275,11 +3281,15 @@ async function renderVerification() {
   if (gen !== serverGen || vgen !== viewGen) return;
   try {
     const servers = (serversRes && serversRes.servers) || [];
+    // Same reason as renderBaselines: swallowed, a transient 500 renders
+    // "Select a server to run verification" while a server IS selected.
+    const serversErr = serversRes && serversRes.error;
     const v = VIEW(); clear(v);
     v.append(pageHead("Verification", el("p", { class: "page-sub" },
       "Prove a snapshot still reconstructs what it claims — the check that answers whether a restore would actually work.")));
+    if (serversErr) v.append(el("div", { class: "error-box", text: "Could not load servers: " + serversErr }));
     const grid = el("div", { class: "ov-grid", style: "margin-top:18px" });
-    grid.append(verifyPanel(servers));
+    grid.append(verifyPanel(servers, { hideTitle: true }));
     v.append(grid);
     viewEnter();
   } catch (err) {
@@ -3522,16 +3532,30 @@ async function setTelemetry(enabled) {
   renderStorage();
 }
 
-function baselineSummaryCard(b, cur) {
+// On Storage this card is the POINTER to Protect > Baselines, so it carries a
+// link there — docs/console.md says it "links onward" and, before this, it did
+// not. On the Baselines page itself the link would point at the current page,
+// so the caller omits it.
+function baselineSummaryCard(b, cur, opts) {
   const card = el("div", { class: "card" }, el("div", { class: "card-title", text: "Baselines" }));
+  // Appended at every exit, so the link is the card's FOOT rather than sitting
+  // above an error message. Every branch returns through here.
+  const done = () => {
+    if (opts && opts.linkOnward) {
+      card.append(el("div", { class: "stg-cardfoot" },
+        el("button", { class: "btn btn-sm", type: "button", text: "All snapshots \u2192",
+          onclick: () => navigate("baselines") })));
+    }
+    return card;
+  };
   if (!b || b.error) {
     card.append(el("p", { class: "form-hint", text: "Could not list baselines: " + ((b && b.error) || "unavailable") }));
-    return card;
+    return done();
   }
   if (!b.configured) {
     kvRow(card, "source", "not configured");
     kvRow(card, "time-travel", "off");
-    return card;
+    return done();
   }
   const snaps = b.snapshots || [];
   kvRow(card, "source", b.source);
@@ -3539,7 +3563,7 @@ function baselineSummaryCard(b, cur) {
   kvRow(card, "latest (UTC)", snaps.length ? snaps[0].time : "none yet");
   if (snaps.length) kvRow(card, "age", formatAge(snaps[0].age_hours));
   kvRow(card, "time-travel", b.reconstruct ? "enabled" : "off (archives disabled)");
-  return card;
+  return done();
 }
 
 // baselineConfigHint: the boot (cli) entry is not editable from the UI — its
@@ -3741,7 +3765,12 @@ async function pollBaseline(id) {
 // baseline_trigger) plus a per-server precondition (verify: a baseline is
 // configured; verify_live_source: a source DSN is also configured), both
 // re-enforced server-side so this gating is UX only.
-function verifyPanel(servers) {
+// opts.hideTitle: /verification renders pageHead("Verification") already, and
+// an h1 immediately above an identical h2 is a duplicated landmark for anyone
+// navigating by heading. The parameter exists rather than deleting the head
+// outright because the head is also the panel's own append target in three
+// early-return branches.
+function verifyPanel(servers, opts) {
   // Full-width. This override was originally a workaround: verification was a
   // third panel in a 2-column grid built for archiving | baselines, and with
   // align-items:start it landed under the SHORT sibling with a dead gap beside
@@ -3750,7 +3779,8 @@ function verifyPanel(servers) {
   // sole panel should do. Kept because the grid is still 2-column.
   const panel = el("section", { class: "ov-panel vfy-panel-full" });
   const cur = (servers || []).find((s) => s.id === (currentServer || defaultServerId));
-  const head = el("div", { class: "ov-panel-head" }, el("h2", { class: "ov-panel-title", text: "Verification" }));
+  const head = el("div", { class: "ov-panel-head" });
+  if (!(opts && opts.hideTitle)) head.append(el("h2", { class: "ov-panel-title", text: "Verification" }));
   const list = el("div", { class: "stg-list vfy-list" });
 
   if (!capsCache.verify_trigger) {
@@ -5295,6 +5325,8 @@ function cmdkCommands() {
   ];
   if (capsCache.reconstruct) cmds.push({ group: "Navigate", label: "Time-travel", run: () => navigate("timetravel") });
   if (capsCache.sql) cmds.push({ group: "Navigate", label: "SQL", run: () => navigate("sql") });
+  if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Baselines", run: () => navigate("baselines") });
+  if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Verification", run: () => navigate("verification") });
   if (capsCache.monitor) cmds.push({ group: "Navigate", label: "Storage", run: () => navigate("storage") });
   cmds.push({ group: "Navigate", label: "Connect AI", run: () => navigate("connect") });
   cmds.push({ group: "Actions", label: "Manage servers", run: () => { closeCmdk(); openServersModal(); } });

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -3265,7 +3265,7 @@ async function renderBaselines() {
     v.append(cards);
     if (serversErr) v.append(el("div", { class: "error-box", text: "Could not load servers: " + serversErr }));
     const grid = el("div", { class: "ov-grid", style: "margin-top:18px" });
-    grid.append(baselinesPanel(baselines, servers));
+    grid.append(baselinesPanel(baselines, servers, { serversErr: serversErr }));
     v.append(grid);
     viewEnter();
   } catch (err) {
@@ -3289,7 +3289,7 @@ async function renderVerification() {
       "Prove a snapshot still reconstructs what it claims — the check that answers whether a restore would actually work.")));
     if (serversErr) v.append(el("div", { class: "error-box", text: "Could not load servers: " + serversErr }));
     const grid = el("div", { class: "ov-grid", style: "margin-top:18px" });
-    grid.append(verifyPanel(servers, { hideTitle: true }));
+    grid.append(verifyPanel(servers, { hideTitle: true, serversErr: serversErr }));
     v.append(grid);
     viewEnter();
   } catch (err) {
@@ -3570,7 +3570,10 @@ function baselineSummaryCard(b, cur, opts) {
 // baseline comes only from --baseline-dir/--baseline-s3 (or the BINTRAIL_
 // CONSOLE_BASELINE_DIR/_S3 env; BASELINE_DIR in the compose stack) — so the
 // "edit the server" instruction would point it at a dead end.
-function baselineConfigHint(cur) {
+function baselineConfigHint(cur, serversErr) {
+  // A failed server list is not an empty one. "Add a server first" told an
+  // operator who has servers to create another, and hid the real cause.
+  if (serversErr) return "The server list could not be loaded (" + serversErr + "), so this cannot be checked.";
   if (!cur) return "Add a server first (Manage servers).";
   if (cur.kind === "ephemeral") {
     return "Restart the daemon with --baseline-dir or --baseline-s3 (compose: BASELINE_DIR in .env).";
@@ -3639,11 +3642,18 @@ function baselineRefreshNote(rf) {
   return el("p", { class: "form-hint", text: text });
 }
 
-function baselinesPanel(b, servers) {
+// opts.serversErr: when /api/servers failed, `servers` is empty for the WRONG
+// reason. Without it this panel derives affirmative claims from a failure —
+// the Create baseline button vanishes with no stated cause, and the `owner`
+// fallback below attributes the snapshots to the daemon when the selected
+// server may have its own baseline_s3.
+function baselinesPanel(b, servers, opts) {
   const panel = el("section", { class: "ov-panel" });
   const cur = (servers || []).find((s) => s.id === (currentServer || defaultServerId));
   let owner = cur ? serverLabel(cur) : "";
-  if (!owner && b && !b.error && b.configured) owner = "daemon (--baseline-dir / --baseline-s3)";
+  if (!owner && b && !b.error && b.configured && !(opts && opts.serversErr)) {
+    owner = "daemon (--baseline-dir / --baseline-s3)";
+  }
   const head = el("div", { class: "ov-panel-head" },
     el("h2", { class: "ov-panel-title", text: "Baseline snapshots" + (owner ? " — " + owner : "") }),
     tzChip());
@@ -3675,7 +3685,7 @@ function baselinesPanel(b, servers) {
       el("p", { class: "stg-empty-sub", text: "A baseline is a full copy of your table at one point in time. With one, Time-travel can show complete rows — not just the ones that changed recently." }),
       el("p", { class: "stg-empty-sub", text: "1. Create snapshots:" }),
       el("code", { class: "stg-code", text: "docker compose --profile baseline run --rm baseline" }),
-      el("p", { class: "stg-empty-sub", text: "2. " + baselineConfigHint(cur) })));
+      el("p", { class: "stg-empty-sub", text: "2. " + baselineConfigHint(cur, opts && opts.serversErr) })));
   } else if (!(b.snapshots || []).length) {
     list.append(el("div", { class: "stg-empty" },
       el("p", { class: "stg-empty-lead", text: "Source configured, no snapshots found." }),
@@ -3737,8 +3747,9 @@ async function createBaseline(id, btn) {
   // still appears on /storage, so refresh whichever is on screen. Hardcoding
   // /storage would leave the page that OWNS the button showing a stale list
   // right after the run it started.
+  // Only /baselines: the Create baseline button lives in baselinesPanel, which
+  // no longer renders on Storage, so a /storage arm here would be unreachable.
   if (location.pathname === "/baselines") renderBaselines();
-  else if (location.pathname === "/storage") renderStorage();
 }
 
 // pollBaseline polls the per-server baseline status until it leaves "running"
@@ -3792,7 +3803,13 @@ function verifyPanel(servers, opts) {
     return panel;
   }
   if (!cur || !cur.id) {
-    list.append(el("div", { class: "ev-empty", text: "Select a server to run verification." }));
+    // A failed /api/servers arrives here as an empty list, and "Select a
+    // server" is then an instruction to do something the operator already did.
+    // archivingPanel takes serversErr for exactly this reason; prepending an
+    // error box above the panel does not stop the panel from contradicting it.
+    list.append(el("div", { class: "ev-empty", text: (opts && opts.serversErr)
+      ? "Could not load the server list, so verification cannot target one: " + opts.serversErr
+      : "Select a server to run verification." }));
     panel.append(head, list);
     return panel;
   }

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -82,6 +82,25 @@
             <span>Status</span>
           </a>
         </div>
+        <!-- Protect group (#1384). Baselines and verification used to be two of
+             three panels on Settings > Storage, which was a category error —
+             Create baseline and Run verification are operations that produce
+             and validate recovery artifacts, not settings — and a layout
+             problem: the snapshot list is unbounded, so it pushed verification
+             far below the fold. Same per-item monitor gate as Storage: both
+             read watch-daemon state, so on a standalone serve the whole group
+             collapses to nothing rather than showing dead entries. -->
+        <div class="nav-group">
+          <div class="nav-label">Protect</div>
+          <a class="nav-item" data-route="baselines" href="/baselines" data-capability="monitor">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 3 7l9 5 9-5-9-5z"/><path d="m3 12 9 5 9-5"/><path d="m3 17 9 5 9-5"/></svg></span>
+            <span>Baselines</span>
+          </a>
+          <a class="nav-item" data-route="verification" href="/verification" data-capability="monitor">
+            <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3 4 6v6c0 4.4 3.2 8.2 8 9 4.8-.8 8-4.6 8-9V6l-8-3z"/><path d="m9 12 2 2 4-4"/></svg></span>
+            <span>Verification</span>
+          </a>
+        </div>
         <!-- Settings group. Storage and Rotation exist only on the watch
              daemon (the process that runs rotation and archiving) — gated
              per-item like the Time-travel item, so the always-available

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -88,9 +88,15 @@
              and validate recovery artifacts, not settings — and a layout
              problem: the snapshot list is unbounded, so it pushed verification
              far below the fold. Same per-item monitor gate as Storage: both
-             read watch-daemon state, so on a standalone serve the whole group
-             collapses to nothing rather than showing dead entries. -->
-        <div class="nav-group">
+             read watch-daemon state. The gate is on the GROUP, not per item:
+             every member is monitor-gated, so per-item gating would leave a
+             bare "Protect" heading with nothing under it on a standalone
+             serve — and on every console for the duration of the boot
+             capabilities fetch. (Settings is per-item for the opposite
+             reason: Connect AI is always visible, so its group must survive.)
+             The [data-capability]:not(.cap-on) rule and the $all sweep are
+             both element-agnostic, so this works unchanged. -->
+        <div class="nav-group" data-capability="monitor">
           <div class="nav-label">Protect</div>
           <a class="nav-item" data-route="baselines" href="/baselines" data-capability="monitor">
             <span class="ni-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 3 7l9 5 9-5-9-5z"/><path d="m3 12 9 5 9-5"/><path d="m3 17 9 5 9-5"/></svg></span>

--- a/internal/console/assets_nav_routes_test.go
+++ b/internal/console/assets_nav_routes_test.go
@@ -1,0 +1,96 @@
+package console
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var navRouteRE = regexp.MustCompile(`data-route="([a-z-]+)"`)
+
+// Every nav entry must name a route the router knows.
+//
+// The failure this prevents is silent: navigate() falls back to "overview" for
+// an unknown route, so a sidebar link with a typo'd or retired data-route
+// still renders a page — the wrong one — with no error anywhere. #1384 added
+// two routes across two files, which is exactly the shape that drifts.
+func TestNavEntriesNameKnownRoutes(t *testing.T) {
+	html, err := os.ReadFile("assets/index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	js, err := os.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	routes := parseRoutesConst(t, string(js))
+	dispatch := string(js)
+
+	matches := navRouteRE.FindAllStringSubmatch(string(html), -1)
+	if len(matches) == 0 {
+		t.Fatal("no data-route attributes found in assets/index.html — the selector this guard " +
+			"depends on changed, so it is no longer checking anything")
+	}
+	for _, m := range matches {
+		route := m[1]
+		if !routes[route] {
+			t.Errorf("nav entry data-route=%q is not in the ROUTES list in app.js — navigate() "+
+				"silently falls back to Overview, so this link would render the wrong page with no error", route)
+		}
+		// A route in ROUTES with no dispatch arm renders Overview too, via the
+		// switch default. Both halves must exist for a nav entry to work.
+		if !strings.Contains(dispatch, `case "`+route+`":`) {
+			t.Errorf("route %q has a nav entry but no case in renderRoute's switch — it would "+
+				"fall through to the default and render Overview", route)
+		}
+	}
+
+	// The Protect group specifically: it is the one whose panels were moved out
+	// of another view, so a half-revert (nav removed, routes left, or vice
+	// versa) is plausible.
+	for _, want := range []string{"baselines", "verification"} {
+		if !routes[want] {
+			t.Errorf("route %q is missing from ROUTES", want)
+		}
+		if !strings.Contains(string(html), `data-route="`+want+`"`) {
+			t.Errorf("no nav entry for route %q — the view exists but nothing links to it", want)
+		}
+	}
+}
+
+// parseRoutesConst reads the ROUTES array literal out of app.js. Parsing the
+// source rather than hardcoding the list keeps this guard honest: a hardcoded
+// copy would drift from the thing it claims to check.
+func parseRoutesConst(t *testing.T, js string) map[string]bool {
+	t.Helper()
+	const marker = "const ROUTES = ["
+	i := strings.Index(js, marker)
+	if i < 0 {
+		t.Fatal("could not find the ROUTES declaration in assets/app.js")
+	}
+	rest := js[i+len(marker):]
+	j := strings.Index(rest, "]")
+	if j < 0 {
+		t.Fatal("unterminated ROUTES array in assets/app.js")
+	}
+	out := map[string]bool{}
+	for _, part := range strings.Split(rest[:j], ",") {
+		// Strip whitespace, comments and quotes. Entries may be spread over
+		// several lines with // comments between them.
+		for _, line := range strings.Split(part, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "//") {
+				continue
+			}
+			if name := strings.Trim(line, `"' `); name != "" {
+				out[name] = true
+			}
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("parsed zero routes from the ROUTES array — the parser broke, not the code")
+	}
+	return out
+}

--- a/internal/console/assets_nav_routes_test.go
+++ b/internal/console/assets_nav_routes_test.go
@@ -9,6 +9,9 @@ import (
 
 var navRouteRE = regexp.MustCompile(`data-route="([a-z-]+)"`)
 
+// Route names as they appear in the ROUTES array: quoted, lowercase, no spaces.
+var routeLiteralRE = regexp.MustCompile(`"([a-z-]+)"`)
+
 // Every nav entry must name a route the router knows.
 //
 // The failure this prevents is silent: navigate() falls back to "overview" for
@@ -26,7 +29,12 @@ func TestNavEntriesNameKnownRoutes(t *testing.T) {
 	}
 
 	routes := parseRoutesConst(t, string(js))
-	dispatch := string(js)
+	// Scoped to renderRoute. A file-wide search for `case "x":` passes when the
+	// arm is deleted from the router and an unrelated switch happens to carry
+	// the same case label — demonstrated by the reviewer, who removed the real
+	// arm, added one elsewhere, and watched this go green while the failure
+	// message still said "no case in renderRoute's switch".
+	dispatch := renderRouteBody(t, string(js))
 
 	matches := navRouteRE.FindAllStringSubmatch(string(html), -1)
 	if len(matches) == 0 {
@@ -60,9 +68,30 @@ func TestNavEntriesNameKnownRoutes(t *testing.T) {
 	}
 }
 
+// renderRouteBody returns the body of renderRoute's dispatch switch.
+func renderRouteBody(t *testing.T, js string) string {
+	t.Helper()
+	i := strings.Index(js, "function renderRoute(")
+	if i < 0 {
+		t.Fatal("renderRoute is gone from assets/app.js — this guard covers nothing")
+	}
+	rest := js[i:]
+	if j := strings.Index(rest, "\nfunction "); j > 0 {
+		rest = rest[:j]
+	}
+	return rest
+}
+
 // parseRoutesConst reads the ROUTES array literal out of app.js. Parsing the
 // source rather than hardcoding the list keeps this guard honest: a hardcoded
 // copy would drift from the thing it claims to check.
+//
+// Comments are stripped per line BEFORE splitting. Without that the splitter
+// treats commas inside the explanatory comment as separators and accepts prose
+// fragments as route names — the reviewer measured 14 "routes" parsed from an
+// array of 10, four of them sentence fragments. That also made the
+// len(out) == 0 tripwire dead: emptying the array entirely still parsed four
+// entries, so the "parser broke, not the code" check could never fire.
 func parseRoutesConst(t *testing.T, js string) map[string]bool {
 	t.Helper()
 	const marker = "const ROUTES = ["
@@ -75,19 +104,17 @@ func parseRoutesConst(t *testing.T, js string) map[string]bool {
 	if j < 0 {
 		t.Fatal("unterminated ROUTES array in assets/app.js")
 	}
-	out := map[string]bool{}
-	for _, part := range strings.Split(rest[:j], ",") {
-		// Strip whitespace, comments and quotes. Entries may be spread over
-		// several lines with // comments between them.
-		for _, line := range strings.Split(part, "\n") {
-			line = strings.TrimSpace(line)
-			if line == "" || strings.HasPrefix(line, "//") {
-				continue
-			}
-			if name := strings.Trim(line, `"' `); name != "" {
-				out[name] = true
-			}
+	var code strings.Builder
+	for _, line := range strings.Split(rest[:j], "\n") {
+		if c := strings.Index(line, "//"); c >= 0 {
+			line = line[:c]
 		}
+		code.WriteString(line)
+		code.WriteString("\n")
+	}
+	out := map[string]bool{}
+	for _, m := range routeLiteralRE.FindAllStringSubmatch(code.String(), -1) {
+		out[m[1]] = true
 	}
 	if len(out) == 0 {
 		t.Fatal("parsed zero routes from the ROUTES array — the parser broke, not the code")

--- a/internal/console/assets_nav_routes_test.go
+++ b/internal/console/assets_nav_routes_test.go
@@ -49,9 +49,19 @@ func TestNavEntriesNameKnownRoutes(t *testing.T) {
 		}
 		// A route in ROUTES with no dispatch arm renders Overview too, via the
 		// switch default. Both halves must exist for a nav entry to work.
-		if !strings.Contains(dispatch, `case "`+route+`":`) {
-			t.Errorf("route %q has a nav entry but no case in renderRoute's switch — it would "+
-				"fall through to the default and render Overview", route)
+		arm := regexp.MustCompile(`case "` + regexp.QuoteMeta(route) + `":\s*return (\w+)\(`)
+		m := arm.FindStringSubmatch(dispatch)
+		if m == nil {
+			t.Errorf("route %q has a nav entry but no `case \"%s\": return …()` in renderRoute's "+
+				"switch — it would fall through to the default and render Overview", route, route)
+			continue
+		}
+		// The arm naming a function does not mean the function exists. Deleting
+		// the renderer leaves the switch intact, so a text guard on the case
+		// alone passes and the route throws at runtime.
+		if fn := m[1]; !strings.Contains(string(js), "function "+fn+"(") {
+			t.Errorf("route %q dispatches to %s(), which is not defined in app.js — the route would "+
+				"throw instead of rendering", route, fn)
 		}
 	}
 

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1436,8 +1436,13 @@ try {
   ok("protect: /baselines renders the snapshot panel");
 
   await page.evaluate(() => navigate("verification"));
+  // NOT .ov-panel-title: the page suppresses the panel's own h2 (hideTitle) so
+  // it does not sit under an identical h1, which makes that selector
+  // unsatisfiable here. Anchor on the page heading and the mode control — the
+  // things whose absence would mean the route did not render.
   await page.waitForFunction(() => location.pathname === "/verification"
-    && Array.from(document.querySelectorAll(".ov-panel-title")).some((h) => /Verification/.test(h.textContent)),
+    && Array.from(document.querySelectorAll("h1.page-title")).some((h) => /Verification/.test(h.textContent))
+    && document.querySelector(".vfy-panel-full") !== null,
     { timeout: 10000 });
   ok("protect: /verification renders the verification panel");
 

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1365,11 +1365,12 @@ try {
     ? ok("overview: a failed aggregate shows no number, never a zero")
     : bad("overview: a failed aggregate shows no number, never a zero", JSON.stringify(ov.missing));
 
-  // Scenario 15b — Storage page live (#686): with the daemon opted in
-  // (BINTRAIL_CONSOLE_BASELINE_TRIGGER=1) and this server baseline-configured,
-  // the Create-baseline button must render enabled, and the fixture snapshot
-  // (1 table, anchored at binlog.000001:50) must be listed.
-  await page.evaluate(() => navigate("storage"));
+  // Scenario 15b — Baselines page live (#686, moved off Storage by #1384):
+  // with the daemon opted in (BINTRAIL_CONSOLE_BASELINE_TRIGGER=1) and this
+  // server baseline-configured, the Create-baseline button must render
+  // enabled, and the fixture snapshot (1 table, anchored at
+  // binlog.000001:50) must be listed.
+  await page.evaluate(() => navigate("baselines"));
   await page.waitForFunction(() => Array.from(document.querySelectorAll(".stg-row")).some((r) => r.textContent.includes("binlog.000001:50")), { timeout: 10000 });
   const stg = await page.evaluate(() => {
     const heads = Array.from(document.querySelectorAll(".ov-panel-head"));
@@ -1378,9 +1379,9 @@ try {
     const row = Array.from(document.querySelectorAll(".stg-row")).find((r) => r.textContent.includes("binlog.000001:50"));
     return { capOn: !!capsCache.baseline_trigger, btnPresent: !!btn, btnEnabled: btn ? !btn.disabled : false, rowText: row ? row.textContent : "" };
   });
-  stg.capOn ? ok("storage: baseline_trigger capability reaches the frontend") : bad("storage: baseline_trigger capability reaches the frontend", "capsCache.baseline_trigger falsy");
-  (stg.btnPresent && stg.btnEnabled) ? ok("storage: Create-baseline button renders enabled when both gates pass") : bad("storage: Create-baseline button renders enabled when both gates pass", `present=${stg.btnPresent} enabled=${stg.btnEnabled}`);
-  stg.rowText.includes("1 table(s)") ? ok("storage: the fixture snapshot is listed with its table count") : bad("storage: the fixture snapshot is listed with its table count", stg.rowText);
+  stg.capOn ? ok("baselines: baseline_trigger capability reaches the frontend") : bad("baselines: baseline_trigger capability reaches the frontend", "capsCache.baseline_trigger falsy");
+  (stg.btnPresent && stg.btnEnabled) ? ok("baselines: Create-baseline button renders enabled when both gates pass") : bad("baselines: Create-baseline button renders enabled when both gates pass", `present=${stg.btnPresent} enabled=${stg.btnEnabled}`);
+  stg.rowText.includes("1 table(s)") ? ok("baselines: the fixture snapshot is listed with its table count") : bad("baselines: the fixture snapshot is listed with its table count", stg.rowText);
 
   // Scenario 15c — the button's other gate arms, fixture-driven through the
   // REAL baselinesPanel (destination-missing can't exist live once the daemon
@@ -1405,11 +1406,50 @@ try {
     };
   });
   (!gates.cfgOffBtn && gates.cfgOffEmpty)
-    ? ok("storage: no baseline destination → no button, setup empty state")
-    : bad("storage: no baseline destination → no button, setup empty state", JSON.stringify(gates));
+    ? ok("baselines: no baseline destination → no button, setup empty state")
+    : bad("baselines: no baseline destination → no button, setup empty state", JSON.stringify(gates));
   (!gates.capOffBtn && gates.capOffEmpty)
-    ? ok("storage: baseline_trigger off → no button even with a destination")
-    : bad("storage: baseline_trigger off → no button even with a destination", JSON.stringify(gates));
+    ? ok("baselines: baseline_trigger off → no button even with a destination")
+    : bad("baselines: baseline_trigger off → no button even with a destination", JSON.stringify(gates));
+
+  // Scenario 15d — Protect group (#1384). Baselines and verification moved off
+  // Settings > Storage into their own routes. Two halves must hold TOGETHER,
+  // and only the first is obvious: each route renders its panel, AND Storage
+  // no longer carries it. A move that left a copy behind would sail past a
+  // "does /baselines work" check — which is the shape of the regression 15b
+  // caught when this scenario did not exist.
+  //
+  // waitForFunction rather than a sleep: renderBaselines awaits two fetches,
+  // and a fixed delay is the classic way this suite goes intermittently red.
+  const protectNav = await page.evaluate(() => ({
+    baselines: !!document.querySelector('.nav-item[data-route="baselines"]'),
+    verification: !!document.querySelector('.nav-item[data-route="verification"]'),
+  }));
+  (protectNav.baselines && protectNav.verification)
+    ? ok("protect: both nav entries render")
+    : bad("protect: both nav entries render", JSON.stringify(protectNav));
+
+  await page.evaluate(() => navigate("baselines"));
+  await page.waitForFunction(() => location.pathname === "/baselines"
+    && Array.from(document.querySelectorAll(".ov-panel-title")).some((h) => /Baseline snapshots/.test(h.textContent)),
+    { timeout: 10000 });
+  ok("protect: /baselines renders the snapshot panel");
+
+  await page.evaluate(() => navigate("verification"));
+  await page.waitForFunction(() => location.pathname === "/verification"
+    && Array.from(document.querySelectorAll(".ov-panel-title")).some((h) => /Verification/.test(h.textContent)),
+    { timeout: 10000 });
+  ok("protect: /verification renders the verification panel");
+
+  await page.evaluate(() => navigate("storage"));
+  await page.waitForFunction(() => location.pathname === "/storage"
+    && Array.from(document.querySelectorAll(".ov-panel-title")).some((h) => /S3 archiving/.test(h.textContent)),
+    { timeout: 10000 });
+  const storageTitles = await page.evaluate(() =>
+    Array.from(document.querySelectorAll(".ov-panel-title")).map((h) => h.textContent));
+  (!storageTitles.some((t) => /Baseline snapshots|Verification/.test(t)))
+    ? ok("protect: Storage no longer carries the moved panels")
+    : bad("protect: Storage no longer carries the moved panels", JSON.stringify(storageTitles));
 
   // Scenario 16 — Restore Table combobox (#1364). The Table field must be an
   // input + datalist fed from /api/schemas?schema=… (the same endpoint the


### PR DESCRIPTION
Closes #1384.

`Settings › Storage` carried three unrelated concerns:

| concern | panels |
|---|---|
| storage policy | rotation, credentials, telemetry, DuckDB views, S3 archiving |
| backup lifecycle | snapshot listing + **Create baseline** |
| recovery assurance | Verification + **Run verification** |

### The page had already been patched around the mismatch

`verifyPanel` carried a both-columns override whose own comment explained
that a third panel in a 2-column grid lands under the *short* sibling with a
dead gap beside the tall one. That is an information-architecture problem
wearing a CSS fix.

With the snapshot list unbounded in practice (20 rows on a modest install),
Verification — the panel that answers *"would a restore actually work"* — sat
roughly two screens below the fold, with the left column empty above it.

### Change

**Baselines** and **Verification** are now their own routes under a new
**Protect** nav group, beside Investigate / Resolve / Monitor. Storage keeps
storage policy plus the compact baseline summary card as the pointer.

- Gating is **per-item** on `capsCache.monitor`, matching Storage: both read
  watch-daemon state, so on a standalone `serve` the group collapses to
  nothing rather than showing dead entries.
- Both routes use the `replaceState` + re-dispatch pattern
  `renderStorage`/`renderTimetravel` share, so a deep link with the capability
  off rewrites the URL instead of leaving the address bar on an unreachable
  view.
- The post-run refresh moved with the button: completing a baseline used to
  re-render `/storage` unconditionally, which would now leave the page that
  *owns* the button stale. Verification refreshes through DOM lookups and is
  route-agnostic, so it needed no change.

### Guard

`TestNavEntriesNameKnownRoutes` pins the nav markup against the router. The
failure it prevents is silent: `navigate()` falls back to `overview` for an
unknown route, so a typo'd or retired `data-route` still renders a page — the
wrong one — with no error. Every `data-route` must be in `ROUTES` **and** have
a dispatch arm; `ROUTES` is parsed out of `app.js` rather than duplicated, so
the guard cannot drift from the thing it checks.

Mutation-verified:

| mutation | guard |
|---|---|
| typo in a nav `data-route` | fails ✓ |
| route dropped from `ROUTES`, nav kept | fails ✓ |
| dispatch arm removed, route + nav kept | fails ✓ |
| nav entry deleted for an existing route | fails ✓ |

`go test ./internal/console/` green, `go vet -tags integration` clean,
`node --check` clean, `gofmt` clean. `docs/console.md` updated, including the
three stale "from the Storage page" references to the moved controls.
