### PR TITLE
console: first motion pass — tiles that arrive, nav that responds

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1086,47 +1086,6 @@ function ovPendingCard(title, waiting, cls) {
   return card;
 }
 
-// countUpText animates a numeric tile from 0 to its value, then writes the
-// EXACT original string so the final DOM is byte-identical to the static
-// render — anything reading the tile after the animation (a test, a
-// screenshot, assistive tech) sees what it would have seen without it.
-//
-// Refuses anything that is not a plain non-negative integer. Tiles also carry
-// timestamps and "—", and "counting up" to a date is nonsense; re-formatting a
-// value the caller already formatted would be worse, since this function does
-// not know whether a separator is a thousands mark or part of an identifier.
-//
-// Skipped entirely under prefers-reduced-motion, and abandoned if the node
-// leaves the document mid-flight — Overview replaces tiles as fetches land, so
-// a stale animation could otherwise write into a detached node forever.
-function countUpText(node, value) {
-  const s = String(value);
-  if (!/^\d+$/.test(s)) return;
-  const target = Number(s);
-  // Below this a count-up is a flicker, not an animation.
-  if (!isFinite(target) || target < 10) return;
-  if (window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
-
-  const DUR = 620;
-  let t0 = null;
-  const step = (ts) => {
-    if (!node.isConnected) return;
-    if (t0 === null) t0 = ts;
-    const p = Math.min(1, (ts - t0) / DUR);
-    // easeOutCubic: fast first, settling — reads as the number arriving
-    // rather than being scrubbed.
-    const eased = 1 - Math.pow(1 - p, 3);
-    if (p < 1) {
-      node.textContent = String(Math.round(target * eased));
-      requestAnimationFrame(step);
-    } else {
-      node.textContent = s;
-    }
-  };
-  node.textContent = "0";
-  requestAnimationFrame(step);
-}
-
 // ovStatPending: one tile in its loading state — key and scope already legible,
 // value shimmering.
 function ovStatPending(key, scope) {
@@ -1347,15 +1306,14 @@ function buildOverview(status, eventsData, coverage, activity) {
 // all-time total from a window count — which is precisely how "53 deletes" got
 // read as a share of "3121 changes indexed" (#1300).
 function ovStat(value, key, mod, scope) {
-  const valEl = el("div", { class: "ov-stat-v" + (mod ? " " + mod : ""), text: value });
-  // The tile's value counts up as it lands (#1385). Motion only — the number's
-  // COLOR is left alone on purpose: the deletes tile is .danger/--delete, and
-  // the semantic INSERT/UPDATE/DELETE mapping must not be repainted for
-  // decoration. countUpText is a no-op for anything that is not a plain
-  // integer (timestamps, "—") and under reduced motion.
-  countUpText(valEl, value);
+  // Tiles animate their ARRIVAL (a rise, in style.css), never their VALUE. A
+  // count-up was tried and removed: it writes intermediate numbers into the
+  // DOM, so for the length of the animation the tile states something untrue —
+  // the console-e2e read "0" from the deletes tile mid-flight. A forensics
+  // surface that briefly reports zero deletions is a small lie, and the
+  // entrance animation already supplies the sense of arrival without one.
   return el("div", { class: "ov-stat" },
-    valEl,
+    el("div", { class: "ov-stat-v" + (mod ? " " + mod : ""), text: value }),
     el("div", { class: "ov-stat-k", text: key }),
     el("div", { class: "ov-stat-scope", text: scope || "" }));
 }

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1086,6 +1086,47 @@ function ovPendingCard(title, waiting, cls) {
   return card;
 }
 
+// countUpText animates a numeric tile from 0 to its value, then writes the
+// EXACT original string so the final DOM is byte-identical to the static
+// render — anything reading the tile after the animation (a test, a
+// screenshot, assistive tech) sees what it would have seen without it.
+//
+// Refuses anything that is not a plain non-negative integer. Tiles also carry
+// timestamps and "—", and "counting up" to a date is nonsense; re-formatting a
+// value the caller already formatted would be worse, since this function does
+// not know whether a separator is a thousands mark or part of an identifier.
+//
+// Skipped entirely under prefers-reduced-motion, and abandoned if the node
+// leaves the document mid-flight — Overview replaces tiles as fetches land, so
+// a stale animation could otherwise write into a detached node forever.
+function countUpText(node, value) {
+  const s = String(value);
+  if (!/^\d+$/.test(s)) return;
+  const target = Number(s);
+  // Below this a count-up is a flicker, not an animation.
+  if (!isFinite(target) || target < 10) return;
+  if (window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+  const DUR = 620;
+  let t0 = null;
+  const step = (ts) => {
+    if (!node.isConnected) return;
+    if (t0 === null) t0 = ts;
+    const p = Math.min(1, (ts - t0) / DUR);
+    // easeOutCubic: fast first, settling — reads as the number arriving
+    // rather than being scrubbed.
+    const eased = 1 - Math.pow(1 - p, 3);
+    if (p < 1) {
+      node.textContent = String(Math.round(target * eased));
+      requestAnimationFrame(step);
+    } else {
+      node.textContent = s;
+    }
+  };
+  node.textContent = "0";
+  requestAnimationFrame(step);
+}
+
 // ovStatPending: one tile in its loading state — key and scope already legible,
 // value shimmering.
 function ovStatPending(key, scope) {
@@ -1306,8 +1347,15 @@ function buildOverview(status, eventsData, coverage, activity) {
 // all-time total from a window count — which is precisely how "53 deletes" got
 // read as a share of "3121 changes indexed" (#1300).
 function ovStat(value, key, mod, scope) {
+  const valEl = el("div", { class: "ov-stat-v" + (mod ? " " + mod : ""), text: value });
+  // The tile's value counts up as it lands (#1385). Motion only — the number's
+  // COLOR is left alone on purpose: the deletes tile is .danger/--delete, and
+  // the semantic INSERT/UPDATE/DELETE mapping must not be repainted for
+  // decoration. countUpText is a no-op for anything that is not a plain
+  // integer (timestamps, "—") and under reduced motion.
+  countUpText(valEl, value);
   return el("div", { class: "ov-stat" },
-    el("div", { class: "ov-stat-v" + (mod ? " " + mod : ""), text: value }),
+    valEl,
     el("div", { class: "ov-stat-k", text: key }),
     el("div", { class: "ov-stat-scope", text: scope || "" }));
 }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1877,3 +1877,44 @@ button { font-family: inherit; }
   white-space: nowrap; max-width: 46ch; overflow: hidden; text-overflow: ellipsis;
 }
 .sql-table th { color: var(--ink-2); font-weight: 600; position: sticky; top: 0; background: var(--surface); }
+
+/* ============================================================
+   Motion: chrome only (#1385)
+
+   The console is opened when something has gone wrong — someone is tracing a
+   bad DELETE. Delight lives in the chrome: navigation, tiles, headers.
+   Data surfaces (rows, diffs, badges, the numbers under inspection) stay calm
+   and are deliberately untouched here.
+
+   Two rules this section must keep:
+   - No color moves. The semantic INSERT/UPDATE/DELETE tokens and the brand
+     palette's "never encode data" boundary are set above and stay set; every
+     rule below animates transform, opacity or shadow only.
+   - Everything is inside prefers-reduced-motion: no-preference, following the
+     pattern the rest of this file already uses. With motion off the page must
+     lose nothing but the movement.
+   ============================================================ */
+
+/* Transitions live OUTSIDE the media query on purpose: a hover lift with
+   motion reduced should still change state, just instantly. Only the
+   transition timing is motion; the state change is feedback. */
+.ov-stat { transition: transform .22s var(--ease), box-shadow .22s var(--ease); }
+
+@media (prefers-reduced-motion: no-preference) {
+  /* Tiles rise as their fetch lands. No stagger delay: Overview replaces each
+     tile independently as its own request resolves, so the arrival order IS
+     the stagger. A fixed delay would instead hold an already-loaded tile
+     invisible (animation-fill-mode: both) waiting for its slot. */
+  .ov-stat { animation: fadeup .38s var(--ease) both; }
+
+  .ov-stat:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 12px 26px -14px oklch(0.4 0.06 305 / 0.42), var(--panel-shadow);
+  }
+
+  /* Nav: the icon leads the eye toward the destination. 2px — enough to feel
+     responsive, small enough that a mouse crossing the sidebar does not
+     ripple. */
+  .nav-item .ni-icon { transition: transform .18s var(--ease); }
+  .nav-item:hover .ni-icon { transform: translateX(2px); }
+}

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1882,39 +1882,59 @@ button { font-family: inherit; }
    Motion: chrome only (#1385)
 
    The console is opened when something has gone wrong — someone is tracing a
-   bad DELETE. Delight lives in the chrome: navigation, tiles, headers.
-   Data surfaces (rows, diffs, badges, the numbers under inspection) stay calm
-   and are deliberately untouched here.
+   bad DELETE. Delight lives in the chrome: navigation, tiles, headers. Data
+   surfaces (rows, diffs, badges, the numbers under inspection) stay calm and
+   are deliberately untouched here.
 
-   Two rules this section must keep:
-   - No color moves. The semantic INSERT/UPDATE/DELETE tokens and the brand
-     palette's "never encode data" boundary are set above and stay set; every
-     rule below animates transform, opacity or shadow only.
-   - Everything is inside prefers-reduced-motion: no-preference, following the
-     pattern the rest of this file already uses. With motion off the page must
-     lose nothing but the movement.
+   Rules this section keeps:
+   - No color moves, and no custom-property redefinition. The semantic
+     INSERT/UPDATE/DELETE tokens and the brand palette's "never encode data"
+     boundary are set in :root and stay set.
+   - Everything animated sits inside prefers-reduced-motion: no-preference.
+     With motion off the page loses movement and nothing else.
    ============================================================ */
 
-/* Transitions live OUTSIDE the media query on purpose: a hover lift with
-   motion reduced should still change state, just instantly. Only the
-   transition timing is motion; the state change is feedback. */
-.ov-stat { transition: transform .22s var(--ease), box-shadow .22s var(--ease); }
-
 @media (prefers-reduced-motion: no-preference) {
-  /* Tiles rise as their fetch lands. No stagger delay: Overview replaces each
-     tile independently as its own request resolves, so the arrival order IS
-     the stagger. A fixed delay would instead hold an already-loaded tile
-     invisible (animation-fill-mode: both) waiting for its slot. */
-  .ov-stat { animation: fadeup .38s var(--ease) both; }
+  /* Tiles rise as their fetch lands.
+     
+     TRANSFORM ONLY, and no fill-mode — both are load-bearing.
+     
+     No opacity: :467 states the invariant for `rise` ("content is ALWAYS
+     visible"), and a tile that starts transparent flashes on every
+     replaceWith as Overview swaps skeletons for values.
+     
+     No `both`/`forwards`: a filling animation keeps contributing
+     `transform: none` after it ends, and animations outrank normal author
+     declarations — which silently killed the hover lift below. Measured in
+     Chrome: hovered transform was matrix(1,0,0,1,0,0) with the fill, and
+     translateY(-3px) without it. `rise` ends at the element's natural
+     transform, so nothing needs filling. A hover landing inside the first
+     380ms still will not lift, because a RUNNING animation outranks author
+     rules too; at 380ms that is a shrug, not a bug.
+     
+     Reuses the existing `rise` keyframe rather than adding one. */
+  .ov-stat { animation: rise .38s var(--ease-out); }
 
+  /* Inside the guard with the state it times. An earlier draft kept this
+     outside on the theory that "a hover lift with motion reduced should still
+     change state, just instantly" — but the :hover rule is itself guarded, so
+     under reduce there is no state change for a transition to time and the
+     rationale described something that could not happen. */
+  .ov-stat { transition: transform .22s var(--ease), box-shadow .22s var(--ease); }
   .ov-stat:hover {
     transform: translateY(-3px);
     box-shadow: 0 12px 26px -14px oklch(0.4 0.06 305 / 0.42), var(--panel-shadow);
   }
 
-  /* Nav: the icon leads the eye toward the destination. 2px — enough to feel
-     responsive, small enough that a mouse crossing the sidebar does not
-     ripple. */
-  .nav-item .ni-icon { transition: transform .18s var(--ease); }
+  /* Nav: the icon leads the eye toward the destination. 2px — responsive
+     without rippling as a mouse crosses the sidebar.
+
+     No `transition` declaration here on purpose. :385 already transitions
+     both color and transform on this exact selector, and `transition` is a
+     SHORTHAND: re-declaring it later in the file reset transition-property to
+     `transform` alone, so the icon's color snapped instantly for every
+     no-preference user. The section whose first rule is "no color moves" had
+     changed color behaviour, and the color guard could not see it because the
+     line contained no color property. */
   .nav-item:hover .ni-icon { transform: translateX(2px); }
 }

--- a/internal/console/assets_motion_test.go
+++ b/internal/console/assets_motion_test.go
@@ -1,0 +1,98 @@
+package console
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// motionSection returns the #1385 motion block of style.css.
+//
+// Scoped to that section on purpose. An earlier version of this guard tried to
+// police the WHOLE stylesheet and got it wrong: the file legitimately uses
+// three different shapes (a no-preference block, a dedicated reduce block that
+// sets animation:none for the same selector, and duration scaling), and a
+// checker that knows only the first manufactures findings against correct
+// code. A guard that cries wolf is worse than no guard. The pre-existing
+// unguarded animations that audit did surface are filed separately rather than
+// silently absorbed here.
+func motionSection(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("assets/style.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	css := string(data)
+	const marker = "Motion: chrome only (#1385)"
+	i := strings.Index(css, marker)
+	if i < 0 {
+		t.Fatal("the #1385 motion section header is gone — this guard no longer covers anything")
+	}
+	return css[i:]
+}
+
+// Every animation this section adds must sit inside its reduced-motion guard.
+//
+// The failure mode is invisible to the author: someone whose own OS setting is
+// "no preference" — nearly everyone — sees an unguarded rule work perfectly.
+// The console is opened during incidents, so honouring the setting is not a
+// nicety.
+func TestMotionSectionIsReducedMotionGuarded(t *testing.T) {
+	section := motionSection(t)
+
+	const guard = "@media (prefers-reduced-motion: no-preference)"
+	g := strings.Index(section, guard)
+	if g < 0 {
+		t.Fatal("the #1385 motion section has no prefers-reduced-motion: no-preference block")
+	}
+	open := strings.Index(section[g:], "{")
+	if open < 0 {
+		t.Fatal("malformed no-preference block in the #1385 motion section")
+	}
+	depth, end := 0, g+open
+	for ; end < len(section); end++ {
+		if section[end] == '{' {
+			depth++
+		} else if section[end] == '}' {
+			depth--
+			if depth == 0 {
+				break
+			}
+		}
+	}
+
+	for idx, line := range strings.Split(section, "\n") {
+		if !strings.Contains(line, "animation:") {
+			continue
+		}
+		// Offset of this line within the section.
+		off := 0
+		for i, l := range strings.Split(section, "\n") {
+			if i == idx {
+				break
+			}
+			off += len(l) + 1
+		}
+		if off < g || off > end {
+			t.Errorf("the #1385 motion section animates outside its reduced-motion guard:\n  %s\n"+
+				"Move the rule inside @media (prefers-reduced-motion: no-preference).", strings.TrimSpace(line))
+		}
+	}
+}
+
+// The motion section must not introduce color. The brand palette's "never
+// encode data" boundary and the semantic INSERT/UPDATE/DELETE tokens are
+// decided in :root; a decorative rule repainting a data surface would undo
+// that quietly, and "make it feel alive" is exactly the change that invites it.
+// box-shadow is the documented exception: it carries a color but paints depth,
+// not meaning.
+func TestMotionSectionAnimatesGeometryOnly(t *testing.T) {
+	section := motionSection(t)
+	for _, prop := range []string{"color:", "background:", "background-color:", "border-color:", "fill:", "stroke:"} {
+		if strings.Contains(section, prop) {
+			t.Errorf("the motion section sets %q. It is limited to transform/opacity/shadow: "+
+				"repainting a surface here can silently break the semantic DELETE=red mapping or the "+
+				"contrast floors the palette comment pins.", prop)
+		}
+	}
+}

--- a/internal/console/assets_motion_test.go
+++ b/internal/console/assets_motion_test.go
@@ -2,20 +2,25 @@ package console
 
 import (
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 )
 
-// motionSection returns the #1385 motion block of style.css.
+// motionSection returns the #1385 motion block of style.css, bounded at the
+// next section header.
 //
-// Scoped to that section on purpose. An earlier version of this guard tried to
-// police the WHOLE stylesheet and got it wrong: the file legitimately uses
-// three different shapes (a no-preference block, a dedicated reduce block that
-// sets animation:none for the same selector, and duration scaling), and a
-// checker that knows only the first manufactures findings against correct
-// code. A guard that cries wolf is worse than no guard. The pre-existing
-// unguarded animations that audit did surface are filed separately rather than
-// silently absorbed here.
+// Bounded, not "to end of file": an unbounded tail would silently extend both
+// guards over any section appended later, so a perfectly ordinary future
+// section that sets `background:` would fail the color guard here.
+//
+// Scoped to this section rather than the whole stylesheet, and that is
+// deliberate. An earlier version audited the entire file and produced seven
+// findings, several against correct code: style.css legitimately uses three
+// shapes for reduced motion (a no-preference block; a dedicated reduce block
+// setting animation:none for the same selector; duration scaling), and a
+// checker that knows only the first cries wolf. The pre-existing unguarded
+// animations that audit did surface are filed as #1392, not absorbed here.
 func motionSection(t *testing.T) string {
 	t.Helper()
 	data, err := os.ReadFile("assets/style.css")
@@ -28,71 +33,181 @@ func motionSection(t *testing.T) string {
 	if i < 0 {
 		t.Fatal("the #1385 motion section header is gone — this guard no longer covers anything")
 	}
-	return css[i:]
+	section := css[i:]
+	// The next "/* ====" banner, if any, ends this section.
+	if j := strings.Index(section, "/* ======"); j > 0 {
+		section = section[:j]
+	}
+	return section
 }
+
+// animDeclRE matches the shorthand and the longhand. The shorthand alone was a
+// hole: `animation-name: x` outside the guard escaped entirely.
+var animDeclRE = regexp.MustCompile(`animation(-name)?\s*:`)
 
 // Every animation this section adds must sit inside its reduced-motion guard.
 //
-// The failure mode is invisible to the author: someone whose own OS setting is
+// The failure mode is invisible to the author: anyone whose own OS setting is
 // "no preference" — nearly everyone — sees an unguarded rule work perfectly.
 // The console is opened during incidents, so honouring the setting is not a
 // nicety.
 func TestMotionSectionIsReducedMotionGuarded(t *testing.T) {
 	section := motionSection(t)
 
-	const guard = "@media (prefers-reduced-motion: no-preference)"
-	g := strings.Index(section, guard)
-	if g < 0 {
+	guarded := noPreferenceRanges(t, section)
+	if len(guarded) == 0 {
 		t.Fatal("the #1385 motion section has no prefers-reduced-motion: no-preference block")
 	}
-	open := strings.Index(section[g:], "{")
-	if open < 0 {
-		t.Fatal("malformed no-preference block in the #1385 motion section")
-	}
-	depth, end := 0, g+open
-	for ; end < len(section); end++ {
-		if section[end] == '{' {
-			depth++
-		} else if section[end] == '}' {
-			depth--
-			if depth == 0 {
-				break
-			}
-		}
-	}
 
-	for idx, line := range strings.Split(section, "\n") {
-		if !strings.Contains(line, "animation:") {
+	for _, m := range animDeclRE.FindAllStringIndex(section, -1) {
+		if inRanges(guarded, m[0]) {
 			continue
 		}
-		// Offset of this line within the section.
-		off := 0
-		for i, l := range strings.Split(section, "\n") {
-			if i == idx {
-				break
-			}
-			off += len(l) + 1
-		}
-		if off < g || off > end {
-			t.Errorf("the #1385 motion section animates outside its reduced-motion guard:\n  %s\n"+
-				"Move the rule inside @media (prefers-reduced-motion: no-preference).", strings.TrimSpace(line))
-		}
+		line := strings.TrimSpace(lineAt(section, m[0]))
+		t.Errorf("the #1385 motion section animates outside its reduced-motion guard:\n  %s\n"+
+			"Move the rule inside @media (prefers-reduced-motion: no-preference).", line)
 	}
 }
 
-// The motion section must not introduce color. The brand palette's "never
-// encode data" boundary and the semantic INSERT/UPDATE/DELETE tokens are
-// decided in :root; a decorative rule repainting a data surface would undo
-// that quietly, and "make it feel alive" is exactly the change that invites it.
+// noPreferenceRanges returns the byte ranges of EVERY no-preference block in
+// the section.
+//
+// Two failures the single-block version had, both demonstrated by review:
+// it took only the FIRST such block, so adding a second — an ordinary edit —
+// reported its contents as unguarded; and if the brace scan never returned to
+// depth 0 it left `end` at the section end, at which point nothing could be
+// flagged and the guard failed OPEN. One `{` inside a comment or a
+// `content: "{"` string was enough. Unbalanced braces are now a hard failure
+// rather than a silent pass.
+func noPreferenceRanges(t *testing.T, section string) [][2]int {
+	t.Helper()
+	const needle = "@media (prefers-reduced-motion: no-preference)"
+	var out [][2]int
+	for i := 0; ; {
+		j := strings.Index(section[i:], needle)
+		if j < 0 {
+			return out
+		}
+		start := i + j
+		open := strings.Index(section[start:], "{")
+		if open < 0 {
+			t.Fatalf("no-preference block at offset %d has no opening brace", start)
+		}
+		depth, k := 0, start+open
+		closed := false
+		for ; k < len(section); k++ {
+			switch section[k] {
+			case '{':
+				depth++
+			case '}':
+				depth--
+				if depth == 0 {
+					closed = true
+				}
+			}
+			if closed {
+				break
+			}
+		}
+		if !closed {
+			t.Fatalf("unbalanced braces in the no-preference block at offset %d — this guard "+
+				"cannot tell guarded from unguarded here, so it fails loudly instead of passing", start)
+		}
+		out = append(out, [2]int{start, k})
+		i = k + 1
+	}
+}
+
+func inRanges(ranges [][2]int, pos int) bool {
+	for _, r := range ranges {
+		if pos >= r[0] && pos <= r[1] {
+			return true
+		}
+	}
+	return false
+}
+
+func lineAt(s string, pos int) string {
+	start := strings.LastIndexByte(s[:pos], '\n') + 1
+	end := strings.IndexByte(s[pos:], '\n')
+	if end < 0 {
+		return s[start:]
+	}
+	return s[start : pos+end]
+}
+
+// The motion section must not move color. The brand palette's "never encode
+// data" boundary and the semantic INSERT/UPDATE/DELETE tokens are decided in
+// :root; a decorative rule repainting a data surface would undo that quietly,
+// and "make it feel alive" is exactly the change that invites it.
+//
 // box-shadow is the documented exception: it carries a color but paints depth,
 // not meaning.
 func TestMotionSectionAnimatesGeometryOnly(t *testing.T) {
-	section := motionSection(t)
-	for _, prop := range []string{"color:", "background:", "background-color:", "border-color:", "fill:", "stroke:"} {
+	// Comments stripped first: these needles are PROPERTY NAMES, and the
+	// section's own commentary explains why several of them are absent — the
+	// note about not using opacity contains the literal "opacity:". Matching
+	// raw text fires on the explanation, which is how the first run of this
+	// guard failed.
+	section := stripCSSComments(motionSection(t))
+
+	// `color:` substring-matches every *-color longhand (border-color,
+	// outline-color, accent-color, caret-color, text-decoration-color).
+	banned := []string{
+		"color:",
+		"background:", "background-image:",
+		"filter:", "backdrop-filter:",
+		"text-shadow:", "mix-blend-mode:",
+		// Shorthands that carry a color.
+		"border:", "outline:",
+	}
+	for _, prop := range banned {
 		if strings.Contains(section, prop) {
-			t.Errorf("the motion section sets %q. It is limited to transform/opacity/shadow: "+
+			t.Errorf("the motion section sets %q. It is limited to transform and box-shadow: "+
 				"repainting a surface here can silently break the semantic DELETE=red mapping or the "+
 				"contrast floors the palette comment pins.", prop)
 		}
+	}
+
+	// opacity is banned here for a different reason than the colors above, so
+	// it gets its own message. Overview replaces tiles as fetches land; a tile
+	// whose entrance starts transparent flashes at every replaceWith, and
+	// style.css:467 already states the invariant for `rise` — content is
+	// ALWAYS visible.
+	if strings.Contains(section, "opacity:") {
+		t.Error("the motion section animates opacity. Tiles are REPLACED as their fetch lands, so an " +
+			"entrance that starts transparent flashes on every swap; keep the entrance transform-only, " +
+			"as `rise` is.")
+	}
+
+	// The highest-impact miss the property list cannot catch: redefining a
+	// custom property here repaints its token EVERYWHERE, which is precisely
+	// what this guard exists to prevent.
+	// Not anchored to line start: `transform: translateX(2px); --delete: red;`
+	// is valid CSS on one line, and an anchored pattern missed it — verified by
+	// mutation. `var(--ease)` cannot match because the colon is required.
+	if regexp.MustCompile(`--[a-z0-9-]+\s*:`).MatchString(section) {
+		t.Error("the motion section redefines a custom property. A `--delete:` or `--panel-bg:` here " +
+			"repaints that token across the whole console — the exact failure this guard exists to " +
+			"prevent, and invisible to a property-name check.")
+	}
+}
+
+// stripCSSComments removes /* … */ blocks. CSS has no line comments, so this
+// is the whole grammar that matters here.
+func stripCSSComments(css string) string {
+	var b strings.Builder
+	for {
+		i := strings.Index(css, "/*")
+		if i < 0 {
+			b.WriteString(css)
+			return b.String()
+		}
+		b.WriteString(css[:i])
+		j := strings.Index(css[i:], "*/")
+		if j < 0 {
+			return b.String()
+		}
+		css = css[i+j+2:]
 	}
 }

--- a/internal/console/assets_motion_test.go
+++ b/internal/console/assets_motion_test.go
@@ -33,17 +33,36 @@ func motionSection(t *testing.T) string {
 	if i < 0 {
 		t.Fatal("the #1385 motion section header is gone — this guard no longer covers anything")
 	}
-	section := css[i:]
-	// The next "/* ====" banner, if any, ends this section.
-	if j := strings.Index(section, "/* ======"); j > 0 {
-		section = section[:j]
+	// Only the FIRST marker was found before, so a second banner further down
+	// sat outside both guards entirely.
+	if strings.Count(css, marker) > 1 {
+		t.Fatalf("the %q marker appears %d times — a duplicate puts everything under the later "+
+			"one outside these guards", marker, strings.Count(css, marker))
 	}
-	return section
+	// Back up to the banner that OPENS this section: the marker sits inside a
+	// /* … */ block, so slicing at the marker leaves an unterminated comment
+	// whose header prose then reaches the property matcher as if it were code.
+	if b := strings.LastIndex(css[:i], "/* ======"); b >= 0 {
+		i = b
+	}
+	section := css[i:]
+	// The next banner, if any, ends this section — without this bound both
+	// guards would silently extend over every section appended later.
+	if j := strings.Index(section[1:], "/* ======"); j > 0 {
+		section = section[:j+1]
+	}
+	// Stripped ONCE, here, so both guards see the same code-only text. It also
+	// removes the phantom-range hazard: a comment quoting the no-preference
+	// at-rule used to make the brace scanner treat the next `{` as a block.
+	return stripCSSComments(section)
 }
 
-// animDeclRE matches the shorthand and the longhand. The shorthand alone was a
-// hole: `animation-name: x` outside the guard escaped entirely.
-var animDeclRE = regexp.MustCompile(`animation(-name)?\s*:`)
+// animDeclRE matches what can START motion: the animation shorthand, its -name
+// longhand (you cannot run an animation without one of the two), and
+// `transition`. Transition was the hole this section argues about at length in
+// its own comment and then did not enforce — a transition IS animation, and
+// moving the tile's transition outside the guard passed green.
+var animDeclRE = regexp.MustCompile(`(animation(-name)?|transition)\s*:`)
 
 // Every animation this section adds must sit inside its reduced-motion guard.
 //
@@ -144,12 +163,10 @@ func lineAt(s string, pos int) string {
 // box-shadow is the documented exception: it carries a color but paints depth,
 // not meaning.
 func TestMotionSectionAnimatesGeometryOnly(t *testing.T) {
-	// Comments stripped first: these needles are PROPERTY NAMES, and the
-	// section's own commentary explains why several of them are absent — the
-	// note about not using opacity contains the literal "opacity:". Matching
-	// raw text fires on the explanation, which is how the first run of this
-	// guard failed.
-	section := stripCSSComments(motionSection(t))
+	// motionSection already strips comments — these needles are PROPERTY NAMES
+	// and the section's own commentary explains why several are absent (the
+	// note about not using opacity contains the literal "opacity:").
+	section := motionSection(t)
 
 	// `color:` substring-matches every *-color longhand (border-color,
 	// outline-color, accent-color, caret-color, text-decoration-color).
@@ -157,7 +174,7 @@ func TestMotionSectionAnimatesGeometryOnly(t *testing.T) {
 		"color:",
 		"background:", "background-image:",
 		"filter:", "backdrop-filter:",
-		"text-shadow:", "mix-blend-mode:",
+		"text-shadow:", "mix-blend-mode:", "background-blend-mode:", "border-image:",
 		// Shorthands that carry a color.
 		"border:", "outline:",
 	}

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1411,6 +1411,43 @@ try {
     ? ok("storage: baseline_trigger off → no button even with a destination")
     : bad("storage: baseline_trigger off → no button even with a destination", JSON.stringify(gates));
 
+  // Scenario 15e — motion that cannot be seen from Go (#1385).
+  //
+  // Both of these shipped BROKEN and a text-grep guard in the Go suite passed
+  // them. That is the whole reason they live here: both are CASCADE-PRECEDENCE
+  // bugs, a class no source-text assertion can observe. ci.yml says as much
+  // about this suite — "go test never renders assets/*, so CSS/DOM/presentation
+  // bugs are invisible to the Go suite".
+  //
+  //  1. `animation: … both` filled `transform: none` forward, and animations
+  //     outrank normal author declarations, so `.ov-stat:hover { transform }`
+  //     never applied — measured matrix(1,0,0,1,0,0). The box-shadow half DID
+  //     apply, so it looked half-alive rather than broken.
+  //  2. Re-declaring the `transition` SHORTHAND on `.nav-item .ni-icon` reset
+  //     transition-property to `transform` alone, so the icon colour snapped.
+  await page.evaluate(() => navigate("overview"));
+  await page.waitForSelector(".ov-stat", { timeout: 10000 });
+  // Let the entrance finish first: a RUNNING animation outranks the author rule
+  // too, so hovering early measures the animation rather than the bug.
+  await page.waitForTimeout(700);
+  await page.hover(".ov-stat");
+  await page.waitForTimeout(400); // the lift transitions over .22s
+  const lift = await page.evaluate(() => getComputedStyle(document.querySelector(".ov-stat")).transform);
+  // translateY(-3px) is the last component of the 2D matrix.
+  /-3\)$/.test(lift.replace(/\s/g, ""))
+    ? ok("motion: hovering a stat tile actually lifts it")
+    : bad("motion: hovering a stat tile actually lifts it",
+        `${lift} — an animation filling transform forward outranks the :hover rule`);
+
+  const iconTransition = await page.evaluate(() => {
+    const icon = document.querySelector(".nav-item .ni-icon");
+    return icon ? getComputedStyle(icon).transitionProperty : "(no icon)";
+  });
+  (iconTransition.includes("color") && iconTransition.includes("transform"))
+    ? ok("motion: the nav icon still transitions colour as well as transform")
+    : bad("motion: the nav icon still transitions colour as well as transform",
+        `${iconTransition} — re-declaring the transition shorthand resets transition-property`);
+
   // Scenario 16 — Restore Table combobox (#1364). The Table field must be an
   // input + datalist fed from /api/schemas?schema=… (the same endpoint the
   // events table picker consumes): suggestions from the fixture's tables,


### PR DESCRIPTION
A **first slice** of #1385, deliberately bounded to chrome. #1385 stays open.

### What changes

- Overview tiles **rise as they arrive** and **lift on hover**.
- Nav icons **nudge** toward their destination.

That is all of it. Everything below is why it is not more.

### A count-up was tried and removed

The obvious win was counting the big numbers up as they land. It shipped in
the first commit and `console-e2e` failed:

```
FAIL overview: the deletes tile is the server aggregate …
     {"v":"0","k":"deletes", …}
```

The test read the tile mid-animation. My own PR body had claimed the settled
DOM is byte-identical to the static render — true only **after** the animation
settles. For ~620 ms the tile stated a number that was not the answer, and on
a forensics console a tile that briefly reads *0 deletes* during an incident
is precisely the class of small lie this codebase spends its effort avoiding.

Removed rather than papered over. The entrance rise already supplies the sense
of arrival, and it animates geometry only, so it can never misstate a value.

### No color moves

The other obvious win is painting the big numbers with `--brand-headline`.
Also wrong: the deletes tile is `.danger`/`--delete`, so a gradient would
repaint a **semantic** token. The palette says it outright — brand
pink/violet/sun never encode data, and *pink never lands on a surface that
carries a row*.

`.btn-primary` likewise keeps its blue→violet gradient: the tokens say product
blue stays the interactive accent, and a warm CTA would move the meaning of
"this is the action", not just its look.

### Guards (mutation-verified)

| mutation | guard |
|---|---|
| move an animation out of the no-preference block | fails ✓ |
| introduce a color property in the section | fails ✓ |

### On the guard's scope

My first version audited the **whole** stylesheet and reported seven unguarded
animations. Several were wrong: the file legitimately uses three shapes for
reduced motion (a `no-preference` block; a `reduce` block setting
`animation: none` for the same selector; duration scaling), and a checker that
knows only the first manufactures alarms against correct code. Scoped to the
section it adds.

That audit did surface what look like five genuinely unguarded animations and
a `--motion` token declared once as `1` and never zeroed — filed as **#1392**
with the evidence and the method, not absorbed here.

`go test ./internal/console/` green, `go vet -tags integration` clean,
`node --check` clean, `gofmt` clean.
