### PR TITLE
console: one shape for reduced motion, plus a guard that sees the whole file

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -126,6 +126,16 @@ function setCurrentServer(id) {
 
 // ── tiny DOM helpers (no data ever assigned as HTML) ─────────────────────────
 
+// prefersReducedMotion reports the OS-level setting for motion started from
+// JavaScript, which no media query in style.css can reach.
+//
+// Read at CALL time rather than cached once: the setting can change while the
+// console is open — both macOS and Windows apply it live — and this console
+// stays open for hours during an incident.
+function prefersReducedMotion() {
+  return !!(window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+}
+
 function el(tag, attrs, ...kids) {
   const n = document.createElement(tag);
   if (attrs) {
@@ -2633,7 +2643,7 @@ function aimUndoAtInstant(form, at) {
   form.elements.since.value = since;
   form.elements.until.value = "";
   previewRecover(form);
-  form.scrollIntoView({ behavior: "smooth", block: "start" });
+  form.scrollIntoView({ behavior: prefersReducedMotion() ? "auto" : "smooth", block: "start" });
   toast("Undo window set to everything after " + at + " UTC");
 }
 
@@ -2672,7 +2682,7 @@ function useTimelineInstant(at) {
   if (!field || !form) return;
   field.value = at;
   runState(form, false);
-  field.scrollIntoView({ behavior: "smooth", block: "center" });
+  field.scrollIntoView({ behavior: prefersReducedMotion() ? "auto" : "smooth", block: "center" });
 }
 
 // shiftSeconds adds n seconds to a "YYYY-MM-DD HH:MM:SS" UTC stamp, returning
@@ -2831,9 +2841,18 @@ function renderTimeline(container, data) {
   container.append(tl);
 
   // "draws itself" — progressive-enhancement reveal (decorative).
+  //
+  // The stagger is gated here and not only in CSS, because the CSS guard
+  // removes the SMOOTHNESS while this loop still schedules the position
+  // change: with the transition gone, a 50-row timeline snapped one node at a
+  // time across ~2.8s of content shifting under the reader — a jumpier version
+  // of the motion the preference asked to remove. Under reduce every node
+  // arrives at once and nothing moves.
   requestAnimationFrame(() => {
     tl.classList.add("drawn");
-    $all(".tl-node", tl).forEach((n, i) => setTimeout(() => n.classList.add("in"), 60 + i * 55));
+    const nodes = $all(".tl-node", tl);
+    if (prefersReducedMotion()) { nodes.forEach((n) => n.classList.add("in")); return; }
+    nodes.forEach((n, i) => setTimeout(() => n.classList.add("in"), 60 + i * 55));
   });
 }
 

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -924,7 +924,6 @@ button { font-family: inherit; }
 [data-accent="blue"][data-dir="studio"] .timeline::before { background: var(--line); }
 [data-accent="blue"][data-dir="paper"] .timeline::before { background: var(--line); width: 1.5px; }
 
-@keyframes fadeup { from { opacity: 0; transform: translateY(9px); } to { opacity: 1; transform: none; } }
 
 .tl-node {
   position: relative; padding: 0 0 26px 4px;
@@ -959,8 +958,13 @@ button { font-family: inherit; }
   background: var(--orange); border-radius: 2px; transform-origin: left;
 }
 @keyframes ul { to { transform: scaleX(1); } }
-/* All four timeline entrance effects, in one guard. Each rule above is left in
-   its RESTING state, which is the part that is easy to get wrong: `ul` defines
+/* All four timeline entrance effects, in one guard — and their TRIGGER is
+   gated to match, in app.js, which applies the .in class to every node at once
+   under reduce. Guarding only the CSS removes the smoothness while the timer
+   still schedules the movement, which is a jumpier version of the same thing.
+
+   Each rule above is left in its RESTING state, the part that is easy to get
+   wrong: `ul` defines
    only a `to` frame, so its scaleX(0) start has to live in here too — leaving
    it on the base rule would hide the changed-value underline permanently for
    anyone who asked for less motion, turning a motion preference into lost
@@ -1227,8 +1231,10 @@ button { font-family: inherit; }
 .skel-line.skel-stat { height: 26px; width: 72px; margin-bottom: 4px; }
 .skel-note { font-family: var(--f-mono); font-size: 11px; color: var(--ink-4); margin-top: 8px; }
 @keyframes skel-shimmer { from { background-position: 200% 0; } to { background-position: -200% 0; } }
-/* Without the shimmer the bar is still a visibly empty grey placeholder, so
-   unlike the spinner below it needs no static stand-in. */
+/* Without the shimmer the bar is still visible: at the static
+   background-position the gradient renders solid --line across its left half,
+   fading out towards the right. A placeholder either way, so unlike the
+   spinner below it needs no stand-in. */
 @media (prefers-reduced-motion: no-preference) {
   .skel-line { animation: skel-shimmer 1.4s linear infinite; }
 }
@@ -1865,11 +1871,17 @@ button { font-family: inherit; }
 .cov-refresh-ico { display: flex; }
 .cov-refresh-ico svg { width: 14px; height: 14px; }
 @keyframes covspin { to { transform: rotate(360deg); } }
-/* The values deliberately stay on screen until the response lands, so this
-   spin is the ONLY signal that a refresh is in flight. That makes it the one
-   place a reduce block is the right answer: honouring the preference by simply
-   dropping the animation would remove the signal, not just the motion, so the
-   button dims instead. */
+/* The values deliberately stay on screen until the response lands, so the spin
+   carries nearly all of the in-flight signal. It is not quite alone — the
+   :disabled rule above shifts the icon --ink-3 -> --ink-4 and drops the cursor
+   to default — but both are easy to miss, so dropping the animation with no
+   replacement would leave almost nothing. The button dims instead.
+
+   This is the file's only reduce block, and it is a preference rather than a
+   law: the busy modal solves the same problem in shape 1, keeping a static
+   note as the base rule and revealing the animation under no-preference. That
+   shape swaps a display value; here the base rule stays byte-identical for the
+   overwhelmingly common case and the stand-in is purely additive. */
 @media (prefers-reduced-motion: no-preference) {
   .cov-refresh-btn.spin .cov-refresh-ico svg { animation: covspin .7s linear infinite; }
 }
@@ -1921,8 +1933,8 @@ button { font-family: inherit; }
      
      TRANSFORM ONLY, and no fill-mode — both are load-bearing.
      
-     No opacity: :467 states the invariant for `rise` ("content is ALWAYS
-     visible"), and a tile that starts transparent flashes on every
+     No opacity: the `rise` keyframes comment states the invariant ("content
+     is ALWAYS visible"), and a tile that starts transparent flashes on every
      replaceWith as Overview swaps skeletons for values.
      
      No `both`/`forwards`: a filling animation keeps contributing
@@ -1951,8 +1963,9 @@ button { font-family: inherit; }
   /* Nav: the icon leads the eye toward the destination. 2px — responsive
      without rippling as a mouse crosses the sidebar.
 
-     No `transition` declaration here on purpose. :385 already transitions
-     both color and transform on this exact selector, and `transition` is a
+     No `transition` declaration here on purpose. `.nav-item .ni-icon`'s own
+     base rule already transitions both color and transform on this exact
+     selector, and `transition` is a
      SHORTHAND: re-declaring it later in the file reset transition-property to
      `transform` alone, so the icon's color snapped instantly for every
      no-preference user. The section whose first rule is "no color moves" had

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -167,7 +167,6 @@
   --title-font: var(--f-display);
   --title-weight: 600;
   --title-tracking: -0.02em;
-  --motion: 1;
   --rail: var(--line);
 
   --shell-w: 248px;
@@ -396,7 +395,9 @@ button { font-family: inherit; }
   content: ""; position: absolute; left: -18px; top: 50%; transform: translateY(-50%);
   width: 3px; height: 18px; border-radius: 0 3px 3px 0;
   background: var(--brand-rail);
-  animation: railpop .3s var(--ease-out);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .nav-item.active::before { animation: railpop .3s var(--ease-out); }
 }
 [data-dir="trail"] .nav-item.active::before {
   height: 26px; width: 4px;
@@ -468,10 +469,10 @@ button { font-family: inherit; }
    (the preview's animation clock can freeze at t=0; opacity-from-0 would blank it) */
 @keyframes rise { from { transform: translateY(var(--rise, 10px)); } to { transform: none; } }
 @media (prefers-reduced-motion: no-preference) {
-  .view-enter > * { animation: rise calc(.45s * var(--motion)) var(--ease-out) both; }
-  .view-enter > *:nth-child(2) { animation-delay: calc(.04s * var(--motion)); }
-  .view-enter > *:nth-child(3) { animation-delay: calc(.08s * var(--motion)); }
-  .view-enter > *:nth-child(4) { animation-delay: calc(.12s * var(--motion)); }
+  .view-enter > * { animation: rise .45s var(--ease-out) both; }
+  .view-enter > *:nth-child(2) { animation-delay: .04s; }
+  .view-enter > *:nth-child(3) { animation-delay: .08s; }
+  .view-enter > *:nth-child(4) { animation-delay: .12s; }
 }
 
 /* ============================================================
@@ -734,7 +735,9 @@ button { font-family: inherit; }
   border-radius: var(--radius-sm);
   overflow: hidden;
   background: var(--surface);
-  animation: diffin calc(.32s * var(--motion)) var(--ease-out);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .diff { animation: diffin .32s var(--ease-out); }
 }
 @keyframes diffin { from { transform: translateY(-6px); } to { transform: none; } }
 .diff-grid { display: grid; grid-template-columns: 150px 1fr 1fr; }
@@ -927,16 +930,14 @@ button { font-family: inherit; }
   position: relative; padding: 0 0 26px 4px;
   transform: translateX(10px);
 }
-.tl-node.in { transform: none; transition: transform .45s var(--ease-out); }
+.tl-node.in { transform: none; }
 .tl-node:last-child { padding-bottom: 4px; }
 .tl-dot {
   position: absolute; left: -29px; top: 3px;
   width: 12px; height: 12px; border-radius: 50%;
   background: var(--surface); border: 2px solid var(--accent);
   box-shadow: 0 0 0 4px var(--bg);
-  transition: transform .3s var(--ease-out);
 }
-.tl-node.in .tl-dot { animation: dotpop .4s var(--ease-out) both; }
 @keyframes dotpop { 0% { transform: scale(0); } 60% { transform: scale(1.3); } 100% { transform: scale(1); } }
 .tl-dot.insert { border-color: var(--insert); }
 .tl-dot.update { border-color: var(--update); }
@@ -955,10 +956,21 @@ button { font-family: inherit; }
 .tl-body .pv.changed { color: var(--orange-2); font-weight: 600; position: relative; }
 .tl-body .pv.changed::after {
   content: ""; position: absolute; left: 0; right: 0; bottom: -2px; height: 2px;
-  background: var(--orange); border-radius: 2px; transform: scaleX(0); transform-origin: left;
-  animation: ul .4s .2s var(--ease-out) forwards;
+  background: var(--orange); border-radius: 2px; transform-origin: left;
 }
 @keyframes ul { to { transform: scaleX(1); } }
+/* All four timeline entrance effects, in one guard. Each rule above is left in
+   its RESTING state, which is the part that is easy to get wrong: `ul` defines
+   only a `to` frame, so its scaleX(0) start has to live in here too — leaving
+   it on the base rule would hide the changed-value underline permanently for
+   anyone who asked for less motion, turning a motion preference into lost
+   information. */
+@media (prefers-reduced-motion: no-preference) {
+  .tl-node.in { transition: transform .45s var(--ease-out); }
+  .tl-dot { transition: transform .3s var(--ease-out); }
+  .tl-node.in .tl-dot { animation: dotpop .4s var(--ease-out) both; }
+  .tl-body .pv.changed::after { transform: scaleX(0); animation: ul .4s .2s var(--ease-out) forwards; }
+}
 
 /* restore action on each timeline node */
 .tl-actions { margin-top: 10px; display: flex; gap: 8px; flex-wrap: wrap; }
@@ -1135,8 +1147,11 @@ button { font-family: inherit; }
   font-family: var(--f-ui); color: var(--ink);
   display: none; flex-direction: column; overflow: hidden;
 }
-#tweaks.open { display: flex; animation: twkin .28s var(--ease-out); }
+#tweaks.open { display: flex; }
 @keyframes twkin { from { transform: translateY(10px) scale(.98); } to { transform: none; } }
+@media (prefers-reduced-motion: no-preference) {
+  #tweaks.open { animation: twkin .28s var(--ease-out); }
+}
 .twk-h { display: flex; align-items: center; justify-content: space-between; padding: 13px 12px 11px 16px; border-bottom: 1px solid var(--line-soft); }
 .twk-h b { font-family: var(--f-display); font-size: 14px; font-weight: 600; letter-spacing: -0.01em; }
 .twk-h .x { border: none; background: none; color: var(--ink-3); cursor: pointer; width: 24px; height: 24px; border-radius: 6px; font-size: 15px; }
@@ -1208,12 +1223,15 @@ button { font-family: inherit; }
   height: 13px; border-radius: 4px;
   background: linear-gradient(90deg, var(--line) 25%, transparent 50%, var(--line) 75%);
   background-size: 200% 100%;
-  animation: skel-shimmer 1.4s linear infinite;
 }
 .skel-line.skel-stat { height: 26px; width: 72px; margin-bottom: 4px; }
 .skel-note { font-family: var(--f-mono); font-size: 11px; color: var(--ink-4); margin-top: 8px; }
 @keyframes skel-shimmer { from { background-position: 200% 0; } to { background-position: -200% 0; } }
-@media (prefers-reduced-motion: reduce) { .skel-line { animation: none; } }
+/* Without the shimmer the bar is still a visibly empty grey placeholder, so
+   unlike the spinner below it needs no static stand-in. */
+@media (prefers-reduced-motion: no-preference) {
+  .skel-line { animation: skel-shimmer 1.4s linear infinite; }
+}
 
 .ov-grid { display: grid; grid-template-columns: 1.35fr 1fr; gap: 18px; align-items: start; }
 .ov-panel {
@@ -1846,12 +1864,16 @@ button { font-family: inherit; }
 .cov-refresh-btn:disabled { cursor: default; color: var(--ink-4); }
 .cov-refresh-ico { display: flex; }
 .cov-refresh-ico svg { width: 14px; height: 14px; }
-/* The spinner is the only signal that an in-flight refresh is happening — the
-   values deliberately stay on screen until the response lands. */
-.cov-refresh-btn.spin .cov-refresh-ico svg { animation: covspin .7s linear infinite; }
 @keyframes covspin { to { transform: rotate(360deg); } }
+/* The values deliberately stay on screen until the response lands, so this
+   spin is the ONLY signal that a refresh is in flight. That makes it the one
+   place a reduce block is the right answer: honouring the preference by simply
+   dropping the animation would remove the signal, not just the motion, so the
+   button dims instead. */
+@media (prefers-reduced-motion: no-preference) {
+  .cov-refresh-btn.spin .cov-refresh-ico svg { animation: covspin .7s linear infinite; }
+}
 @media (prefers-reduced-motion: reduce) {
-  .cov-refresh-btn.spin .cov-refresh-ico svg { animation: none; }
   .cov-refresh-btn.spin { opacity: .55; }
 }
 .cov-chips { display: flex; gap: 8px; margin-top: 8px; flex-wrap: wrap; }

--- a/internal/console/assets_motion_test.go
+++ b/internal/console/assets_motion_test.go
@@ -15,12 +15,16 @@ import (
 // section that sets `background:` would fail the color guard here.
 //
 // Scoped to this section rather than the whole stylesheet, and that is
-// deliberate. An earlier version audited the entire file and produced seven
-// findings, several against correct code: style.css legitimately uses three
-// shapes for reduced motion (a no-preference block; a dedicated reduce block
-// setting animation:none for the same selector; duration scaling), and a
-// checker that knows only the first cries wolf. The pre-existing unguarded
-// animations that audit did surface are filed as #1392, not absorbed here.
+// deliberate — though for a different reason than when it was written. The
+// original reason (style.css honoured reduced motion three inconsistent ways,
+// so a whole-file checker cried wolf) is gone: #1392 settled on one shape and
+// TestReducedMotionHasOneShape now audits the entire file.
+//
+// What survives is a STRICTER local rule. The whole-file guard tolerates short
+// geometry transitions anywhere, because a 120ms hover nudge is feedback and
+// banning it outright is a rule nobody follows. This section exists for no
+// reason except to add decorative motion, so here every transition is motion
+// regardless of duration and none may sit outside the guard.
 func motionSection(t *testing.T) string {
 	t.Helper()
 	data, err := os.ReadFile("assets/style.css")

--- a/internal/console/assets_motion_test.go
+++ b/internal/console/assets_motion_test.go
@@ -17,14 +17,16 @@ import (
 // Scoped to this section rather than the whole stylesheet, and that is
 // deliberate — though for a different reason than when it was written. The
 // original reason (style.css honoured reduced motion three inconsistent ways,
-// so a whole-file checker cried wolf) is gone: #1392 settled on one shape and
-// TestReducedMotionHasOneShape now audits the entire file.
+// so a whole-file checker cried wolf) is gone: #1392 settled on one shape plus
+// a narrow reduce-block exception, and TestReducedMotionHasOneShape now audits
+// the entire file.
 //
 // What survives is a STRICTER local rule. The whole-file guard tolerates short
 // geometry transitions anywhere, because a 120ms hover nudge is feedback and
 // banning it outright is a rule nobody follows. This section exists for no
-// reason except to add decorative motion, so here every transition is motion
-// regardless of duration and none may sit outside the guard.
+// reason except to add decorative motion, so here EVERY transition is motion —
+// any duration, and colour and opacity too, both of which the whole-file guard
+// ignores by design — and none may sit outside the guard.
 func motionSection(t *testing.T) string {
 	t.Helper()
 	data, err := os.ReadFile("assets/style.css")
@@ -193,7 +195,7 @@ func TestMotionSectionAnimatesGeometryOnly(t *testing.T) {
 	// opacity is banned here for a different reason than the colors above, so
 	// it gets its own message. Overview replaces tiles as fetches land; a tile
 	// whose entrance starts transparent flashes at every replaceWith, and
-	// style.css:467 already states the invariant for `rise` — content is
+	// the `rise` keyframes comment already states the invariant — content is
 	// ALWAYS visible.
 	if strings.Contains(section, "opacity:") {
 		t.Error("the motion section animates opacity. Tiles are REPLACED as their fetch lands, so an " +

--- a/internal/console/assets_reducedmotion_test.go
+++ b/internal/console/assets_reducedmotion_test.go
@@ -1,0 +1,231 @@
+package console
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// sanitizeCSS blanks out comment bodies and string literals, preserving both
+// byte offsets and newlines so every match position and line number computed
+// against the result is valid for the original file.
+//
+// Blanking rather than deleting is what makes the whole-file scan safe. Two
+// concrete hazards it removes, both of which produced wrong answers in earlier
+// hand-written versions of this audit: a comment quoting `@media
+// (prefers-reduced-motion: ...)` was picked up as a real at-rule, and a
+// `content: "{"` declaration desynchronised the brace scanner so a block's
+// computed end landed hundreds of lines past its real one.
+func sanitizeCSS(css string) string {
+	out := []byte(css)
+	blank := func(i int) {
+		if out[i] != '\n' {
+			out[i] = ' '
+		}
+	}
+	for i := 0; i < len(css); i++ {
+		switch {
+		case css[i] == '/' && i+1 < len(css) && css[i+1] == '*':
+			for ; i < len(css); i++ {
+				blank(i)
+				if css[i] == '/' && i > 0 && css[i-1] == '*' && i > 1 {
+					break
+				}
+			}
+		case css[i] == '"' || css[i] == '\'':
+			q := css[i]
+			i++
+			for ; i < len(css) && css[i] != q; i++ {
+				if css[i] == '\\' && i+1 < len(css) {
+					blank(i)
+					i++
+				}
+				blank(i)
+			}
+		}
+	}
+	return string(out)
+}
+
+// atRuleRanges returns the byte ranges of every block introduced by needle.
+func atRuleRanges(t *testing.T, css, needle string) [][2]int {
+	t.Helper()
+	var out [][2]int
+	for i := 0; ; {
+		j := strings.Index(css[i:], needle)
+		if j < 0 {
+			return out
+		}
+		start := i + j
+		open := strings.IndexByte(css[start:], '{')
+		if open < 0 {
+			t.Fatalf("%s at line %d has no opening brace", needle, lineOf(css, start))
+		}
+		depth, k, closed := 0, start+open, false
+		for ; k < len(css); k++ {
+			if css[k] == '{' {
+				depth++
+			} else if css[k] == '}' {
+				if depth--; depth == 0 {
+					closed = true
+				}
+			}
+			if closed {
+				break
+			}
+		}
+		if !closed {
+			// Failing loudly rather than returning a range that swallows the
+			// rest of the file: that shape makes every later declaration look
+			// guarded, so the guard would pass by covering everything.
+			t.Fatalf("unbalanced braces in the %s block at line %d", needle, lineOf(css, start))
+		}
+		out = append(out, [2]int{start, k})
+		i = k + 1
+	}
+}
+
+func lineOf(css string, pos int) int { return strings.Count(css[:pos], "\n") + 1 }
+
+func within(rs [][2]int, p int) bool {
+	for _, r := range rs {
+		if p >= r[0] && p <= r[1] {
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	animRE = regexp.MustCompile(`(?:^|[;{\s])animation(?:-name)?\s*:`)
+	tranRE = regexp.MustCompile(`(?:^|[;{\s])transition\s*:`)
+	// Properties whose transition physically moves something on screen.
+	// Colour and shadow transitions are deliberately absent: reduced-motion is
+	// about vestibular motion, and banning a 150ms colour fade would make the
+	// rule one nobody could follow.
+	geomRE = regexp.MustCompile(`\b(transform|all|translate|scale|rotate|top|left|right|bottom|width|height|margin|padding|inset|gap)\b`)
+	durRE  = regexp.MustCompile(`(?:^|[\s(,])(\d*\.?\d+)(ms|s)\b`)
+)
+
+// transitionIsMotion reports whether any comma-separated segment of a
+// transition value both moves geometry AND runs long enough to read as
+// animation rather than feedback.
+//
+// The threshold exists because a blanket "no transform transitions outside the
+// guard" would be a rule nobody follows: five of the seven this audit first
+// surfaced were a 2px icon nudge on hover, a 1px button press, and a rotating
+// caret — direct-manipulation feedback, not the large sustained motion
+// prefers-reduced-motion is about. At a third of a second a transition has
+// stopped being feedback; that is where the two genuine entrance animations in
+// this file (a timeline node sliding in, its dot scaling up) sit, and both are
+// entrances, exactly the class `rise` is already guarded for.
+func transitionIsMotion(value string) (bool, string) {
+	for _, seg := range strings.Split(value, ",") {
+		if !geomRE.MatchString(seg) {
+			continue
+		}
+		m := durRE.FindStringSubmatch(seg)
+		if m == nil {
+			continue // no duration: nothing transitions
+		}
+		ms, err := strconv.ParseFloat(m[1], 64)
+		if err != nil {
+			continue
+		}
+		if m[2] == "s" {
+			ms *= 1000
+		}
+		if ms >= motionThresholdMs {
+			return true, strings.TrimSpace(seg)
+		}
+	}
+	return false, ""
+}
+
+// Where feedback ends and animation begins, in milliseconds.
+const motionThresholdMs = 300
+
+func declValue(css string, from int) string {
+	end := strings.IndexAny(css[from:], ";}")
+	if end < 0 {
+		return css[from:]
+	}
+	return css[from : from+end]
+}
+
+// Every motion declaration in style.css must sit inside the reduced-motion
+// guard, and a reduce block must never itself animate.
+//
+// Two legal shapes, and this test is what makes "two" true rather than
+// aspirational (#1392 found three, one of them — scaling durations by a
+// --motion variable that was never zeroed — guarding nothing at all):
+//
+//  1. motion lives in @media (prefers-reduced-motion: no-preference); the rule
+//     outside it is the resting state.
+//  2. @media (prefers-reduced-motion: reduce) may carry a STATIC alternative
+//     for an indicator whose animation was the only signal (the coverage
+//     spinner dims instead of spinning), and nothing else.
+//
+// The console is opened during incidents. Someone whose OS asks for reduced
+// motion is not asking for a nicer console; motion sickness while reading a
+// recovery plan is the failure this prevents.
+func TestReducedMotionHasOneShape(t *testing.T) {
+	raw, err := os.ReadFile("assets/style.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	css := sanitizeCSS(string(raw))
+
+	noPref := atRuleRanges(t, css, "@media (prefers-reduced-motion: no-preference)")
+	reduce := atRuleRanges(t, css, "@media (prefers-reduced-motion: reduce)")
+	if len(noPref) == 0 {
+		t.Fatal("style.css has no prefers-reduced-motion: no-preference block — this guard covers nothing")
+	}
+
+	ws := regexp.MustCompile(`\s+`)
+	report := func(pos int, why string) {
+		t.Errorf("style.css:%d: %s\n  %s", lineOf(css, pos),
+			strings.TrimSpace(ws.ReplaceAllString(declValue(css, pos), " ")), why)
+	}
+
+	for _, m := range animRE.FindAllStringIndex(css, -1) {
+		switch {
+		case within(reduce, m[0]):
+			report(m[0], "a reduce block must not animate. Move the animation into the "+
+				"no-preference block; keep only the static alternative here.")
+		case !within(noPref, m[0]):
+			report(m[0], "animates outside @media (prefers-reduced-motion: no-preference). "+
+				"Move it in, and make sure the rule left outside is the RESTING state — an "+
+				"animation with forwards/both fill often leaves the base rule holding the "+
+				"START frame, which then becomes permanent.")
+		}
+	}
+
+	for _, m := range tranRE.FindAllStringIndex(css, -1) {
+		motion, seg := transitionIsMotion(declValue(css, m[0]))
+		if !motion {
+			continue
+		}
+		switch {
+		case within(reduce, m[0]):
+			report(m[0], "a reduce block must not transition geometry: "+seg)
+		case !within(noPref, m[0]):
+			report(m[0], "`"+seg+"` moves geometry for "+strconv.Itoa(motionThresholdMs)+
+				"ms or longer, which reads as animation rather than feedback. Move the "+
+				"transition into @media (prefers-reduced-motion: no-preference); leave the "+
+				"final position outside it so the element still ARRIVES without the animation.")
+		}
+	}
+
+	// The third shape #1392 retired. A duration multiplier reads like a global
+	// motion switch, so the next person scales a new animation by it and
+	// believes that honours the setting — but nothing ever set it to 0, and no
+	// media query referenced it.
+	if i := strings.Index(css, "--motion"); i >= 0 {
+		t.Errorf("style.css:%d: --motion is back. It was deleted in #1392 because it was never "+
+			"zeroed under reduce, so scaling a duration by it guarded nothing while looking "+
+			"like it did. Put the rule in the no-preference block instead.", lineOf(css, i))
+	}
+}

--- a/internal/console/assets_reducedmotion_test.go
+++ b/internal/console/assets_reducedmotion_test.go
@@ -13,12 +13,14 @@ import (
 // byte offsets and newlines so every match position and line number computed
 // against the result is valid for the original file.
 //
-// Blanking rather than deleting is what makes the whole-file scan safe, and it
-// is load-bearing twice over. It keeps offsets aligned, and because a blanked
-// comment becomes whitespace it still satisfies the `[;{\s]` prefix the
-// declaration patterns below require — so `.a{/*c*/animation: x 1s}` is caught
-// where deleting the comment would have joined `{` to `animation` and, with a
-// different prefix class, could have hidden it.
+// Blanking rather than deleting is what keeps every offset and line number
+// reported below valid against the ORIGINAL file.
+//
+// An earlier version of this comment also argued blanking was needed so a
+// commented-out declaration still satisfied the `[;{\s]` prefix. That was
+// wrong, and it is recorded rather than quietly dropped because of how it
+// failed: `{` is itself in the prefix class, so `.a{/*c*/animation: x 1s}` is
+// caught either way. It read as a verified rationale because nobody ran it.
 //
 // Two hazards it forecloses. Neither is present in style.css today, and both
 // were demonstrated by review rather than observed in the wild: a comment
@@ -38,9 +40,12 @@ func sanitizeCSS(css string) string {
 			blank(i)
 			blank(i + 1)
 			// Scanning from i+2, not i: starting at the opening `/` let the
-			// terminator check match the comment's OWN `*`, so `/*/` closed
-			// immediately and `.a>*/*{ … } */` leaked its braces into the
-			// scan — the exact desync this function exists to prevent.
+			// terminator check match a `*` belonging to the opener, so
+			// `.a>*/* c */ {` closed early and leaked the comment's braces
+			// into the scan — the exact desync this function prevents.
+			// (`/*/` on its own is unaffected; both versions close it at the
+			// third character. Worth stating, because it was the example
+			// originally given and it was the wrong one.)
 			i += 2
 			for ; i < len(css); i++ {
 				blank(i)
@@ -101,6 +106,27 @@ func atRuleRanges(t *testing.T, css, needle string) [][2]int {
 	}
 }
 
+// guardRanges is atRuleRanges plus the merge check, so both tests get it.
+//
+// atRuleRanges fails loudly on ONE brace error, but a stray `{` inside a guard
+// paired with a stray `}` later balances into a single range spanning the
+// file — at which point everything looks guarded. Comparing the range count to
+// the needle count catches that without re-architecting the scanner.
+//
+// It catches the merge only when the swallowed region still CONTAINS another
+// occurrence of the needle. A merge that also removed the swallowed at-rule
+// keeps both counts in step and passes; that needs a brace fault and a
+// refactor in the same edit, and is not claimed to be covered.
+func guardRanges(t *testing.T, css, needle string) [][2]int {
+	t.Helper()
+	rs := atRuleRanges(t, css, needle)
+	if want := strings.Count(css, needle); len(rs) != want {
+		t.Fatalf("found %d %s blocks but %d occurrences of the at-rule: a brace error has merged "+
+			"blocks, so this guard cannot tell guarded from unguarded", len(rs), needle, want)
+	}
+	return rs
+}
+
 func lineOf(css string, pos int) int { return strings.Count(css[:pos], "\n") + 1 }
 
 func within(rs [][2]int, p int) bool {
@@ -129,15 +155,16 @@ var (
 	// Colour and shadow transitions are deliberately absent: reduced-motion is
 	// about vestibular motion, and banning a 150ms colour fade would make the
 	// rule one nobody could follow.
-	geomRE = regexp.MustCompile(`\b(transform|all|translate|scale|rotate|top|left|right|bottom|width|height|margin|padding|inset|gap)\b`)
+	geomRE = regexp.MustCompile(`(?i)\b(transform|all|translate|scale|rotate|top|left|right|bottom|width|height|margin|padding|inset|gap)\b`)
 	// `\btop\b` matches INSIDE `border-top-color`, because `-` is a non-word
-	// character on both sides — so the rule above fired on a pure colour
-	// transition, contradicting its own comment. A guard that invents alarms
+	// character on both sides — so the rule above WOULD fire on a pure colour
+	// transition, contradicting its own comment. Nothing in style.css triggers
+	// it today; this is defensive. A guard that invents alarms
 	// against correct code is the one that gets deleted, so the non-geometric
 	// suffixed properties are removed before matching. Dropping every
 	// hyphenated name instead would also lose `max-height` and `margin-left`,
 	// which genuinely do move things.
-	nonGeomPropRE = regexp.MustCompile(`\b[a-z-]*-(color|style|shadow|image|radius)\b`)
+	nonGeomPropRE = regexp.MustCompile(`(?i)\b[a-z-]*-(color|style|shadow|image|radius)\b`)
 	// Case-insensitive: `400MS` is valid CSS. The prefix class admits `:` so a
 	// duration written flush against the colon (`transition:.4s transform`) is
 	// still found.
@@ -146,9 +173,11 @@ var (
 	// commas inside `cubic-bezier(.4, 0, .2, 1)` tore one transition into four
 	// fragments, and a duration written AFTER the timing function landed in a
 	// fragment naming no property, so it escaped entirely.
-	parenGroupRE = regexp.MustCompile(`\([^()]*\)`)
-	kfDeclRE     = regexp.MustCompile(`@keyframes\s+([\w-]+)`)
-	animValueRE  = regexp.MustCompile(`(?:^|[;{\s])animation(?:-name)?\s*:([^;}]*)`)
+	parenGroupRE   = regexp.MustCompile(`\([^()]*\)`)
+	longhandPropRE = regexp.MustCompile(`transition-property\s*:([^;}]*)`)
+	longhandDurRE  = regexp.MustCompile(`transition-duration\s*:([^;}]*)`)
+	kfDeclRE       = regexp.MustCompile(`@keyframes\s+([\w-]+)`)
+	animValueRE    = regexp.MustCompile(`(?:^|[;{\s])animation(?:-name)?\s*:([^;}]*)`)
 )
 
 // declValue returns the declaration starting at from, up to its terminator.
@@ -175,19 +204,20 @@ func blankParens(s string) string {
 // animation rather than feedback.
 //
 // The threshold exists because a blanket "no transform transitions outside the
-// guard" would be a rule nobody follows. Of the seven this audit first
-// surfaced, five are direct-manipulation feedback: a 2px icon nudge on hover,
+// guard" would be a rule nobody follows. Of the seven sitting outside the
+// guard when this was written (count today and you find more, because three
+// are now inside it), five are direct-manipulation feedback: a 2px icon nudge on hover,
 // a 1px button press, a rotating caret, an 8% swatch hover scale, and — the
 // largest thing the threshold waives, so worth naming rather than implying —
 // a 16px settings-toggle knob slide. At a third of a second a transition has
 // stopped being feedback; that is where the timeline node's .45s slide-in
 // sits, an entrance of exactly the class `rise` is already guarded for.
 //
-// The other declaration above the line, `.tl-dot`'s .3s, is currently inert —
-// nothing changes that element's transform, and the dot's scale-up is the
-// `dotpop` ANIMATION, not this transition. It is guarded anyway rather than
-// deleted: the cost is one line, and the day something does move the dot the
-// guard is already in place.
+// The other declaration above the line, `.tl-dot`'s .3s, is currently inert:
+// no cascade-level transform change ever applies to that element, and the
+// dot's scale-up is the `dotpop` ANIMATION — animation output does not start a
+// transition. Guarded anyway rather than deleted; the cost is one line, and
+// the day something does move the dot the guard is already there.
 func transitionIsMotion(value string) (bool, string) {
 	for _, seg := range strings.Split(blankParens(value), ",") {
 		if !geomRE.MatchString(nonGeomPropRE.ReplaceAllString(seg, "")) {
@@ -199,18 +229,70 @@ func transitionIsMotion(value string) (bool, string) {
 			// not proven safe.
 			continue
 		}
-		ms, err := strconv.ParseFloat(m[1], 64)
-		if err != nil {
-			continue
-		}
-		if !strings.EqualFold(m[2], "ms") {
-			ms *= 1000
-		}
-		if ms >= motionThresholdMs {
+		if ms, ok := durationMs(seg); ok && ms >= motionThresholdMs {
 			return true, strings.TrimSpace(seg)
 		}
 	}
 	return false, ""
+}
+
+// durationMs reads the first literal time in seg, which per spec is the
+// duration (a second time would be the delay).
+func durationMs(seg string) (float64, bool) {
+	m := durRE.FindStringSubmatch(seg)
+	if m == nil {
+		return 0, false
+	}
+	ms, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		return 0, false
+	}
+	if !strings.EqualFold(m[2], "ms") {
+		ms *= 1000
+	}
+	return ms, true
+}
+
+// longhandIsMotion answers the same question for the split form, where the
+// duration lives in a declaration of its own.
+//
+// The first version of this branch simply treated any geometry named by a
+// transition-property as motion, duration unread. That was not a possible
+// false alarm but a certain one — `transition-property: transform;
+// transition-duration: .1s` is feedback by the very threshold this file
+// spends a paragraph justifying, and it would have been flagged. Pairing them
+// costs a rule-block scan.
+//
+// A transition-property with NO transition-duration is deliberately not
+// motion: the initial value is 0s, so the property is listed and nothing
+// transitions.
+func longhandIsMotion(css string, pos int) (bool, string) {
+	block := enclosingRule(css, pos)
+	pm := longhandPropRE.FindStringSubmatch(block)
+	if pm == nil || !geomRE.MatchString(nonGeomPropRE.ReplaceAllString(pm[1], "")) {
+		return false, ""
+	}
+	dm := longhandDurRE.FindStringSubmatch(block)
+	if dm == nil {
+		return false, ""
+	}
+	for _, seg := range strings.Split(blankParens(dm[1]), ",") {
+		if ms, ok := durationMs(seg); ok && ms >= motionThresholdMs {
+			return true, "transition-property:" + strings.TrimSpace(pm[1]) +
+				"; transition-duration:" + strings.TrimSpace(dm[1])
+		}
+	}
+	return false, ""
+}
+
+// enclosingRule returns the declaration block containing pos.
+func enclosingRule(css string, pos int) string {
+	start := strings.LastIndexAny(css[:pos], "{}") + 1
+	end := strings.IndexByte(css[pos:], '}')
+	if end < 0 {
+		return css[start:]
+	}
+	return css[start : pos+end]
 }
 
 // Every motion declaration in style.css must sit inside the reduced-motion
@@ -238,8 +320,9 @@ func transitionIsMotion(value string) (bool, string) {
 // question no text scan can answer. Scenario 17d drives renderTimeline under
 // both media states and pins the stagger app.js schedules in JavaScript, which
 // neither this test nor 17c can reach. The two scrollIntoView call sites that
-// read the same matchMedia helper have NO guard: their smooth/auto difference
-// is a browser-internal scroll with no observable DOM state.
+// read the same matchMedia helper have no E2E guard: their smooth/auto
+// difference is a browser-internal scroll with no observable DOM state. The
+// Go test below is what holds them.
 //
 // The console is opened during incidents. Someone whose OS asks for reduced
 // motion is not asking for a nicer console; motion sickness while reading a
@@ -251,8 +334,8 @@ func TestReducedMotionHasOneShape(t *testing.T) {
 	}
 	css := sanitizeCSS(string(raw))
 
-	noPref := atRuleRanges(t, css, noPrefNeedle)
-	reduce := atRuleRanges(t, css, reduceNeedle)
+	noPref := guardRanges(t, css, noPrefNeedle)
+	reduce := guardRanges(t, css, reduceNeedle)
 	if len(noPref) == 0 {
 		t.Fatal("style.css has no prefers-reduced-motion: no-preference block — this guard covers nothing")
 	}
@@ -261,15 +344,6 @@ func TestReducedMotionHasOneShape(t *testing.T) {
 	// spanning most of the file — at which point everything looks guarded.
 	// Comparing the range count to the needle count catches the swallowing
 	// without re-architecting the scanner.
-	for _, n := range []struct {
-		needle string
-		got    int
-	}{{noPrefNeedle, len(noPref)}, {reduceNeedle, len(reduce)}} {
-		if want := strings.Count(css, n.needle); n.got != want {
-			t.Fatalf("found %d %s blocks but %d occurrences of the at-rule: a brace error has "+
-				"merged blocks, so this guard cannot tell guarded from unguarded", n.got, n.needle, want)
-		}
-	}
 
 	ws := regexp.MustCompile(`\s+`)
 	report := func(pos int, why string) {
@@ -293,11 +367,7 @@ func TestReducedMotionHasOneShape(t *testing.T) {
 		val := declValue(css, m[0])
 		motion, seg := transitionIsMotion(val)
 		if strings.Contains(val, "transition-property") {
-			// The longhand's duration lives in a SEPARATE declaration, so
-			// pairing them reliably is more machinery than the case is worth.
-			// Geometry named by a transition-property must be inside the
-			// guard, duration unread.
-			motion, seg = geomRE.MatchString(nonGeomPropRE.ReplaceAllString(val, "")), strings.TrimSpace(val)
+			motion, seg = longhandIsMotion(css, m[0])
 		}
 		if !motion {
 			continue
@@ -336,13 +406,19 @@ func TestReducedMotionHasOneShape(t *testing.T) {
 // the two in step automatically: a new animation is covered the moment its
 // keyframes land, and an intentionally retired one is removed in the same
 // commit as its declaration or this fails.
+//
+// Two deletions it still cannot see, both covered by console-e2e 17c instead,
+// which reads computed durations and animation-names in a real browser: a
+// guarded TRANSITION has no keyframes to orphan, and a keyframe with two
+// drivers stays driven when one goes — `rise` is declared on both
+// `.view-enter > *` and `.ov-stat`.
 func TestEveryKeyframeIsDrivenFromInsideTheGuard(t *testing.T) {
 	raw, err := os.ReadFile("assets/style.css")
 	if err != nil {
 		t.Fatal(err)
 	}
 	css := sanitizeCSS(string(raw))
-	noPref := atRuleRanges(t, css, noPrefNeedle)
+	noPref := guardRanges(t, css, noPrefNeedle)
 
 	declared := map[string]int{}
 	for _, m := range kfDeclRE.FindAllStringSubmatchIndex(css, -1) {
@@ -389,10 +465,22 @@ func TestEveryKeyframeIsDrivenFromInsideTheGuard(t *testing.T) {
 // still moves things. The timeline reveal was exactly that — the guarded CSS
 // left every node snapping into place one at a time across ~2.8 seconds.
 //
-// Both anchors name a visual effect rather than a mechanism, so they survive
-// renaming a local or retuning the stagger: `behavior: "smooth"` is the only
-// scroll animation the platform offers, and `"in"` is the entrance class the
-// stylesheet's .tl-node rules key on.
+// Both anchors name a visual effect rather than a mechanism, so retuning the
+// stagger or hoisting the gate into a local does not disarm them: `behavior:
+// "smooth"` is the only scroll animation an element API offers, and `"in"` is
+// the entrance class the stylesheet's .tl-node rules key on.
+//
+// Both scope to the enclosing FUNCTION, not the line. Line scoping looked
+// tighter and was worse twice: the value pattern could not cross the `)` in
+// `prefersReducedMotion()`, so it matched NEITHER real call site, and the
+// ordinary hoist — `const reduced = prefersReducedMotion()` — would have
+// false-alarmed for naming the gate on a different line.
+//
+// What this cannot do is notice a NEW kind of JavaScript motion. The CSS
+// guards extend themselves because every animation must declare @keyframes;
+// there is no equivalent anchor here, so `el.animate([...])` or a fresh
+// `setTimeout` reveal ships unguarded. Filed rather than bolted on: a
+// badly-chosen heuristic anchor cries wolf, which is how a guard gets deleted.
 func TestJavaScriptMotionConsultsThePreference(t *testing.T) {
 	raw, err := os.ReadFile("assets/app.js")
 	if err != nil {
@@ -401,23 +489,26 @@ func TestJavaScriptMotionConsultsThePreference(t *testing.T) {
 	js := string(raw)
 	const gate = "prefersReducedMotion"
 
-	for _, m := range regexp.MustCompile(`\bbehavior:\s*[^,;)\n]*"smooth"`).FindAllStringIndex(js, -1) {
-		if !strings.Contains(lineAt(js, m[0]), gate) {
+	for _, m := range regexp.MustCompile(`\bbehavior:\s*[^;\n]*["']smooth["']`).FindAllStringIndex(js, -1) {
+		if !strings.Contains(enclosingFunc(js, m[0]), gate) {
 			t.Errorf("app.js:%d: %s\n  Smooth scrolling is a vestibular trigger and this one is on "+
 				"the Restore path. Pass %s() ? \"auto\" : \"smooth\".",
 				lineOf(js, m[0]), strings.TrimSpace(lineAt(js, m[0])), gate)
 		}
 	}
 
-	// Scoped to the enclosing function, not the whole file: a gate anywhere in
-	// 5000 lines would satisfy a file-wide search while the reveal it is
-	// supposed to cover stays ungated.
-	for _, m := range regexp.MustCompile(`classList\.add\("in"\)`).FindAllStringIndex(js, -1) {
-		body := js[enclosingFuncStart(js, m[0]):]
-		if end := strings.Index(body[1:], "\nfunction "); end > 0 {
-			body = body[:end+1]
-		}
-		if !strings.Contains(body, gate) {
+	// Renaming the entrance class would leave this loop with nothing to iterate
+	// and no complaint — the shape both CSS guards above refuse to have. The
+	// smooth-scroll loop deliberately gets no equivalent check: removing the
+	// last smooth scroll is a legitimate edit, whereas the timeline reveal
+	// going away silently means this test stopped covering its subject.
+	entrance := regexp.MustCompile(`classList\.add\("in"\)`).FindAllStringIndex(js, -1)
+	if len(entrance) == 0 {
+		t.Fatal(`app.js no longer applies the "in" entrance class — either the timeline reveal is ` +
+			`gone or the class was renamed, and either way this guard now covers nothing`)
+	}
+	for _, m := range entrance {
+		if !strings.Contains(enclosingFunc(js, m[0]), gate) {
 			t.Errorf("app.js:%d: the entrance class is applied in a function that never consults %s().\n"+
 				"  Guarding the CSS only removes the SMOOTHNESS; a scheduled class change still moves "+
 				"content. Apply it to every node at once when the preference is set.",
@@ -426,11 +517,94 @@ func TestJavaScriptMotionConsultsThePreference(t *testing.T) {
 	}
 }
 
-// enclosingFuncStart returns the offset of the top-level function declaration
-// containing pos, or 0 if there is none before it.
-func enclosingFuncStart(js string, pos int) int {
-	if i := strings.LastIndex(js[:pos], "\nfunction "); i >= 0 {
-		return i
+// funcBoundaryRE matches every top-level declaration that starts a function
+// body in app.js.
+//
+// `\nfunction ` alone was not enough and the gap was invisible: app.js has 56
+// `async function` declarations, so the window computed for the timeline
+// reveal ran 72 lines past the end of renderTimeline and swallowed the whole
+// of renderStatus. A gate written in THAT function satisfied the check — the
+// exact failure the scoping exists to prevent.
+var funcBoundaryRE = regexp.MustCompile(`(?m)^(?:async\s+)?function\s|^(?:const|let|var|class)\s`)
+
+// enclosingFunc returns the body of the top-level declaration containing pos,
+// bounded at the next one.
+func enclosingFunc(js string, pos int) string {
+	start, end := 0, len(js)
+	for _, l := range funcBoundaryRE.FindAllStringIndex(js, -1) {
+		if l[0] <= pos {
+			start = l[0]
+			continue
+		}
+		end = l[0]
+		break
 	}
-	return 0
+	return js[start:end]
+}
+
+// The classifier decides which transitions the whole-file guard polices, and
+// until now it was driven only by the real stylesheet — so every branch it
+// does not currently reach was untested, including one that would have been
+// wrong the first time it fired.
+//
+// The threshold cases are the point: 250ms is feedback and 300ms is motion,
+// and getting that backwards produces either a guard that misses entrances or
+// one that alarms on a hover nudge.
+func TestTransitionIsMotionClassifies(t *testing.T) {
+	for _, tc := range []struct {
+		decl string
+		want bool
+		why  string
+	}{
+		{"transition: transform .12s var(--ease)", false, "button press, feedback"},
+		{"transition: color .18s, transform .25s var(--ease-out)", false, "icon nudge, feedback"},
+		{"transition: transform .3s var(--ease-out)", true, "exactly the threshold, inclusive"},
+		{"transition: transform .45s var(--ease-out)", true, "timeline entrance"},
+		{"transition: all .5s", true, "`all` includes transform"},
+		{"transition: all .1s", false, "`all`, but too short to be motion"},
+		{"transition: border-top-color .4s", false, "colour only — \\btop\\b must not match inside it"},
+		{"transition: border-top-width .4s", true, "width is geometry; the strip must not eat it"},
+		{"transition: box-shadow 2s", false, "shadow paints depth, it does not move"},
+		{"transition: background-image 2s", false, "not geometry"},
+		{"transition: transform cubic-bezier(.4, 0, .2, 1) .45s", true, "duration after the timing function"},
+		{"transition: transform .35s cubic-bezier(.4, 0, .2, 1)", true, "commas inside the group must not split it"},
+		{"transition: transform .1s .5s", false, "the second time is the DELAY, not the duration"},
+		{"transition: transform 400MS ease", true, "units are case-insensitive"},
+		{"transition:.4s transform", true, "duration flush against the colon"},
+		{"transition: TRANSFORM .5s", true, "property names are case-insensitive"},
+		{"transition: opacity .5s, transform 2s", true, "one moving segment is enough"},
+		{"transition: opacity .5s, color 2s", false, "no segment moves"},
+		{"transition: transform var(--slow)", false, "no literal duration: waived, not proven safe"},
+	} {
+		if got, _ := transitionIsMotion(tc.decl); got != tc.want {
+			t.Errorf("transitionIsMotion(%q) = %v, want %v — %s", tc.decl, got, tc.want, tc.why)
+		}
+	}
+}
+
+// The longhand form is judged from its rule block, because its duration is a
+// separate declaration.
+//
+// The no-duration row is the one that matters and it is not a technicality:
+// `transition-duration`'s initial value is 0s, so a property listed without
+// one transitions nothing. Treating the property alone as motion — which the
+// first version of this branch did — flags a rule that cannot animate.
+func TestTransitionLonghandNeedsItsDuration(t *testing.T) {
+	for _, tc := range []struct {
+		css  string
+		want bool
+		why  string
+	}{
+		{".x { transition-property: transform; transition-duration: .45s; }", true, "the escape this branch exists for"},
+		{".x { transition-property: transform; transition-duration: .1s; }", false, "short: feedback, same threshold as the shorthand"},
+		{".x { transition-property: transform; }", false, "no duration: initial value 0s, nothing transitions"},
+		{".x { transition-duration: 2s; transition-property: transform; }", true, "declaration order must not matter"},
+		{".x { transition-property: color; transition-duration: 2s; }", false, "long, but colour does not move"},
+		{".x { transition-property: transform; transition-duration: 100ms, 2s; }", true, "any listed duration over the line"},
+	} {
+		pos := strings.Index(tc.css, "transition-property")
+		if got, _ := longhandIsMotion(tc.css, pos); got != tc.want {
+			t.Errorf("longhandIsMotion(%q) = %v, want %v — %s", tc.css, got, tc.want, tc.why)
+		}
+	}
 }

--- a/internal/console/assets_reducedmotion_test.go
+++ b/internal/console/assets_reducedmotion_test.go
@@ -3,6 +3,7 @@ package console
 import (
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -12,12 +13,18 @@ import (
 // byte offsets and newlines so every match position and line number computed
 // against the result is valid for the original file.
 //
-// Blanking rather than deleting is what makes the whole-file scan safe. Two
-// concrete hazards it removes, both of which produced wrong answers in earlier
-// hand-written versions of this audit: a comment quoting `@media
-// (prefers-reduced-motion: ...)` was picked up as a real at-rule, and a
-// `content: "{"` declaration desynchronised the brace scanner so a block's
-// computed end landed hundreds of lines past its real one.
+// Blanking rather than deleting is what makes the whole-file scan safe, and it
+// is load-bearing twice over. It keeps offsets aligned, and because a blanked
+// comment becomes whitespace it still satisfies the `[;{\s]` prefix the
+// declaration patterns below require — so `.a{/*c*/animation: x 1s}` is caught
+// where deleting the comment would have joined `{` to `animation` and, with a
+// different prefix class, could have hidden it.
+//
+// Two hazards it forecloses. Neither is present in style.css today, and both
+// were demonstrated by review rather than observed in the wild: a comment
+// quoting `@media (prefers-reduced-motion: ...)` read as a real at-rule, and a
+// `content: "{"` declaration desynchronising the brace scanner so a block's
+// computed end lands hundreds of lines past its real one.
 func sanitizeCSS(css string) string {
 	out := []byte(css)
 	blank := func(i int) {
@@ -28,9 +35,16 @@ func sanitizeCSS(css string) string {
 	for i := 0; i < len(css); i++ {
 		switch {
 		case css[i] == '/' && i+1 < len(css) && css[i+1] == '*':
+			blank(i)
+			blank(i + 1)
+			// Scanning from i+2, not i: starting at the opening `/` let the
+			// terminator check match the comment's OWN `*`, so `/*/` closed
+			// immediately and `.a>*/*{ … } */` leaked its braces into the
+			// scan — the exact desync this function exists to prevent.
+			i += 2
 			for ; i < len(css); i++ {
 				blank(i)
-				if css[i] == '/' && i > 0 && css[i-1] == '*' && i > 1 {
+				if css[i] == '/' && css[i-1] == '*' {
 					break
 				}
 			}
@@ -98,43 +112,98 @@ func within(rs [][2]int, p int) bool {
 	return false
 }
 
+const (
+	noPrefNeedle = "@media (prefers-reduced-motion: no-preference)"
+	reduceNeedle = "@media (prefers-reduced-motion: reduce)"
+	// Where feedback ends and animation begins, in milliseconds.
+	motionThresholdMs = 300
+)
+
 var (
 	animRE = regexp.MustCompile(`(?:^|[;{\s])animation(?:-name)?\s*:`)
-	tranRE = regexp.MustCompile(`(?:^|[;{\s])transition\s*:`)
+	// The longhand is matched too. `animation(-name)?` already covered its
+	// counterpart, and the asymmetry was the whole bug: `transition-property:
+	// transform; transition-duration: .45s` produced zero findings.
+	tranRE = regexp.MustCompile(`(?:^|[;{\s])transition(?:-property)?\s*:`)
 	// Properties whose transition physically moves something on screen.
 	// Colour and shadow transitions are deliberately absent: reduced-motion is
 	// about vestibular motion, and banning a 150ms colour fade would make the
 	// rule one nobody could follow.
 	geomRE = regexp.MustCompile(`\b(transform|all|translate|scale|rotate|top|left|right|bottom|width|height|margin|padding|inset|gap)\b`)
-	durRE  = regexp.MustCompile(`(?:^|[\s(,])(\d*\.?\d+)(ms|s)\b`)
+	// `\btop\b` matches INSIDE `border-top-color`, because `-` is a non-word
+	// character on both sides — so the rule above fired on a pure colour
+	// transition, contradicting its own comment. A guard that invents alarms
+	// against correct code is the one that gets deleted, so the non-geometric
+	// suffixed properties are removed before matching. Dropping every
+	// hyphenated name instead would also lose `max-height` and `margin-left`,
+	// which genuinely do move things.
+	nonGeomPropRE = regexp.MustCompile(`\b[a-z-]*-(color|style|shadow|image|radius)\b`)
+	// Case-insensitive: `400MS` is valid CSS. The prefix class admits `:` so a
+	// duration written flush against the colon (`transition:.4s transform`) is
+	// still found.
+	durRE = regexp.MustCompile(`(?i)(?:^|[\s(,:])(\d*\.?\d+)(ms|s)\b`)
+	// Balanced groups are blanked before the value is split on commas: the
+	// commas inside `cubic-bezier(.4, 0, .2, 1)` tore one transition into four
+	// fragments, and a duration written AFTER the timing function landed in a
+	// fragment naming no property, so it escaped entirely.
+	parenGroupRE = regexp.MustCompile(`\([^()]*\)`)
+	kfDeclRE     = regexp.MustCompile(`@keyframes\s+([\w-]+)`)
+	animValueRE  = regexp.MustCompile(`(?:^|[;{\s])animation(?:-name)?\s*:([^;}]*)`)
 )
+
+// declValue returns the declaration starting at from, up to its terminator.
+func declValue(css string, from int) string {
+	end := strings.IndexAny(css[from:], ";}")
+	if end < 0 {
+		return css[from:]
+	}
+	return css[from : from+end]
+}
+
+func blankParens(s string) string {
+	for {
+		next := parenGroupRE.ReplaceAllStringFunc(s, func(m string) string { return strings.Repeat(" ", len(m)) })
+		if next == s {
+			return s
+		}
+		s = next
+	}
+}
 
 // transitionIsMotion reports whether any comma-separated segment of a
 // transition value both moves geometry AND runs long enough to read as
 // animation rather than feedback.
 //
 // The threshold exists because a blanket "no transform transitions outside the
-// guard" would be a rule nobody follows: five of the seven this audit first
-// surfaced were a 2px icon nudge on hover, a 1px button press, and a rotating
-// caret — direct-manipulation feedback, not the large sustained motion
-// prefers-reduced-motion is about. At a third of a second a transition has
-// stopped being feedback; that is where the two genuine entrance animations in
-// this file (a timeline node sliding in, its dot scaling up) sit, and both are
-// entrances, exactly the class `rise` is already guarded for.
+// guard" would be a rule nobody follows. Of the seven this audit first
+// surfaced, five are direct-manipulation feedback: a 2px icon nudge on hover,
+// a 1px button press, a rotating caret, an 8% swatch hover scale, and — the
+// largest thing the threshold waives, so worth naming rather than implying —
+// a 16px settings-toggle knob slide. At a third of a second a transition has
+// stopped being feedback; that is where the timeline node's .45s slide-in
+// sits, an entrance of exactly the class `rise` is already guarded for.
+//
+// The other declaration above the line, `.tl-dot`'s .3s, is currently inert —
+// nothing changes that element's transform, and the dot's scale-up is the
+// `dotpop` ANIMATION, not this transition. It is guarded anyway rather than
+// deleted: the cost is one line, and the day something does move the dot the
+// guard is already in place.
 func transitionIsMotion(value string) (bool, string) {
-	for _, seg := range strings.Split(value, ",") {
-		if !geomRE.MatchString(seg) {
+	for _, seg := range strings.Split(blankParens(value), ",") {
+		if !geomRE.MatchString(nonGeomPropRE.ReplaceAllString(seg, "")) {
 			continue
 		}
 		m := durRE.FindStringSubmatch(seg)
 		if m == nil {
-			continue // no duration: nothing transitions
+			// No LITERAL duration. A `var(--slow)` duration is waived here,
+			// not proven safe.
+			continue
 		}
 		ms, err := strconv.ParseFloat(m[1], 64)
 		if err != nil {
 			continue
 		}
-		if m[2] == "s" {
+		if !strings.EqualFold(m[2], "ms") {
 			ms *= 1000
 		}
 		if ms >= motionThresholdMs {
@@ -142,17 +211,6 @@ func transitionIsMotion(value string) (bool, string) {
 		}
 	}
 	return false, ""
-}
-
-// Where feedback ends and animation begins, in milliseconds.
-const motionThresholdMs = 300
-
-func declValue(css string, from int) string {
-	end := strings.IndexAny(css[from:], ";}")
-	if end < 0 {
-		return css[from:]
-	}
-	return css[from : from+end]
 }
 
 // Every motion declaration in style.css must sit inside the reduced-motion
@@ -165,8 +223,23 @@ func declValue(css string, from int) string {
 //  1. motion lives in @media (prefers-reduced-motion: no-preference); the rule
 //     outside it is the resting state.
 //  2. @media (prefers-reduced-motion: reduce) may carry a STATIC alternative
-//     for an indicator whose animation was the only signal (the coverage
+//     for an indicator whose animation carried nearly all of its signal (the coverage
 //     spinner dims instead of spinning), and nothing else.
+//
+// This test enforces the negative half of shape 2 — no animation, no long
+// geometry transition inside a reduce block — and cannot enforce "nothing
+// else". Nor is it "every motion declaration" in the fullest sense: it knows
+// two property families, so `scroll-behavior: smooth`, view transitions and
+// anything driven from JavaScript are invisible to it.
+//
+// Where the rest is checked, precisely, because "the e2e covers it" was itself
+// wrong once: scenario 17c in console-e2e renders the guarded rules in a real
+// browser and asserts the RESTING state each one leaves behind — a cascade
+// question no text scan can answer. Scenario 17d drives renderTimeline under
+// both media states and pins the stagger app.js schedules in JavaScript, which
+// neither this test nor 17c can reach. The two scrollIntoView call sites that
+// read the same matchMedia helper have NO guard: their smooth/auto difference
+// is a browser-internal scroll with no observable DOM state.
 //
 // The console is opened during incidents. Someone whose OS asks for reduced
 // motion is not asking for a nicer console; motion sickness while reading a
@@ -178,10 +251,24 @@ func TestReducedMotionHasOneShape(t *testing.T) {
 	}
 	css := sanitizeCSS(string(raw))
 
-	noPref := atRuleRanges(t, css, "@media (prefers-reduced-motion: no-preference)")
-	reduce := atRuleRanges(t, css, "@media (prefers-reduced-motion: reduce)")
+	noPref := atRuleRanges(t, css, noPrefNeedle)
+	reduce := atRuleRanges(t, css, reduceNeedle)
 	if len(noPref) == 0 {
 		t.Fatal("style.css has no prefers-reduced-motion: no-preference block — this guard covers nothing")
+	}
+	// atRuleRanges fails loudly on ONE brace error, but a stray `{` inside a
+	// guard paired with a stray `}` later balances out into a single range
+	// spanning most of the file — at which point everything looks guarded.
+	// Comparing the range count to the needle count catches the swallowing
+	// without re-architecting the scanner.
+	for _, n := range []struct {
+		needle string
+		got    int
+	}{{noPrefNeedle, len(noPref)}, {reduceNeedle, len(reduce)}} {
+		if want := strings.Count(css, n.needle); n.got != want {
+			t.Fatalf("found %d %s blocks but %d occurrences of the at-rule: a brace error has "+
+				"merged blocks, so this guard cannot tell guarded from unguarded", n.got, n.needle, want)
+		}
 	}
 
 	ws := regexp.MustCompile(`\s+`)
@@ -196,15 +283,22 @@ func TestReducedMotionHasOneShape(t *testing.T) {
 			report(m[0], "a reduce block must not animate. Move the animation into the "+
 				"no-preference block; keep only the static alternative here.")
 		case !within(noPref, m[0]):
-			report(m[0], "animates outside @media (prefers-reduced-motion: no-preference). "+
-				"Move it in, and make sure the rule left outside is the RESTING state — an "+
-				"animation with forwards/both fill often leaves the base rule holding the "+
-				"START frame, which then becomes permanent.")
+			report(m[0], "animates outside "+noPrefNeedle+". Move it in, and make sure the rule "+
+				"left outside is the RESTING state — an animation with forwards/both fill often "+
+				"leaves the base rule holding the START frame, which then becomes permanent.")
 		}
 	}
 
 	for _, m := range tranRE.FindAllStringIndex(css, -1) {
-		motion, seg := transitionIsMotion(declValue(css, m[0]))
+		val := declValue(css, m[0])
+		motion, seg := transitionIsMotion(val)
+		if strings.Contains(val, "transition-property") {
+			// The longhand's duration lives in a SEPARATE declaration, so
+			// pairing them reliably is more machinery than the case is worth.
+			// Geometry named by a transition-property must be inside the
+			// guard, duration unread.
+			motion, seg = geomRE.MatchString(nonGeomPropRE.ReplaceAllString(val, "")), strings.TrimSpace(val)
+		}
 		if !motion {
 			continue
 		}
@@ -214,8 +308,8 @@ func TestReducedMotionHasOneShape(t *testing.T) {
 		case !within(noPref, m[0]):
 			report(m[0], "`"+seg+"` moves geometry for "+strconv.Itoa(motionThresholdMs)+
 				"ms or longer, which reads as animation rather than feedback. Move the "+
-				"transition into @media (prefers-reduced-motion: no-preference); leave the "+
-				"final position outside it so the element still ARRIVES without the animation.")
+				"transition into "+noPrefNeedle+"; leave the final position outside it so the "+
+				"element still ARRIVES without the animation.")
 		}
 	}
 
@@ -228,4 +322,115 @@ func TestReducedMotionHasOneShape(t *testing.T) {
 			"zeroed under reduce, so scaling a duration by it guarded nothing while looking "+
 			"like it did. Put the rule in the no-preference block instead.", lineOf(css, i))
 	}
+}
+
+// Every @keyframes must be driven from inside the reduced-motion guard.
+//
+// This is the half the rule above structurally cannot see. "Motion may not sit
+// outside the guard" is satisfied perfectly by having no motion at all, so
+// deleting a guarded declaration — the ordinary way a refactor loses an
+// animation — passes it green. Nine such deletions were demonstrated during
+// review, every assertion still passing.
+//
+// Anchoring on the keyframes rather than on a list of names in a test keeps
+// the two in step automatically: a new animation is covered the moment its
+// keyframes land, and an intentionally retired one is removed in the same
+// commit as its declaration or this fails.
+func TestEveryKeyframeIsDrivenFromInsideTheGuard(t *testing.T) {
+	raw, err := os.ReadFile("assets/style.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	css := sanitizeCSS(string(raw))
+	noPref := atRuleRanges(t, css, noPrefNeedle)
+
+	declared := map[string]int{}
+	for _, m := range kfDeclRE.FindAllStringSubmatchIndex(css, -1) {
+		declared[css[m[2]:m[3]]] = m[0]
+	}
+	if len(declared) == 0 {
+		t.Fatal("style.css declares no @keyframes — this guard covers nothing")
+	}
+
+	driven := map[string]bool{}
+	for _, m := range animValueRE.FindAllStringSubmatchIndex(css, -1) {
+		if !within(noPref, m[0]) {
+			continue
+		}
+		for _, tok := range strings.FieldsFunc(css[m[2]:m[3]], func(r rune) bool {
+			return r == ' ' || r == ',' || r == '\t' || r == '\n'
+		}) {
+			if _, ok := declared[tok]; ok {
+				driven[tok] = true
+			}
+		}
+	}
+
+	var orphans []string
+	for name := range declared {
+		if !driven[name] {
+			orphans = append(orphans, name)
+		}
+	}
+	sort.Strings(orphans)
+	for _, name := range orphans {
+		t.Errorf("style.css:%d: @keyframes %s is never driven from inside %s.\n"+
+			"  Either it lost its animation declaration (a deletion no other guard here can "+
+			"see), the declaration sits outside the guard, or the keyframes are dead code and "+
+			"should go in this commit.", lineOf(css, declared[name]), name, noPrefNeedle)
+	}
+}
+
+// Motion started from JavaScript must consult the setting itself.
+//
+// style.css cannot reach it, and the CSS guard's success is what makes this
+// necessary rather than optional: removing a transition under `reduce` stops
+// the movement being SMOOTH, but a timer that schedules the position change
+// still moves things. The timeline reveal was exactly that — the guarded CSS
+// left every node snapping into place one at a time across ~2.8 seconds.
+//
+// Both anchors name a visual effect rather than a mechanism, so they survive
+// renaming a local or retuning the stagger: `behavior: "smooth"` is the only
+// scroll animation the platform offers, and `"in"` is the entrance class the
+// stylesheet's .tl-node rules key on.
+func TestJavaScriptMotionConsultsThePreference(t *testing.T) {
+	raw, err := os.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := string(raw)
+	const gate = "prefersReducedMotion"
+
+	for _, m := range regexp.MustCompile(`\bbehavior:\s*[^,;)\n]*"smooth"`).FindAllStringIndex(js, -1) {
+		if !strings.Contains(lineAt(js, m[0]), gate) {
+			t.Errorf("app.js:%d: %s\n  Smooth scrolling is a vestibular trigger and this one is on "+
+				"the Restore path. Pass %s() ? \"auto\" : \"smooth\".",
+				lineOf(js, m[0]), strings.TrimSpace(lineAt(js, m[0])), gate)
+		}
+	}
+
+	// Scoped to the enclosing function, not the whole file: a gate anywhere in
+	// 5000 lines would satisfy a file-wide search while the reveal it is
+	// supposed to cover stays ungated.
+	for _, m := range regexp.MustCompile(`classList\.add\("in"\)`).FindAllStringIndex(js, -1) {
+		body := js[enclosingFuncStart(js, m[0]):]
+		if end := strings.Index(body[1:], "\nfunction "); end > 0 {
+			body = body[:end+1]
+		}
+		if !strings.Contains(body, gate) {
+			t.Errorf("app.js:%d: the entrance class is applied in a function that never consults %s().\n"+
+				"  Guarding the CSS only removes the SMOOTHNESS; a scheduled class change still moves "+
+				"content. Apply it to every node at once when the preference is set.",
+				lineOf(js, m[0]), gate)
+		}
+	}
+}
+
+// enclosingFuncStart returns the offset of the top-level function declaration
+// containing pos, or 0 if there is none before it.
+func enclosingFuncStart(js string, pos int) int {
+	if i := strings.LastIndex(js[:pos], "\nfunction "); i >= 0 {
+		return i
+	}
+	return 0
 }

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -2078,6 +2078,77 @@ try {
     ? ok("busy modal: prefers-reduced-motion collapses the animation to the static note")
     : bad("busy modal: prefers-reduced-motion collapses the animation to the static note", JSON.stringify(rmOn));
 
+  // Scenario 17c — resting states under prefers-reduced-motion (#1392).
+  //
+  // The whole-file guard in assets_reducedmotion_test.go proves every
+  // animation SITS inside the reduced-motion block. It cannot prove the rule
+  // left OUTSIDE is a usable resting state, and that is the failure that costs
+  // information rather than polish: `ul` defines only a `to` frame, so while
+  // its scaleX(0) start lived on the base rule, honouring the preference hid
+  // the underline marking WHICH value changed — permanently, with the guard
+  // green. A text checker cannot see that; it is a cascade question, so it is
+  // asked of a real browser.
+  //
+  // The elements are synthesised rather than driven to through the UI on
+  // purpose: the claim is about the stylesheet, and reaching a timeline with a
+  // changed value through five navigations would test the route, not the CSS.
+  const restProbe = async () => page.evaluate(() => {
+    const host = document.createElement("div");
+    host.innerHTML = '<div class="tl-node in"><span class="tl-dot"></span>'
+      + '<div class="tl-body"><span class="pv changed">v</span></div></div>'
+      + '<nav class="nav"><a class="nav-item active"><span>x</span></a></nav>'
+      + '<button class="cov-refresh-btn spin"><span class="cov-refresh-ico">'
+      + '<svg viewBox="0 0 24 24"></svg></span></button>'
+      + '<div class="view-enter"><div>panel</div></div>';
+    document.body.appendChild(host);
+    const cs = (sel, pseudo) => getComputedStyle(host.querySelector(sel), pseudo || null);
+    const res = {
+      underline: cs(".pv.changed", "::after").transform,
+      underlineAnim: cs(".pv.changed", "::after").animationName,
+      node: cs(".tl-node.in").transform,
+      dot: cs(".tl-dot").transform,
+      railHeight: cs(".nav-item.active", "::before").height,
+      railAnim: cs(".nav-item.active", "::before").animationName,
+      spinAnim: cs(".cov-refresh-ico svg").animationName,
+      spinOpacity: cs(".cov-refresh-btn.spin").opacity,
+      riseAnim: cs(".view-enter > div").animationName,
+    };
+    host.remove();
+    return res;
+  });
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  const rest = await restProbe();
+  await page.emulateMedia({ reducedMotion: "no-preference" });
+  const moved = await restProbe();
+  await page.emulateMedia({ reducedMotion: null });
+
+  // Every element must ARRIVE without its animation. "none" is the computed
+  // transform of an element with none declared — i.e. scaleX(1), full size,
+  // final position.
+  (rest.underline === "none" && rest.underlineAnim === "none")
+    ? ok("reduced motion: the changed-value underline is VISIBLE without its animation")
+    : bad("reduced motion: the changed-value underline is VISIBLE without its animation", JSON.stringify(rest));
+  (rest.node === "none" && rest.dot === "none")
+    ? ok("reduced motion: timeline node and dot rest at their final position")
+    : bad("reduced motion: timeline node and dot rest at their final position", JSON.stringify(rest));
+  (rest.railHeight !== "0px" && rest.railAnim === "none" && rest.riseAnim === "none")
+    ? ok("reduced motion: the active rail keeps its height and no entrance animation runs")
+    : bad("reduced motion: the active rail keeps its height and no entrance animation runs", JSON.stringify(rest));
+  // The spinner is the ONLY in-flight signal, so its guard owes a replacement.
+  (rest.spinAnim === "none" && rest.spinOpacity === "0.55")
+    ? ok("reduced motion: the refresh spinner is replaced by a dimmed button, not by nothing")
+    : bad("reduced motion: the refresh spinner is replaced by a dimmed button, not by nothing", JSON.stringify(rest));
+
+  // The other half: moving the rules into the guard must not have deleted the
+  // motion for everyone else. Without this, emptying the block passes above.
+  (moved.underlineAnim === "ul" && moved.railAnim === "railpop"
+    && moved.spinAnim === "covspin" && moved.riseAnim === "rise")
+    ? ok("reduced motion: under no-preference every guarded animation still runs")
+    : bad("reduced motion: under no-preference every guarded animation still runs", JSON.stringify(moved));
+  moved.spinOpacity === "1"
+    ? ok("reduced motion: the dimmed-button stand-in does not leak into no-preference")
+    : bad("reduced motion: the dimmed-button stand-in does not leak into no-preference", moved.spinOpacity);
+
   // ── Scenario 18 — advisory severity split on the archive fixture (#1365) ──
   // The archive-elision record must render in the INFO register (muted line,
   // no ⚠ icon, no amber, no alert classes) while a real coverage-gap warning

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1264,32 +1264,51 @@ try {
       f.elements.since.value = "";
       f.elements.until.value = "2000-01-01 00:00:00";
       await runState(f, true);
-      // Sample once renderTimeline's rAF has run. Under reduce that callback
-      // marks every node synchronously; under no-preference the FIRST node is
-      // still 60 ms out and the last 60 + (n-1)*55 ms.
-      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
-      const nodes = Array.from(document.querySelectorAll(".tl-node"));
-      return { total: nodes.length, arrived: nodes.filter((n) => n.classList.contains("in")).length };
+      // Record the poll tick at which each node FIRST carries `.in`, instead
+      // of sampling once at a fixed instant.
+      //
+      // What is under test is a relative ordering — setTimeout(60) fires
+      // before setTimeout(115) however loaded the runner is — and an ordering
+      // survives a stall that a fixed window does not. The single snapshot
+      // this replaces needed the second node's 115ms to still be in the
+      // future when it read, and this fixture renders exactly two nodes, so
+      // that margin was the whole assertion. It also gets STRONGER as the
+      // fixture grows rather than weaker.
+      const firstSeen = [];
+      let arrived = 0, total = 0;
+      for (let tick = 0; tick < 90; tick++) {
+        const nodes = document.querySelectorAll(".tl-node");
+        total = nodes.length;
+        arrived = 0;
+        nodes.forEach((n, i) => {
+          if (!n.classList.contains("in")) return;
+          arrived++;
+          if (firstSeen[i] === undefined) firstSeen[i] = tick;
+        });
+        if (total > 0 && arrived === total) break;
+        await new Promise((r) => setTimeout(r, 10));
+      }
+      return { total, arrived, firstSeen };
     });
   };
   const rmTl = await staggerProbe("reduce");
   const npTl = await staggerProbe("no-preference");
   await page.emulateMedia({ reducedMotion: null });
 
-  (rmTl.total > 0 && rmTl.arrived === rmTl.total)
-    ? ok("reduced motion: every timeline node has arrived by the first frame — no JS stagger")
-    : bad("reduced motion: every timeline node has arrived by the first frame — no JS stagger", JSON.stringify(rmTl));
+  (rmTl.total > 0 && rmTl.arrived === rmTl.total
+    && rmTl.firstSeen.every((t) => t === rmTl.firstSeen[0]))
+    ? ok("reduced motion: every timeline node arrives on the same tick — no JS stagger")
+    : bad("reduced motion: every timeline node arrives on the same tick — no JS stagger", JSON.stringify(rmTl));
   // The other half, and the reason the arm above is not satisfied by a broken
-  // render: under no-preference the same probe must find nodes still en route.
-  // Needs two nodes to stay clear of the 60 ms first delay on a slow runner;
-  // with fewer, say so rather than assert on a coin flip.
-  if (npTl.total < 2) {
-    ok("reduced motion: no-preference stagger not asserted (timeline rendered " + npTl.total + " node(s))");
-  } else {
-    (npTl.arrived < npTl.total)
-      ? ok("reduced motion: under no-preference the timeline still arrives one node at a time")
-      : bad("reduced motion: under no-preference the timeline still arrives one node at a time", JSON.stringify(npTl));
-  }
+  // render: under no-preference the nodes must arrive IN SEQUENCE.
+  //
+  // Two nodes are enough for an order claim, so unlike the snapshot version
+  // there is no fixture size at which this quietly stops asserting — and a
+  // fixture that drops below two is reported as a failure rather than waved
+  // through, because at that point the scenario has proved nothing.
+  (npTl.total >= 2 && npTl.arrived === npTl.total && npTl.firstSeen[1] > npTl.firstSeen[0])
+    ? ok("reduced motion: under no-preference the timeline arrives one node at a time")
+    : bad("reduced motion: under no-preference the timeline arrives one node at a time", JSON.stringify(npTl));
 
   // Scenario 14c — the Overview against the LIVE daemon (#1300). The fixture
   // scenario below drives buildOverview directly, so it cannot catch a route
@@ -2150,7 +2169,8 @@ try {
       + '<nav class="nav"><a class="nav-item active"><span>x</span></a></nav>'
       + '<button class="cov-refresh-btn spin"><span class="cov-refresh-ico">'
       + '<svg viewBox="0 0 24 24"></svg></span></button>'
-      + '<div class="view-enter"><div>panel</div></div>';
+      + '<div class="view-enter"><div>panel</div></div>'
+      + '<div class="ov-stat"><div class="ov-stat-v">1</div></div>';
     document.body.appendChild(host);
     const cs = (sel, pseudo) => getComputedStyle(host.querySelector(sel), pseudo || null);
     const res = {
@@ -2163,12 +2183,15 @@ try {
       spinAnim: cs(".cov-refresh-ico svg").animationName,
       spinOpacity: cs(".cov-refresh-btn.spin").opacity,
       riseAnim: cs(".view-enter > div").animationName,
-      // Transitions have no @keyframes, so the Go orphan check cannot notice
-      // one being deleted. These two are the only motion in the file with no
-      // other guard behind them.
+      // The Go orphan check anchors on @keyframes, which leaves two blind
+      // spots these four fields cover. A guarded TRANSITION has no keyframes
+      // to orphan; and `rise` is declared on BOTH .view-enter > * and
+      // .ov-stat, so deleting either one leaves the name still "driven".
       nodeTransDur: cs(".tl-node.in").transitionDuration,
       dotTransDur: cs(".tl-dot").transitionDuration,
       dotAnim: cs(".tl-dot").animationName,
+      ovAnim: cs(".ov-stat").animationName,
+      ovTransDur: cs(".ov-stat").transitionDuration,
     };
     host.remove();
     return res;
@@ -2189,6 +2212,9 @@ try {
     && rest.nodeTransDur === "0s" && rest.dotTransDur === "0s")
     ? ok("reduced motion: timeline node and dot rest at their final position, untimed")
     : bad("reduced motion: timeline node and dot rest at their final position, untimed", JSON.stringify(rest));
+  (rest.ovAnim === "none" && rest.ovTransDur === "0s")
+    ? ok("reduced motion: the stat tile neither enters nor transitions")
+    : bad("reduced motion: the stat tile neither enters nor transitions", JSON.stringify(rest));
   rest.railHeight !== "0px"
     ? ok("reduced motion: the active rail keeps its height without railpop")
     : bad("reduced motion: the active rail keeps its height without railpop", rest.railHeight);
@@ -2208,9 +2234,17 @@ try {
     && moved.riseAnim === "rise" && moved.dotAnim === "dotpop")
     ? ok("reduced motion: under no-preference every animation this probe covers still runs")
     : bad("reduced motion: under no-preference every animation this probe covers still runs", JSON.stringify(moved));
-  (moved.nodeTransDur === "0.45s" && moved.dotTransDur === "0.3s")
-    ? ok("reduced motion: the two guarded timeline transitions still have their durations")
-    : bad("reduced motion: the two guarded timeline transitions still have their durations", JSON.stringify(moved));
+  // Asserted as "nonzero", not as an exact duration. The exact form caught the
+  // deletion this exists for, but it ALSO went red on a legitimate retune
+  // (.45s -> .5s) with a message accusing the author of a deletion that never
+  // happened — the cry-wolf shape this file argues against everywhere else.
+  (parseFloat(moved.nodeTransDur) > 0 && parseFloat(moved.dotTransDur) > 0
+    && parseFloat(moved.ovTransDur) > 0)
+    ? ok("reduced motion: the guarded transitions still have a duration under no-preference")
+    : bad("reduced motion: the guarded transitions still have a duration under no-preference", JSON.stringify(moved));
+  moved.ovAnim === "rise"
+    ? ok("reduced motion: the stat tile keeps its own entrance (rise has a second driver)")
+    : bad("reduced motion: the stat tile keeps its own entrance (rise has a second driver)", moved.ovAnim);
   moved.spinOpacity === "1"
     ? ok("reduced motion: the dimmed-button stand-in does not leak into no-preference")
     : bad("reduced motion: the dimmed-button stand-in does not leak into no-preference", moved.spinOpacity);

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1240,6 +1240,57 @@ try {
     }
   }
 
+
+  // ── Scenario 17d — the JavaScript half of reduced motion (#1392) ──
+  // Placed here, out of numeric order, because this is the one point in the
+  // run with a REAL rendered timeline. The stagger under test is scheduled by
+  // renderTimeline's own rAF loop; the synthesised DOM 17c uses never runs it.
+  //
+  // The Go guard and 17c both stop at the stylesheet. This stagger is driven
+  // from app.js — one setTimeout per node — so honouring the preference in CSS
+  // alone removes the SMOOTHNESS while the loop still moves every node: under
+  // `reduce` a long timeline snapped one node at a time across seconds of
+  // shifting content, a jumpier version of the motion the preference asked to
+  // remove. Only matchMedia can see this, and only at run time.
+  //
+  // NOT covered: the two scrollIntoView call sites gated on the same helper.
+  // Their smooth/auto difference is a browser-internal scroll with no
+  // observable DOM state, so this scenario makes no claim about them.
+  const staggerProbe = async (mode) => {
+    await page.emulateMedia({ reducedMotion: mode });
+    return page.evaluate(async () => {
+      const f = document.getElementById("recover-form");
+      f.elements.pk.value = "1";
+      f.elements.since.value = "";
+      f.elements.until.value = "2000-01-01 00:00:00";
+      await runState(f, true);
+      // Sample once renderTimeline's rAF has run. Under reduce that callback
+      // marks every node synchronously; under no-preference the FIRST node is
+      // still 60 ms out and the last 60 + (n-1)*55 ms.
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      const nodes = Array.from(document.querySelectorAll(".tl-node"));
+      return { total: nodes.length, arrived: nodes.filter((n) => n.classList.contains("in")).length };
+    });
+  };
+  const rmTl = await staggerProbe("reduce");
+  const npTl = await staggerProbe("no-preference");
+  await page.emulateMedia({ reducedMotion: null });
+
+  (rmTl.total > 0 && rmTl.arrived === rmTl.total)
+    ? ok("reduced motion: every timeline node has arrived by the first frame — no JS stagger")
+    : bad("reduced motion: every timeline node has arrived by the first frame — no JS stagger", JSON.stringify(rmTl));
+  // The other half, and the reason the arm above is not satisfied by a broken
+  // render: under no-preference the same probe must find nodes still en route.
+  // Needs two nodes to stay clear of the 60 ms first delay on a slow runner;
+  // with fewer, say so rather than assert on a coin flip.
+  if (npTl.total < 2) {
+    ok("reduced motion: no-preference stagger not asserted (timeline rendered " + npTl.total + " node(s))");
+  } else {
+    (npTl.arrived < npTl.total)
+      ? ok("reduced motion: under no-preference the timeline still arrives one node at a time")
+      : bad("reduced motion: under no-preference the timeline still arrives one node at a time", JSON.stringify(npTl));
+  }
+
   // Scenario 14c — the Overview against the LIVE daemon (#1300). The fixture
   // scenario below drives buildOverview directly, so it cannot catch a route
   // that was never registered, an authz table that refuses it, or a JSON shape
@@ -2083,9 +2134,9 @@ try {
   // The whole-file guard in assets_reducedmotion_test.go proves every
   // animation SITS inside the reduced-motion block. It cannot prove the rule
   // left OUTSIDE is a usable resting state, and that is the failure that costs
-  // information rather than polish: `ul` defines only a `to` frame, so while
-  // its scaleX(0) start lived on the base rule, honouring the preference hid
-  // the underline marking WHICH value changed — permanently, with the guard
+  // information rather than polish: `ul` defines only a `to` frame, so leaving
+  // its scaleX(0) start on the base rule WOULD have hidden the underline
+  // marking WHICH value changed — permanently, and with the text guard
   // green. A text checker cannot see that; it is a cascade question, so it is
   // asked of a real browser.
   //
@@ -2112,6 +2163,12 @@ try {
       spinAnim: cs(".cov-refresh-ico svg").animationName,
       spinOpacity: cs(".cov-refresh-btn.spin").opacity,
       riseAnim: cs(".view-enter > div").animationName,
+      // Transitions have no @keyframes, so the Go orphan check cannot notice
+      // one being deleted. These two are the only motion in the file with no
+      // other guard behind them.
+      nodeTransDur: cs(".tl-node.in").transitionDuration,
+      dotTransDur: cs(".tl-dot").transitionDuration,
+      dotAnim: cs(".tl-dot").animationName,
     };
     host.remove();
     return res;
@@ -2128,23 +2185,32 @@ try {
   (rest.underline === "none" && rest.underlineAnim === "none")
     ? ok("reduced motion: the changed-value underline is VISIBLE without its animation")
     : bad("reduced motion: the changed-value underline is VISIBLE without its animation", JSON.stringify(rest));
-  (rest.node === "none" && rest.dot === "none")
-    ? ok("reduced motion: timeline node and dot rest at their final position")
-    : bad("reduced motion: timeline node and dot rest at their final position", JSON.stringify(rest));
-  (rest.railHeight !== "0px" && rest.railAnim === "none" && rest.riseAnim === "none")
-    ? ok("reduced motion: the active rail keeps its height and no entrance animation runs")
-    : bad("reduced motion: the active rail keeps its height and no entrance animation runs", JSON.stringify(rest));
-  // The spinner is the ONLY in-flight signal, so its guard owes a replacement.
+  (rest.node === "none" && rest.dot === "none" && rest.dotAnim === "none"
+    && rest.nodeTransDur === "0s" && rest.dotTransDur === "0s")
+    ? ok("reduced motion: timeline node and dot rest at their final position, untimed")
+    : bad("reduced motion: timeline node and dot rest at their final position, untimed", JSON.stringify(rest));
+  rest.railHeight !== "0px"
+    ? ok("reduced motion: the active rail keeps its height without railpop")
+    : bad("reduced motion: the active rail keeps its height without railpop", rest.railHeight);
+  (rest.railAnim === "none" && rest.riseAnim === "none")
+    ? ok("reduced motion: neither the rail nor the view entrance animates")
+    : bad("reduced motion: neither the rail nor the view entrance animates", JSON.stringify(rest));
+  // The spin carries nearly all the in-flight signal — the :disabled dim is
+  // subtle and the cursor change invisible without a pointer — so its guard
+  // owes a replacement rather than a plain removal.
   (rest.spinAnim === "none" && rest.spinOpacity === "0.55")
     ? ok("reduced motion: the refresh spinner is replaced by a dimmed button, not by nothing")
     : bad("reduced motion: the refresh spinner is replaced by a dimmed button, not by nothing", JSON.stringify(rest));
 
   // The other half: moving the rules into the guard must not have deleted the
   // motion for everyone else. Without this, emptying the block passes above.
-  (moved.underlineAnim === "ul" && moved.railAnim === "railpop"
-    && moved.spinAnim === "covspin" && moved.riseAnim === "rise")
-    ? ok("reduced motion: under no-preference every guarded animation still runs")
-    : bad("reduced motion: under no-preference every guarded animation still runs", JSON.stringify(moved));
+  (moved.underlineAnim === "ul" && moved.railAnim === "railpop" && moved.spinAnim === "covspin"
+    && moved.riseAnim === "rise" && moved.dotAnim === "dotpop")
+    ? ok("reduced motion: under no-preference every animation this probe covers still runs")
+    : bad("reduced motion: under no-preference every animation this probe covers still runs", JSON.stringify(moved));
+  (moved.nodeTransDur === "0.45s" && moved.dotTransDur === "0.3s")
+    ? ok("reduced motion: the two guarded timeline transitions still have their durations")
+    : bad("reduced motion: the two guarded timeline transitions still have their durations", JSON.stringify(moved));
   moved.spinOpacity === "1"
     ? ok("reduced motion: the dimmed-button stand-in does not leak into no-preference")
     : bad("reduced motion: the dimmed-button stand-in does not leak into no-preference", moved.spinOpacity);


### PR DESCRIPTION
Closes #1392.

## What the issue found, confirmed by hand

The issue asked for its own findings to be re-checked before fixing ("my check
was a brace-matching script, not a CSS parser"). Two independent methods now
agree: a full enclosing-block chain walk and the parser this PR adds report
the same fourteen animation declarations with the same guard status, at the
same line numbers.

| shape | count | verdict |
|---|---|---|
| inside `no-preference` | 7 | correct |
| dedicated `reduce` block | 2 (`skel-shimmer`, `covspin`) | correct but a second shape |
| unguarded | 5 (`railpop`, `diffin`, `dotpop`, `ul`, `twkin`) | the bug |
| `calc(… * var(--motion))` | 5 rules | guards nothing |

`--motion` is declared once as `1` at :170, never overridden, and read by
nothing outside style.css.

## The one that was not just missing polish

`@keyframes ul { to { transform: scaleX(1); } }` — a `to` frame only. Its base
rule carried `transform: scaleX(0)` and relied on `forwards` to arrive.
Wrapping only the animation would have left the underline that marks **which
value changed** at scaleX(0) forever under `reduce`: information lost, for
exactly the users who asked for less motion. The start frame moved into the
guard with the animation.

`covspin` has the mirror-image problem and gets the opposite treatment. Its
values stay on screen during a refresh, so the spin is the only in-flight
signal; its `reduce` block keeps the `opacity: .55` stand-in and drops only
the now-redundant `animation: none`.

## Two shapes, and the guard encodes which is which

1. Motion lives in `@media (prefers-reduced-motion: no-preference)`; the rule
   outside is the resting state.
2. A `reduce` block may carry a static stand-in, and nothing else.

## Transitions: a threshold, not a ban

The audit surfaced seven unguarded geometry transitions. Five are a 2px icon
nudge on hover, a 1px button press, a rotating caret — direct-manipulation
feedback, not the sustained motion `prefers-reduced-motion` exists for. A rule
banning those is a rule nobody follows, so the guard flags geometry
transitions at **300ms or longer**. That line falls between the five (120–250ms)
and the two genuine entrances (`.tl-node.in` 450ms, `.tl-dot` 300ms), both of
which are now guarded.

## Why two test mechanisms

A text checker cannot see a cascade bug. Nine mutations, no survivors, and the
columns are disjoint — which is the argument for keeping both:

| mutation | Go guard | browser |
|---|---|---|
| baseline | pass | pass |
| **scaleX(0) back on the base rule** (the original bug) | **pass — blind** | **fail** |
| `railpop` back outside the guard | fail | fail |
| `--motion` reintroduced | fail | pass |
| `animation: none` back in the `reduce` block | fail | pass |
| 450ms entrance transition outside the guard | fail | pass |
| 120ms feedback transition outside (must pass) | pass | pass |
| spinner stand-in deleted | pass | fail |
| the `ul` animation deleted outright | pass | fail |

console-e2e scenario 17c synthesises the elements rather than navigating to
them: the claim is about the stylesheet, so driving five routes to reach a
timeline with a changed value would test the router. It asserts both
directions — every element arrives under `reduce`, and every animation still
runs under `no-preference`, so emptying the block fails too.

Verified against real headless Chrome with the real style.css bytes: under
`reduce` the underline computes `transform: none` and the spinner sits at
`opacity: 0.55`; under `no-preference` all four animations report their names.

The `#1385`-scoped guard stays, now as the stricter local rule — that section
exists only to add decorative motion, so there every transition is motion
regardless of duration.
