### PR TITLE
console: bring the brand gradient into the console chrome (#1385)

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -1334,8 +1334,16 @@ function ovStat(value, key, mod, scope) {
   // the console-e2e read "0" from the deletes tile mid-flight. A forensics
   // surface that briefly reports zero deletions is a small lie, and the
   // entrance animation already supplies the sense of arrival without one.
+  // The brand gradient (#1385) is opt-in per tile, and this is the only place
+  // that grants it. `mod` already names the exact set that must not have it,
+  // so the gate needs no list of its own: "danger" paints the deletes count in
+  // the semantic --delete, and the `small` variant is 19px at weight 500 —
+  // below WCAG's large-text bar, which is the only bar the gradient's stops
+  // clear. (`small` is built inline elsewhere and has never reached ovStat;
+  // gating on `mod` rather than on the name covers it if it ever does.)
+  const brand = mod ? " " + mod : " ov-stat-num";
   return el("div", { class: "ov-stat" },
-    el("div", { class: "ov-stat-v" + (mod ? " " + mod : ""), text: value }),
+    el("div", { class: "ov-stat-v" + brand, text: value }),
     el("div", { class: "ov-stat-k", text: key }),
     el("div", { class: "ov-stat-scope", text: scope || "" }));
 }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1993,20 +1993,30 @@ button { font-family: inherit; }
 
    WCAG. The gradient may only land on LARGE text, held to 3:1, and can never
    be relied on at the 4.5:1 body bar — a gradient has to satisfy its bar at
-   every point along the sweep, and this one dips to 3.70:1 at --brand-warm-b.
-   (Its violet stop alone would clear 4.5:1. That buys nothing: the other two
-   stops are on the same sweep.)
+   every point along the sweep, and the sweep's floor is --brand-warm-b, at
+   3.70:1 on white and 3.53:1 on the tile. (Its violet stop alone would clear
+   4.5:1. That buys nothing: the other two stops are on the same sweep.)
 
-   Measured against the grounds these rules actually paint on, rather than
-   against white — white is the assumption easiest to make here and none of the
-   shipped grounds IS white:
+   The figures below are read off RENDERED PIXELS in Chromium rather than
+   converted arithmetically, and that distinction earned itself: two
+   independent oklch->sRGB conversions agreed with each other and both
+   disagreed with the browser in the second decimal. --brand-warm-a is outside
+   the sRGB gamut, so the mapping is the engine's to choose and a converter is
+   guessing which one.
 
      ground                             warm-a  warm-b  canvas-3
-     white (not a shipped ground)        3.92    3.70     5.16
-     --surface-2, the .ov-stat tile      3.75    3.54     4.93
-     the studio sidebar, the wordmark    3.82    3.60     5.02
+     white                               3.94    3.70     5.15
+     --surface-2, the studio tile        3.76    3.53     4.91
+     the studio sidebar                  3.82    3.59     5.00
 
-   So the real floor is 3.54:1, still clear of 3:1.
+   So the floor across them is 3.53:1, still clear of 3:1.
+
+   White is in that table as a real ground, not a hypothetical: the login
+   panel's title clips this same gradient onto --surface, and under the `paper`
+   and `trail` directions the Overview tile resolves to white as well
+   (--panel-bg becomes transparent and var(--surface) respectively). The two
+   studio rows are the shipped default, which is the only direction index.html
+   sets.
 
    Which surfaces qualify is the whole reason the gradient is OPT-IN rather
    than a rule on .ov-stat-v. The two 19px elements in this console land on
@@ -2015,7 +2025,7 @@ button { font-family: inherit; }
      .brand-name       19px / 700  bold and >=18.66px  -> large text.  ok
      .ov-stat-num      32px / 600  >=24px              -> large text.  ok
      .ov-stat-v.small  19px / 500  NOT bold            -> body text.   excluded
-     .ov-stat-v.danger colour is semantic              -> excluded
+     .ov-stat-v.danger colour is --delete              -> excluded
 
    The metrics in the first two rows are declared by .brand-name and by
    .ov-stat-v respectively; .ov-stat-num carries no font rules of its own and
@@ -2065,8 +2075,14 @@ button { font-family: inherit; }
      precise about rather than claiming as a property of the design.
      .ov-stat-v.small sets no `color` at all, so this rule would win outright
      and render 19px body text as transparent ink over the gradient — exactly
-     the unreadable outcome this section exists to prevent. `small` is
-     protected by the gate in ovStat and by nothing else. */
+     the unreadable outcome this section exists to prevent.
+
+     What keeps that from happening is neither the cascade nor the gate in
+     ovStat. `small` is built inline in fillOvEvents and never calls ovStat, so
+     it is protected by its own construction site simply not granting the
+     class. The gate WOULD catch it if it were ever routed through ovStat,
+     which is why the gate keys on the modifier rather than on the name — but
+     that protection is latent today, not load-bearing. */
   .brand-name,
   .ov-stat-num {
     background-image: var(--brand-headline);
@@ -2075,14 +2091,25 @@ button { font-family: inherit; }
     color: transparent;
   }
 
-  /* The clip paints the BOX, not the glyphs. .brand-name is a flex item and so
-     already shrink-to-fit, but .ov-stat-v is a block that fills its tile: a
-     two-digit count would sample only the leading sliver of a ramp stretched
-     across the full tile and render as flat pink, with the violet stop never
-     reaching the screen.
+  /* The clip paints the BOX, not the glyphs, so a gradient box wider than its
+     text renders as a slice of the ramp. .ov-stat-v is a block filling its
+     tile: a two-digit count sampled the leading ~10% and came out flat pink,
+     with the violet stop never reaching the screen.
 
-     Scoped to the opt-in class and never to .ov-stat-v — the loading tile puts
-     a .skel-line INSIDE .ov-stat-v, and a shrink-to-fit parent would collapse
-     that skeleton to nothing. Same fix the login panel's title already uses. */
+     .brand-name is here too, though it looks like it does not need to be. It
+     is NOT a flex item — it is a plain block inside an unclassed wrapper, and
+     what shrinks it is that wrapper being .brand's flex item, so its width is
+     the wider of the wordmark and .brand-sub. Today the wordmark wins and the
+     box is already tight. That is a coincidence about two strings, not a
+     property: measured, lengthening .brand-sub takes the box from 55px to 88px
+     around unchanged 55px of glyphs, reproducing the same bug. Cheaper to
+     remove the coincidence than to document it.
+
+     Scoped to these two and never to .ov-stat-v, so the loading tile is
+     untouched. Its skeleton would survive either way — .skel-line.skel-stat
+     carries an explicit width, which a fit-content parent honours — but a rule
+     about painted text has no business reaching a tile with no text in it.
+     Same fix the login panel's title already uses. */
+  .brand-name,
   .ov-stat-num { width: fit-content; }
 }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1973,3 +1973,76 @@ button { font-family: inherit; }
      line contained no color property. */
   .nav-item:hover .ni-icon { transform: translateX(2px); }
 }
+
+/* ============================================================
+   Brand warmth: chrome only (#1385)
+
+   The site's headline gradient, brought into the console's two most
+   chrome-like surfaces. It gets its own section because the motion section
+   above is transform-and-shadow only, by a rule its guard enforces — so the
+   PAINT half of "make it feel alive" has nowhere to live up there.
+
+   This section holds the same line the motion section holds, drawn for colour
+   instead of movement: brand paint decorates chrome and never encodes
+   anything. It goes on the sidebar wordmark and, uniformly, on the Overview
+   counts. It does NOT go on the Restore-coverage card, whose whole job is to
+   state degradation in red and amber — a warm wash behind "Events were
+   permanently lost" competes with the most important alarm this console has.
+   It does not go on rows, diffs or badges.
+
+   WCAG, measured against white rather than assumed. The gradient's stops run
+   3.70:1 (--brand-warm-b) to 5.16:1 (--brand-canvas-3), so a surface here must
+   clear the LARGE-text bar of 3:1 and may never rely on the 4.5:1 body bar.
+   The two 19px elements in this console land on opposite sides of that bar,
+   which is the entire reason the gradient is opt-in rather than a rule on
+   .ov-stat-v:
+
+     .brand-name       19px / 700  bold and >=18.66px  -> large text.  ok
+     .ov-stat-num      32px / 600  >=24px              -> large text.  ok
+     .ov-stat-v.small  19px / 500  NOT bold            -> body text.   excluded
+     .ov-stat-v.danger colour is --delete              -> semantic.    excluded
+
+   Nothing here animates, so there is nothing for prefers-reduced-motion to
+   gate. Anything added here that MOVES belongs in the motion section instead.
+   ============================================================ */
+
+/* Clipping a gradient to text means painting the ink transparent, and that is
+   the whole risk of the technique: wherever the clip does not take effect the
+   text is GONE, not merely unstyled. One query carries that risk, and it is
+   not decorative: @supports puts the declaration that hides the ink behind
+   proof that paint arrives to replace it.
+
+   There is deliberately NO forced-colors companion, which is worth stating
+   because the opposite looks obviously right. The worry — Windows High
+   Contrast strips the gradient, the transparent ink survives alone, the text
+   disappears — turns out to be unreachable: `color` is itself one of the
+   properties forced-colors replaces, so the ink can never be left transparent.
+   Measured in Chromium rather than argued: under forced-colors the computed
+   pair is background-image `none` with color `rgb(0, 0, 0)`, BYTE-IDENTICAL
+   with and without a reset block. A reset here would be a rule no change can
+   affect. (The @supports test above is not the same case: nothing in the
+   platform substitutes for it, and its correctness follows from the at-rule's
+   own semantics rather than from a measurement — if the condition is false the
+   ink is simply never made transparent.)
+
+   Deliberately NOT -webkit-text-fill-color, though that is the more common
+   incantation: it overrides `color` outright, which would break the
+   degradation described below — and it would also defeat the forced-colors
+   substitution this section is relying on. Plain `color: transparent` is
+   enough in every engine that satisfies the @supports test. */
+@supports ((background-clip: text) or (-webkit-background-clip: text)) {
+  /* One class selector each, NOT .ov-stat-v.ov-stat-num — the low specificity
+     is load-bearing in both directions. It is enough to beat .ov-stat-v's own
+     `color` (equal specificity, earlier in the file), and it deliberately
+     LOSES to .ov-stat-v.danger. So a tile that wrongly received this class
+     would still be painted opaque --delete red, hiding the clipped gradient
+     behind its glyphs; the failure degrades to the correct colour instead of
+     to invisible text. Raising the specificity here inverts that. */
+  .brand-name,
+  .ov-stat-num {
+    background-image: var(--brand-headline);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+}

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1979,28 +1979,47 @@ button { font-family: inherit; }
 
    The site's headline gradient, brought into the console's two most
    chrome-like surfaces. It gets its own section because the motion section
-   above is transform-and-shadow only, by a rule its guard enforces — so the
-   PAINT half of "make it feel alive" has nowhere to live up there.
+   above is limited to transform and box-shadow by a guard that bans paint
+   properties — so the PAINT half of "make it feel alive" has nowhere to live
+   up there.
 
    This section holds the same line the motion section holds, drawn for colour
    instead of movement: brand paint decorates chrome and never encodes
-   anything. It goes on the sidebar wordmark and, uniformly, on the Overview
-   counts. It does NOT go on the Restore-coverage card, whose whole job is to
-   state degradation in red and amber — a warm wash behind "Events were
-   permanently lost" competes with the most important alarm this console has.
-   It does not go on rows, diffs or badges.
+   anything. It goes on the sidebar wordmark and on the LARGE Overview counts.
+   It does NOT go on the Restore-coverage card, whose whole job is to state
+   degradation in red and amber — a warm wash behind "Events were permanently
+   lost" competes with the most important alarm this console has. It does not
+   go on rows, diffs or badges.
 
-   WCAG, measured against white rather than assumed. The gradient's stops run
-   3.70:1 (--brand-warm-b) to 5.16:1 (--brand-canvas-3), so a surface here must
-   clear the LARGE-text bar of 3:1 and may never rely on the 4.5:1 body bar.
-   The two 19px elements in this console land on opposite sides of that bar,
-   which is the entire reason the gradient is opt-in rather than a rule on
-   .ov-stat-v:
+   WCAG. The gradient may only land on LARGE text, held to 3:1, and can never
+   be relied on at the 4.5:1 body bar — a gradient has to satisfy its bar at
+   every point along the sweep, and this one dips to 3.70:1 at --brand-warm-b.
+   (Its violet stop alone would clear 4.5:1. That buys nothing: the other two
+   stops are on the same sweep.)
+
+   Measured against the grounds these rules actually paint on, rather than
+   against white — white is the assumption easiest to make here and none of the
+   shipped grounds IS white:
+
+     ground                             warm-a  warm-b  canvas-3
+     white (not a shipped ground)        3.92    3.70     5.16
+     --surface-2, the .ov-stat tile      3.75    3.54     4.93
+     the studio sidebar, the wordmark    3.82    3.60     5.02
+
+   So the real floor is 3.54:1, still clear of 3:1.
+
+   Which surfaces qualify is the whole reason the gradient is OPT-IN rather
+   than a rule on .ov-stat-v. The two 19px elements in this console land on
+   opposite sides of the large-text bar:
 
      .brand-name       19px / 700  bold and >=18.66px  -> large text.  ok
      .ov-stat-num      32px / 600  >=24px              -> large text.  ok
      .ov-stat-v.small  19px / 500  NOT bold            -> body text.   excluded
-     .ov-stat-v.danger colour is --delete              -> semantic.    excluded
+     .ov-stat-v.danger colour is semantic              -> excluded
+
+   The metrics in the first two rows are declared by .brand-name and by
+   .ov-stat-v respectively; .ov-stat-num carries no font rules of its own and
+   only ever rides along on an .ov-stat-v.
 
    Nothing here animates, so there is nothing for prefers-reduced-motion to
    gate. Anything added here that MOVES belongs in the motion section instead.
@@ -2008,36 +2027,46 @@ button { font-family: inherit; }
 
 /* Clipping a gradient to text means painting the ink transparent, and that is
    the whole risk of the technique: wherever the clip does not take effect the
-   text is GONE, not merely unstyled. One query carries that risk, and it is
-   not decorative: @supports puts the declaration that hides the ink behind
-   proof that paint arrives to replace it.
+   text is GONE, not merely unstyled. @supports is what keeps the declaration
+   that hides the ink behind evidence that the engine can paint over it.
 
-   There is deliberately NO forced-colors companion, which is worth stating
-   because the opposite looks obviously right. The worry — Windows High
-   Contrast strips the gradient, the transparent ink survives alone, the text
-   disappears — turns out to be unreachable: `color` is itself one of the
-   properties forced-colors replaces, so the ink can never be left transparent.
-   Measured in Chromium rather than argued: under forced-colors the computed
-   pair is background-image `none` with color `rgb(0, 0, 0)`, BYTE-IDENTICAL
-   with and without a reset block. A reset here would be a rule no change can
-   affect. (The @supports test above is not the same case: nothing in the
-   platform substitutes for it, and its correctness follows from the at-rule's
-   own semantics rather than from a measurement — if the condition is false the
-   ink is simply never made transparent.)
+   Evidence about the ENGINE, and only that: an @supports test cannot notice
+   that --brand-headline stopped resolving, which computes to the same
+   invisible pair. Scenario 17e in console-e2e is what sees that one.
 
-   Deliberately NOT -webkit-text-fill-color, though that is the more common
+   There is deliberately no forced-colors companion, worth writing down because
+   adding one looks obviously right. The worry — High Contrast strips the
+   gradient, the transparent ink survives alone, the text disappears — does not
+   reach: `color` is itself one of the properties forced-colors substitutes, so
+   the ink is never left transparent. Measured under Chromium's LIGHT
+   forced-colors palette, the computed pair is an absent background image with
+   an opaque colour, identical with and without a reset block — so a reset here
+   would have been a rule no change could affect. One engine and one palette,
+   but the substitution is the spec's behaviour rather than Chromium's. What
+   WOULD reopen it is a `forced-color-adjust: none` above these elements;
+   nothing in this file sets one.
+
+   Deliberately NOT -webkit-text-fill-color, though it is the more common
    incantation: it overrides `color` outright, which would break the
-   degradation described below — and it would also defeat the forced-colors
-   substitution this section is relying on. Plain `color: transparent` is
-   enough in every engine that satisfies the @supports test. */
+   degradation described below — and, by the same mechanism, would likely
+   defeat the forced-colors substitution as well. That second half is a
+   prediction from the spec's substituted-property list, not a measurement like
+   the paragraph above. Plain `color: transparent` suffices wherever the
+   @supports test passes. */
 @supports ((background-clip: text) or (-webkit-background-clip: text)) {
-  /* One class selector each, NOT .ov-stat-v.ov-stat-num — the low specificity
-     is load-bearing in both directions. It is enough to beat .ov-stat-v's own
-     `color` (equal specificity, earlier in the file), and it deliberately
-     LOSES to .ov-stat-v.danger. So a tile that wrongly received this class
-     would still be painted opaque --delete red, hiding the clipped gradient
-     behind its glyphs; the failure degrades to the correct colour instead of
-     to invisible text. Raising the specificity here inverts that. */
+  /* One class selector each, NOT .ov-stat-v.ov-stat-num. The low specificity
+     is deliberate: it is enough to beat .ov-stat-v's own `color` (equal
+     specificity, earlier in the file) and it LOSES to .ov-stat-v.danger — so a
+     danger tile that wrongly received this class is still painted opaque in
+     the semantic colour, hiding the clipped gradient behind its own glyphs.
+     Raising the specificity here inverts that.
+
+     That belt covers ONE of the two excluded rows above, which is worth being
+     precise about rather than claiming as a property of the design.
+     .ov-stat-v.small sets no `color` at all, so this rule would win outright
+     and render 19px body text as transparent ink over the gradient — exactly
+     the unreadable outcome this section exists to prevent. `small` is
+     protected by the gate in ovStat and by nothing else. */
   .brand-name,
   .ov-stat-num {
     background-image: var(--brand-headline);
@@ -2045,4 +2074,15 @@ button { font-family: inherit; }
     background-clip: text;
     color: transparent;
   }
+
+  /* The clip paints the BOX, not the glyphs. .brand-name is a flex item and so
+     already shrink-to-fit, but .ov-stat-v is a block that fills its tile: a
+     two-digit count would sample only the leading sliver of a ramp stretched
+     across the full tile and render as flat pink, with the violet stop never
+     reaching the screen.
+
+     Scoped to the opt-in class and never to .ov-stat-v — the loading tile puts
+     a .skel-line INSIDE .ov-stat-v, and a shrink-to-fit parent would collapse
+     that skeleton to nothing. Same fix the login panel's title already uses. */
+  .ov-stat-num { width: fit-content; }
 }

--- a/internal/console/assets_brandpaint_test.go
+++ b/internal/console/assets_brandpaint_test.go
@@ -27,8 +27,9 @@ func readAsset(t *testing.T, name string) string {
 //
 // Blanking rather than deleting keeps every offset inside the section aligned
 // with the original text, so a finding can be reported at its real file line.
-// It is also required rather than tidy: this section's prose names properties
-// and at-rules that the guards below treat as findings.
+// It is also required rather than tidy: the section's prose names --delete
+// while explaining why the deletes tile is excluded, and the semantics guard
+// below treats that token as a finding.
 func brandSection(t *testing.T) (string, int) {
 	t.Helper()
 	css := readAsset(t, "style.css")
@@ -43,11 +44,17 @@ func brandSection(t *testing.T) (string, int) {
 	}
 	// Back up to the banner that OPENS the section. Slicing at the marker
 	// instead does NOT run the comment away — sanitizeCSS only reacts to an
-	// opening `/*`, and starting mid-body it never sees one. The damage is the
-	// opposite shape: the header PROSE survives unblanked and is read as CSS,
-	// and it quotes both `@supports` and `color: transparent`. That turns
-	// guardRanges' count check into a Fatal blaming a brace error that does not
-	// exist, and invents a finding for a sentence.
+	// opening `/*`, and starting mid-body it never sees one, so brace balance
+	// and every at-rule count come out identical either way. What it does leave
+	// behind is the MARKER, now readable as CSS, and the marker contains
+	// `#1385` — which the colour-literal guard below reads as a four-digit hex
+	// colour and reports the section for writing. Backing up to the banner puts
+	// the marker back inside a comment where it belongs.
+	//
+	// It is load-bearing in the other direction too: without it the header
+	// prose reaches the SELECTOR checks, and the wordmark guard is satisfied by
+	// the words ".brand-name" in the exclusion table rather than by the rule.
+	// Drop the back-up and drop the selector together, and that guard passes.
 	if b := strings.LastIndex(css[:i], "/* ======"); b >= 0 {
 		i = b
 	}
@@ -68,6 +75,13 @@ var (
 	// `transparent` and are entirely ordinary. Group 1 ends where `color`
 	// begins.
 	transparentInkRE = regexp.MustCompile(`(^|[^-a-zA-Z])color\s*:\s*transparent\b`)
+	// The other spelling, and it needs its own pattern rather than riding on
+	// the one above — the leading-class guard that excludes `border-color`
+	// excludes this too, because it is also hyphen-prefixed. Missing it would
+	// be worse than an oversight: the section's own prose names
+	// -webkit-text-fill-color as the tempting alternative, so it is the
+	// substitution a reader is most likely to reach for.
+	transparentFillRE = regexp.MustCompile(`(?:-webkit-)?text-fill-color\s*:\s*transparent\b`)
 )
 
 // clipSupportsRanges returns the ranges of the @supports blocks that actually
@@ -87,11 +101,88 @@ func clipSupportsRanges(t *testing.T, css string) [][2]int {
 		if b := strings.IndexByte(prelude, '{'); b >= 0 {
 			prelude = prelude[:b]
 		}
-		if clipToTextRE.MatchString(prelude) {
+		// Polarity is not optional. `@supports not (background-clip: text)`
+		// mentions the feature and means the exact opposite: its body applies
+		// only on the engines that CANNOT paint over transparent ink, which is
+		// the failure this whole guard exists for. A prelude that mentions the
+		// feature under a `not` is therefore not a guard, and the declarations
+		// inside it get reported like any other unguarded ones.
+		if clipToTextRE.MatchString(prelude) && !regexp.MustCompile(`\bnot\b`).MatchString(prelude) {
 			out = append(out, r)
 		}
 	}
 	return out
+}
+
+// topLevelRules splits a block body into (prelude, body) pairs at depth 0, so
+// a nested block cannot contribute its declarations as though they were
+// selectors.
+func topLevelRules(body string) [][2]string {
+	var out [][2]string
+	depth, start, openAt := 0, 0, 0
+	for i := 0; i < len(body); i++ {
+		switch body[i] {
+		case '{':
+			if depth == 0 {
+				openAt = i
+			}
+			depth++
+		case '}':
+			if depth--; depth == 0 {
+				out = append(out, [2]string{body[start:openAt], body[openAt+1 : i]})
+				start = i + 1
+			}
+		}
+	}
+	return out
+}
+
+// gradientRuleSelectors returns the selector list of the rule that actually
+// PAINTS the gradient — not every class mentioned somewhere in the section.
+//
+// The distinction is not pedantic; a mention-based check was already satisfied
+// once by prose, and then a second time by a rule. Both painted classes now
+// appear on TWO rules — the gradient and the width fix beside it — so
+// "is this class in the section" stays true with the class removed from the
+// only rule that paints it. Verified by mutation: that shape passed.
+func gradientRuleSelectors(t *testing.T, section string) []string {
+	t.Helper()
+	rs := guardRanges(t, section, "@supports")
+	if len(rs) != 1 {
+		t.Fatalf("expected exactly one @supports block in the brand section, found %d", len(rs))
+	}
+	open := strings.IndexByte(section[rs[0][0]:], '{') + rs[0][0]
+	for _, rule := range topLevelRules(section[open+1 : rs[0][1]]) {
+		if !strings.Contains(rule[1], "background-image") {
+			continue
+		}
+		var out []string
+		for _, sel := range strings.Split(rule[0], ",") {
+			if s := strings.Join(strings.Fields(sel), " "); s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	t.Fatal("no rule inside the brand section's @supports block declares background-image: " +
+		"the gradient is not painted at all, and every selector check below would be vacuous")
+	return nil
+}
+
+// paintsGradient compares selectors for EQUALITY, not containment.
+//
+// That is what closes the prefix trap an earlier version of this guard fell
+// into: a plain Contains reported the pair as intact when the selector had
+// been renamed to `.ov-stat-number`, because the old name is a prefix of the
+// new one. Exact comparison against a parsed selector list rules out the whole
+// family, extension at either end included.
+func paintsGradient(sels []string, class string) bool {
+	for _, s := range sels {
+		if s == "."+class {
+			return true
+		}
+	}
+	return false
 }
 
 // Clipping a gradient to text requires painting the ink transparent, so where
@@ -118,12 +209,14 @@ func TestTransparentInkStaysBehindABackgroundClipSupportsTest(t *testing.T) {
 			"without background-clip:text renders those elements as blank space")
 	}
 
-	for _, m := range clipToTextRE.FindAllStringIndex(css, -1) {
-		if within(guarded, m[0]) {
-			continue
+	for _, re := range []*regexp.Regexp{clipToTextRE, transparentFillRE} {
+		for _, m := range re.FindAllStringIndex(css, -1) {
+			if within(guarded, m[0]) {
+				continue
+			}
+			t.Errorf("style.css:%d: %q is not inside an @supports test for background-clip.",
+				lineOf(css, m[0]), strings.TrimSpace(css[m[0]:m[1]]))
 		}
-		t.Errorf("style.css:%d: %q is not inside an @supports test for background-clip.",
-			lineOf(css, m[0]), strings.TrimSpace(css[m[0]:m[1]]))
 	}
 	for _, m := range transparentInkRE.FindAllStringSubmatchIndex(css, -1) {
 		at := m[3] // end of group 1 == start of `color`
@@ -166,39 +259,60 @@ func TestBrandSectionPaintsFromTokensAndNeverSemantics(t *testing.T) {
 	}
 
 	// The section is paint-only by construction, which is what lets it exist
-	// alongside the motion section instead of inside it. Motion here would also
-	// escape that section's reduced-motion guard.
+	// alongside the motion section instead of inside it. A PLACEMENT rule, not
+	// a coverage backstop: the whole-file reduced-motion guard would catch a
+	// long transition written here on its own, but it deliberately classifies
+	// anything under 300ms as direct-manipulation feedback rather than
+	// animation, so a short one would land here seen by nothing else.
 	if m := regexp.MustCompile(`\b(animation|transition)(-[a-z]+)?\s*:`).FindStringIndex(section); m != nil {
 		t.Errorf("style.css:%d: the brand section declares %q. It is paint-only; anything that "+
-			"moves belongs in the motion section, where the reduced-motion guard covers it.",
+			"moves belongs in the motion section, where it sits inside the reduced-motion block.",
 			at(m[0]), strings.TrimSpace(section[m[0]:m[1]]))
 	}
 }
 
-// cssRef and jsRef match a class as a WHOLE token, never as a substring.
+// stripJSCommentLines blanks whole-line comments and /* … */ regions, working
+// A LINE AT A TIME.
 //
-// A plain Contains passed happily when the CSS selector was renamed to
-// `.ov-stat-number`, because the old name is a PREFIX of the new one — so the
-// guard reported the pair as intact at the exact moment it came apart. The
-// trailing \b is what closes that; it does not (and need not) reject a name
-// EXTENDED at the front, since `-` is not a word character.
-func cssRef(class string) *regexp.Regexp {
-	return regexp.MustCompile(`\.` + regexp.QuoteMeta(class) + `\b`)
-}
-
-// jsGrantRE counts the class inside STRING literals only.
+// Deliberately not a JavaScript lexer, and the file is the argument: app.js
+// holds a regex literal containing a double quote (`/[",\r\n]/`) and another
+// containing an escaped slash (`/^\//`), plus four URLs with `//` inside
+// string literals. A character scanner tracking quote state desyncs on the
+// first of those and then blanks arbitrary code — silently, and in a guard.
+// Line granularity cannot desync at all.
 //
-// Counting raw bytes made an ordinary documentation line — one that merely
-// named the class in a comment — read as a second grant site, and the test
-// accused it of bypassing the gate. A guard that invents alarms against
-// correct code is the one that gets deleted. Both quote styles are accepted so
-// switching them is not an alarm either.
+// Two earlier shapes were both wrong, each in the direction the other was
+// right. Counting raw bytes made an ordinary documentation line naming the
+// class read as a second grant site. Narrowing to quoted strings fixed that
+// and opened two holes: a grant written in a TEMPLATE literal stopped
+// counting (57 backticks in this file, so not exotic), and English
+// contractions around the class name — "Don't rename ov-stat-num, it's …" —
+// became string delimiters, so the false alarm came back in prose the
+// codebase writes constantly.
 //
-// Known limit, stated rather than papered over: a comment that puts the class
-// in QUOTES still counts. That is a much narrower surface than any mention,
-// and it does not warrant a JavaScript parser here.
-func jsGrantRE(class string) *regexp.Regexp {
-	return regexp.MustCompile(`["'][^"'\n]*\b` + regexp.QuoteMeta(class) + `\b[^"'\n]*["']`)
+// Residual, stated rather than papered over: a mention in a TRAILING comment
+// on a line of code still counts. The failure message says to move it.
+func stripJSCommentLines(js string) string {
+	var b strings.Builder
+	inBlock := false
+	for _, line := range strings.Split(js, "\n") {
+		t := strings.TrimSpace(line)
+		switch {
+		case inBlock:
+			if strings.Contains(line, "*/") {
+				inBlock = false
+			}
+		case strings.HasPrefix(t, "//"):
+		case strings.HasPrefix(t, "/*"):
+			if !strings.Contains(t[2:], "*/") {
+				inBlock = true
+			}
+		default:
+			b.WriteString(line)
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
 }
 
 // The Overview tile's opt-in class must exist on both sides, and app.js must
@@ -218,20 +332,22 @@ func jsGrantRE(class string) *regexp.Regexp {
 // scoped to the file it reads.
 func TestBrandOptInClassIsGrantedInExactlyOnePlace(t *testing.T) {
 	section, _ := brandSection(t)
-	if !cssRef(brandOptInClass).MatchString(section) {
-		t.Fatalf("the brand section no longer styles .%s — app.js still adds the class, so the "+
+	if !paintsGradient(gradientRuleSelectors(t, section), brandOptInClass) {
+		t.Fatalf("the gradient rule no longer lists .%s — app.js still adds the class, so the "+
 			"Overview counts render with no gradient and nothing reports it", brandOptInClass)
 	}
 
-	js := readAsset(t, "app.js")
-	switch n := len(jsGrantRE(brandOptInClass).FindAllString(js, -1)); {
+	js := stripJSCommentLines(readAsset(t, "app.js"))
+	grant := regexp.MustCompile(regexp.QuoteMeta(brandOptInClass) + `\b`)
+	switch n := len(grant.FindAllString(js, -1)); {
 	case n == 0:
 		t.Fatalf("style.css styles .%s but app.js never applies it: the rule is dead and the "+
 			"Overview counts are unstyled", brandOptInClass)
 	case n > 1:
-		t.Errorf("app.js puts %q in %d string literals. It is granted in one place on purpose — "+
-			"that expression is the gate that withholds the gradient from the semantic `danger` "+
-			"tile and from any modifier below the large-text bar; a second site bypasses it.",
+		t.Errorf("app.js names %q %d times outside a comment line. It is granted in one place on "+
+			"purpose — that expression is the gate that withholds the gradient from the semantic "+
+			"`danger` tile and from any modifier below the large-text bar, and a second site "+
+			"bypasses it. If one of these IS just documentation, move it to its own comment line.",
 			brandOptInClass, n)
 	}
 }
@@ -248,9 +364,10 @@ func TestWordmarkKeepsItsGradient(t *testing.T) {
 	const wordmark = "brand-name"
 
 	section, _ := brandSection(t)
-	if !cssRef(wordmark).MatchString(section) {
-		t.Errorf("the #1385 brand section no longer paints .%s. The sidebar wordmark is one of the "+
-			"two surfaces this section exists for; dropping it is silent everywhere else.", wordmark)
+	if !paintsGradient(gradientRuleSelectors(t, section), wordmark) {
+		t.Errorf("the gradient rule no longer lists .%s. The sidebar wordmark is one of the two "+
+			"surfaces this section exists for; dropping it is silent everywhere else, and the "+
+			"class still appearing on the width rule beside it does not count.", wordmark)
 	}
 	if !regexp.MustCompile(`class="[^"]*\b` + wordmark + `\b`).MatchString(readAsset(t, "index.html")) {
 		t.Errorf("index.html no longer carries class=%q, so the wordmark loses BOTH its base rule "+

--- a/internal/console/assets_brandpaint_test.go
+++ b/internal/console/assets_brandpaint_test.go
@@ -7,28 +7,31 @@ import (
 	"testing"
 )
 
-// The class that opts a single Overview tile into the brand gradient. Named
-// once because two guards below pin the two ENDS of it: the CSS must define
-// it and app.js must grant it from exactly one place. Rename one side only and
-// the gradient silently stops appearing, which no visual test would notice
-// because "no gradient" is also what an unstyled tile looks like.
+// The class that opts a single Overview tile into the brand gradient (#1385).
+// Named once because a guard below pins both ENDS of it: the CSS must define
+// it and app.js must grant it. Rename one side only and the gradient silently
+// stops appearing.
 const brandOptInClass = "ov-stat-num"
+
+func readAsset(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile("assets/" + name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
 
 // brandSection returns the #1385 brand-warmth block of style.css with comment
 // BYTES blanked, plus the file line its first byte sits on.
 //
 // Blanking rather than deleting keeps every offset inside the section aligned
 // with the original text, so a finding can be reported at its real file line.
-// It is also required rather than tidy: this section's own prose quotes
-// `color: transparent` and names `--delete`, both of which two guards below
-// treat as failures.
+// It is also required rather than tidy: this section's prose names properties
+// and at-rules that the guards below treat as findings.
 func brandSection(t *testing.T) (string, int) {
 	t.Helper()
-	data, err := os.ReadFile("assets/style.css")
-	if err != nil {
-		t.Fatal(err)
-	}
-	css := string(data)
+	css := readAsset(t, "style.css")
 	const marker = "Brand warmth: chrome only (#1385)"
 	i := strings.Index(css, marker)
 	if i < 0 {
@@ -38,9 +41,13 @@ func brandSection(t *testing.T) (string, int) {
 		t.Fatalf("the %q marker appears %d times — everything under the later one would sit "+
 			"outside these guards", marker, n)
 	}
-	// Back up to the banner that OPENS the section: the marker sits inside a
-	// /* … */ block, so slicing at the marker itself would leave an
-	// unterminated comment and blank the entire rest of the file.
+	// Back up to the banner that OPENS the section. Slicing at the marker
+	// instead does NOT run the comment away — sanitizeCSS only reacts to an
+	// opening `/*`, and starting mid-body it never sees one. The damage is the
+	// opposite shape: the header PROSE survives unblanked and is read as CSS,
+	// and it quotes both `@supports` and `color: transparent`. That turns
+	// guardRanges' count check into a Fatal blaming a brace error that does not
+	// exist, and invents a finding for a sentence.
 	if b := strings.LastIndex(css[:i], "/* ======"); b >= 0 {
 		i = b
 	}
@@ -51,108 +58,202 @@ func brandSection(t *testing.T) (string, int) {
 	return sanitizeCSS(section), strings.Count(css[:i], "\n") + 1
 }
 
+var (
+	// `background-clip: text` has exactly one purpose, so it needs no context
+	// to be recognised. Anchored on `text` so the four `content-box` uses on
+	// the scrollbar thumbs are not swept in.
+	clipToTextRE = regexp.MustCompile(`(?:-webkit-)?background-clip\s*:\s*text\b`)
+	// The leading class is what separates the `color` property from the nine
+	// `border-color` / `background-color` declarations that also end in
+	// `transparent` and are entirely ordinary. Group 1 ends where `color`
+	// begins.
+	transparentInkRE = regexp.MustCompile(`(^|[^-a-zA-Z])color\s*:\s*transparent\b`)
+)
+
+// clipSupportsRanges returns the ranges of the @supports blocks that actually
+// test for background-clip.
+//
+// Matching the bare `@supports` keyword was not enough, and the gap was not
+// theoretical: an `@supports (display: grid)` wrapper around a transparent-ink
+// rule satisfied the keyword check completely while being exactly the state
+// the check exists to forbid. The two real call sites also spell the condition
+// differently — one wraps the disjunction in an extra pair of parens — so this
+// reads the condition rather than matching a fixed string.
+func clipSupportsRanges(t *testing.T, css string) [][2]int {
+	t.Helper()
+	var out [][2]int
+	for _, r := range guardRanges(t, css, "@supports") {
+		prelude := css[r[0]:]
+		if b := strings.IndexByte(prelude, '{'); b >= 0 {
+			prelude = prelude[:b]
+		}
+		if clipToTextRE.MatchString(prelude) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
 // Clipping a gradient to text requires painting the ink transparent, so where
 // the clip does not take effect the text is GONE rather than merely unstyled.
-// Both declarations that create that state must stay behind the @supports test
-// that proves paint arrives to replace the ink.
+// Every declaration that creates that state must stay behind an @supports test
+// for background-clip.
 //
-// The failure is invisible to the author: every engine on a developer's
-// machine satisfies the test, so an unguarded copy of these declarations looks
-// perfect locally and blanks the sidebar wordmark on whatever does not.
-func TestGradientTextStaysBehindItsSupportsTest(t *testing.T) {
-	section, base := brandSection(t)
+// Scoped to the WHOLE stylesheet, not to the #1385 section. The failure is a
+// property of the technique, not of one feature: the login panel's title
+// (added long before this section) uses the identical pair, and a section-
+// scoped guard silently covered neither it nor anything appended below the
+// section's own banner.
+//
+// The failure is also invisible to the author. Every engine on a developer's
+// machine satisfies the test, so an unguarded copy looks perfect locally and
+// blanks the element on whatever does not.
+func TestTransparentInkStaysBehindABackgroundClipSupportsTest(t *testing.T) {
+	css := sanitizeCSS(readAsset(t, "style.css"))
 
-	supports := guardRanges(t, section, "@supports")
-	if len(supports) == 0 {
-		t.Fatal("the brand section has no @supports block: the declarations that make text " +
-			"transparent are unconditional, so any engine without background-clip:text renders " +
-			"the wordmark and the Overview counts as blank space")
+	guarded := clipSupportsRanges(t, css)
+	if len(guarded) == 0 {
+		t.Fatal("style.css has no @supports test for background-clip, yet it clips gradients to " +
+			"text: the declarations that make the ink transparent are unconditional, so any engine " +
+			"without background-clip:text renders those elements as blank space")
 	}
 
-	risky := regexp.MustCompile(`(?:-webkit-)?background-clip\s*:\s*text|color\s*:\s*transparent`)
-	for _, m := range risky.FindAllStringIndex(section, -1) {
-		if within(supports, m[0]) {
+	for _, m := range clipToTextRE.FindAllStringIndex(css, -1) {
+		if within(guarded, m[0]) {
 			continue
 		}
-		t.Errorf("style.css:%d: %q sits outside the @supports test.\n"+
-			"Transparent ink with no gradient to replace it is invisible text, not a missing effect.",
-			base+strings.Count(section[:m[0]], "\n"), strings.TrimSpace(section[m[0]:m[1]]))
+		t.Errorf("style.css:%d: %q is not inside an @supports test for background-clip.",
+			lineOf(css, m[0]), strings.TrimSpace(css[m[0]:m[1]]))
+	}
+	for _, m := range transparentInkRE.FindAllStringSubmatchIndex(css, -1) {
+		at := m[3] // end of group 1 == start of `color`
+		if within(guarded, at) {
+			continue
+		}
+		t.Errorf("style.css:%d: %q is not inside an @supports test for background-clip.\n"+
+			"Transparent ink with no gradient to replace it is invisible text, not a missing effect.\n"+
+			"If this declaration is NOT gradient text, it is hiding an element by making its ink "+
+			"vanish — say so at the site, because this guard cannot tell the two apart.",
+			lineOf(css, at), strings.TrimSpace(css[at:m[1]]))
 	}
 }
 
-// The brand palette decorates chrome. It may not restate, and may not be
-// mistaken for, the semantic colors — and it may not introduce a colour of its
-// own that drifts from the tokens.
+// The brand palette decorates chrome. It may not restate the semantic colors,
+// and it may not introduce a colour of its own that drifts from the tokens.
 func TestBrandSectionPaintsFromTokensAndNeverSemantics(t *testing.T) {
 	section, base := brandSection(t)
+	at := func(i int) int { return base + strings.Count(section[:i], "\n") }
 
 	if m := regexp.MustCompile(`--(insert|update|delete)\b`).FindStringIndex(section); m != nil {
 		t.Errorf("style.css:%d: the brand section references %s. INSERT=mint / UPDATE=blue / "+
 			"DELETE=red are decided in :root and this section decorates chrome — a brand rule that "+
 			"repeats a semantic token is one edit away from overriding it.",
-			base+strings.Count(section[:m[0]], "\n"), section[m[0]:m[1]])
+			at(m[0]), section[m[0]:m[1]])
 	}
 
-	// Re-typing a colour here would silently stop tracking the token it was
-	// copied from the day that token moves — the same reasoning the
-	// --brand-wash-* comment gives for using color-mix.
-	if i := strings.Index(section, "oklch("); i >= 0 {
-		t.Errorf("style.css:%d: the brand section writes a raw oklch() literal. Derive from the "+
+	// Every colour here must come from a brand token. A literal silently stops
+	// tracking whatever it was copied from the day that token moves — the same
+	// reasoning the --brand-wash-* comment gives for using color-mix. All the
+	// notations are listed because banning only oklch() left the hex form
+	// wide open, and the hex values sit in a comment beside the tokens, which
+	// is an active invitation to paste one.
+	literal := regexp.MustCompile(`#[0-9a-fA-F]{3,8}\b|\b(?:oklch|oklab|lab|lch|rgba?|hsla?|hwb)\(`)
+	if m := literal.FindStringIndex(section); m != nil {
+		t.Errorf("style.css:%d: the brand section writes the colour literal %q. Derive from the "+
 			"existing brand tokens (var(--brand-headline), color-mix) so the palette stays one "+
-			"source of truth.", base+strings.Count(section[:i], "\n"))
+			"source of truth — every contrast figure in this section's header is measured against "+
+			"those tokens.", at(m[0]), section[m[0]:m[1]])
 	}
 
 	// The section is paint-only by construction, which is what lets it exist
 	// alongside the motion section instead of inside it. Motion here would also
-	// escape that section's transform-only rule.
+	// escape that section's reduced-motion guard.
 	if m := regexp.MustCompile(`\b(animation|transition)(-[a-z]+)?\s*:`).FindStringIndex(section); m != nil {
 		t.Errorf("style.css:%d: the brand section declares %q. It is paint-only; anything that "+
 			"moves belongs in the motion section, where the reduced-motion guard covers it.",
-			base+strings.Count(section[:m[0]], "\n"), strings.TrimSpace(section[m[0]:m[1]]))
+			at(m[0]), strings.TrimSpace(section[m[0]:m[1]]))
 	}
 }
 
-// The opt-in class must exist on both sides, and app.js must grant it from
-// exactly one place.
+// cssRef and jsRef match a class as a WHOLE token, never as a substring.
+//
+// A plain Contains passed happily when the CSS selector was renamed to
+// `.ov-stat-number`, because the old name is a PREFIX of the new one — so the
+// guard reported the pair as intact at the exact moment it came apart. The
+// trailing \b is what closes that; it does not (and need not) reject a name
+// EXTENDED at the front, since `-` is not a word character.
+func cssRef(class string) *regexp.Regexp {
+	return regexp.MustCompile(`\.` + regexp.QuoteMeta(class) + `\b`)
+}
+
+// jsGrantRE counts the class inside STRING literals only.
+//
+// Counting raw bytes made an ordinary documentation line — one that merely
+// named the class in a comment — read as a second grant site, and the test
+// accused it of bypassing the gate. A guard that invents alarms against
+// correct code is the one that gets deleted. Both quote styles are accepted so
+// switching them is not an alarm either.
+//
+// Known limit, stated rather than papered over: a comment that puts the class
+// in QUOTES still counts. That is a much narrower surface than any mention,
+// and it does not warrant a JavaScript parser here.
+func jsGrantRE(class string) *regexp.Regexp {
+	return regexp.MustCompile(`["'][^"'\n]*\b` + regexp.QuoteMeta(class) + `\b[^"'\n]*["']`)
+}
+
+// The Overview tile's opt-in class must exist on both sides, and app.js must
+// grant it from exactly one place.
 //
 // One place is the invariant that matters, not a style rule: that single
 // expression is where the gradient is withheld from the tiles that cannot take
-// it — the semantic `danger` tile, and any tile carrying a modifier that puts
-// it below WCAG's large-text bar. A second grant site elsewhere in app.js
-// would bypass that gate without touching it.
+// it. A second grant site elsewhere in app.js would bypass the gate without
+// touching it.
 //
-// What this does NOT cover, verified by mutation rather than assumed: rewriting
-// the gate IN PLACE so the class is granted unconditionally keeps the count at
-// one and passes here. Nothing in the text of either file distinguishes a
-// correct gate from an inverted one — that failure is a rendered result, and
-// scenario 17e in test/console-e2e reads it back off a real danger tile.
+// What this does NOT cover, verified by mutation rather than assumed:
+// rewriting the gate IN PLACE so the class is granted unconditionally keeps
+// the count at one and passes here. Nothing in the text of either file
+// distinguishes a correct gate from an inverted one — that failure is a
+// rendered result, and scenario 17e in test/console-e2e reads it back off a
+// real danger tile. Nor does it reach markup outside app.js; the count is
+// scoped to the file it reads.
 func TestBrandOptInClassIsGrantedInExactlyOnePlace(t *testing.T) {
 	section, _ := brandSection(t)
-
-	// Matched as a whole token, never as a substring. A plain Contains passed
-	// happily when the CSS selector was renamed to `.ov-stat-number`, because
-	// the old name is a PREFIX of the new one — so the guard reported the pair
-	// as intact at the exact moment it had come apart.
-	cssRef := regexp.MustCompile(`\.` + regexp.QuoteMeta(brandOptInClass) + `\b`)
-	jsRef := regexp.MustCompile(regexp.QuoteMeta(brandOptInClass) + `\b`)
-
-	if !cssRef.MatchString(section) {
+	if !cssRef(brandOptInClass).MatchString(section) {
 		t.Fatalf("the brand section no longer styles .%s — app.js still adds the class, so the "+
 			"Overview counts render with no gradient and nothing reports it", brandOptInClass)
 	}
 
-	js, err := os.ReadFile("assets/app.js")
-	if err != nil {
-		t.Fatal(err)
-	}
-	switch n := len(jsRef.FindAllString(string(js), -1)); {
+	js := readAsset(t, "app.js")
+	switch n := len(jsGrantRE(brandOptInClass).FindAllString(js, -1)); {
 	case n == 0:
 		t.Fatalf("style.css styles .%s but app.js never applies it: the rule is dead and the "+
 			"Overview counts are unstyled", brandOptInClass)
 	case n > 1:
-		t.Errorf("app.js mentions %q %d times. It is granted in one place on purpose — that "+
-			"expression is the gate that withholds the gradient from the semantic `danger` tile "+
-			"and from any modifier below the large-text bar; a second site bypasses it.",
+		t.Errorf("app.js puts %q in %d string literals. It is granted in one place on purpose — "+
+			"that expression is the gate that withholds the gradient from the semantic `danger` "+
+			"tile and from any modifier below the large-text bar; a second site bypasses it.",
 			brandOptInClass, n)
+	}
+}
+
+// The sidebar wordmark is the OTHER half of what #1385 paints, and it was
+// covered by nothing at all: dropping `.brand-name` from the gradient rule
+// left every guard and every browser scenario green while the wordmark
+// silently reverted to flat ink. "No gradient" is also what an unstyled
+// element looks like, so a screenshot does not catch it either.
+//
+// Unlike the tile, this class is static markup, so the pair to pin is the
+// stylesheet against index.html rather than against app.js.
+func TestWordmarkKeepsItsGradient(t *testing.T) {
+	const wordmark = "brand-name"
+
+	section, _ := brandSection(t)
+	if !cssRef(wordmark).MatchString(section) {
+		t.Errorf("the #1385 brand section no longer paints .%s. The sidebar wordmark is one of the "+
+			"two surfaces this section exists for; dropping it is silent everywhere else.", wordmark)
+	}
+	if !regexp.MustCompile(`class="[^"]*\b` + wordmark + `\b`).MatchString(readAsset(t, "index.html")) {
+		t.Errorf("index.html no longer carries class=%q, so the wordmark loses BOTH its base rule "+
+			"and its gradient and renders as unstyled inherited text.", wordmark)
 	}
 }

--- a/internal/console/assets_brandpaint_test.go
+++ b/internal/console/assets_brandpaint_test.go
@@ -1,0 +1,158 @@
+package console
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The class that opts a single Overview tile into the brand gradient. Named
+// once because two guards below pin the two ENDS of it: the CSS must define
+// it and app.js must grant it from exactly one place. Rename one side only and
+// the gradient silently stops appearing, which no visual test would notice
+// because "no gradient" is also what an unstyled tile looks like.
+const brandOptInClass = "ov-stat-num"
+
+// brandSection returns the #1385 brand-warmth block of style.css with comment
+// BYTES blanked, plus the file line its first byte sits on.
+//
+// Blanking rather than deleting keeps every offset inside the section aligned
+// with the original text, so a finding can be reported at its real file line.
+// It is also required rather than tidy: this section's own prose quotes
+// `color: transparent` and names `--delete`, both of which two guards below
+// treat as failures.
+func brandSection(t *testing.T) (string, int) {
+	t.Helper()
+	data, err := os.ReadFile("assets/style.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	css := string(data)
+	const marker = "Brand warmth: chrome only (#1385)"
+	i := strings.Index(css, marker)
+	if i < 0 {
+		t.Fatal("the #1385 brand-warmth section header is gone — this guard no longer covers anything")
+	}
+	if n := strings.Count(css, marker); n > 1 {
+		t.Fatalf("the %q marker appears %d times — everything under the later one would sit "+
+			"outside these guards", marker, n)
+	}
+	// Back up to the banner that OPENS the section: the marker sits inside a
+	// /* … */ block, so slicing at the marker itself would leave an
+	// unterminated comment and blank the entire rest of the file.
+	if b := strings.LastIndex(css[:i], "/* ======"); b >= 0 {
+		i = b
+	}
+	section := css[i:]
+	if j := strings.Index(section[1:], "/* ======"); j > 0 {
+		section = section[:j+1]
+	}
+	return sanitizeCSS(section), strings.Count(css[:i], "\n") + 1
+}
+
+// Clipping a gradient to text requires painting the ink transparent, so where
+// the clip does not take effect the text is GONE rather than merely unstyled.
+// Both declarations that create that state must stay behind the @supports test
+// that proves paint arrives to replace the ink.
+//
+// The failure is invisible to the author: every engine on a developer's
+// machine satisfies the test, so an unguarded copy of these declarations looks
+// perfect locally and blanks the sidebar wordmark on whatever does not.
+func TestGradientTextStaysBehindItsSupportsTest(t *testing.T) {
+	section, base := brandSection(t)
+
+	supports := guardRanges(t, section, "@supports")
+	if len(supports) == 0 {
+		t.Fatal("the brand section has no @supports block: the declarations that make text " +
+			"transparent are unconditional, so any engine without background-clip:text renders " +
+			"the wordmark and the Overview counts as blank space")
+	}
+
+	risky := regexp.MustCompile(`(?:-webkit-)?background-clip\s*:\s*text|color\s*:\s*transparent`)
+	for _, m := range risky.FindAllStringIndex(section, -1) {
+		if within(supports, m[0]) {
+			continue
+		}
+		t.Errorf("style.css:%d: %q sits outside the @supports test.\n"+
+			"Transparent ink with no gradient to replace it is invisible text, not a missing effect.",
+			base+strings.Count(section[:m[0]], "\n"), strings.TrimSpace(section[m[0]:m[1]]))
+	}
+}
+
+// The brand palette decorates chrome. It may not restate, and may not be
+// mistaken for, the semantic colors — and it may not introduce a colour of its
+// own that drifts from the tokens.
+func TestBrandSectionPaintsFromTokensAndNeverSemantics(t *testing.T) {
+	section, base := brandSection(t)
+
+	if m := regexp.MustCompile(`--(insert|update|delete)\b`).FindStringIndex(section); m != nil {
+		t.Errorf("style.css:%d: the brand section references %s. INSERT=mint / UPDATE=blue / "+
+			"DELETE=red are decided in :root and this section decorates chrome — a brand rule that "+
+			"repeats a semantic token is one edit away from overriding it.",
+			base+strings.Count(section[:m[0]], "\n"), section[m[0]:m[1]])
+	}
+
+	// Re-typing a colour here would silently stop tracking the token it was
+	// copied from the day that token moves — the same reasoning the
+	// --brand-wash-* comment gives for using color-mix.
+	if i := strings.Index(section, "oklch("); i >= 0 {
+		t.Errorf("style.css:%d: the brand section writes a raw oklch() literal. Derive from the "+
+			"existing brand tokens (var(--brand-headline), color-mix) so the palette stays one "+
+			"source of truth.", base+strings.Count(section[:i], "\n"))
+	}
+
+	// The section is paint-only by construction, which is what lets it exist
+	// alongside the motion section instead of inside it. Motion here would also
+	// escape that section's transform-only rule.
+	if m := regexp.MustCompile(`\b(animation|transition)(-[a-z]+)?\s*:`).FindStringIndex(section); m != nil {
+		t.Errorf("style.css:%d: the brand section declares %q. It is paint-only; anything that "+
+			"moves belongs in the motion section, where the reduced-motion guard covers it.",
+			base+strings.Count(section[:m[0]], "\n"), strings.TrimSpace(section[m[0]:m[1]]))
+	}
+}
+
+// The opt-in class must exist on both sides, and app.js must grant it from
+// exactly one place.
+//
+// One place is the invariant that matters, not a style rule: that single
+// expression is where the gradient is withheld from the tiles that cannot take
+// it — the semantic `danger` tile, and any tile carrying a modifier that puts
+// it below WCAG's large-text bar. A second grant site elsewhere in app.js
+// would bypass that gate without touching it.
+//
+// What this does NOT cover, verified by mutation rather than assumed: rewriting
+// the gate IN PLACE so the class is granted unconditionally keeps the count at
+// one and passes here. Nothing in the text of either file distinguishes a
+// correct gate from an inverted one — that failure is a rendered result, and
+// scenario 17e in test/console-e2e reads it back off a real danger tile.
+func TestBrandOptInClassIsGrantedInExactlyOnePlace(t *testing.T) {
+	section, _ := brandSection(t)
+
+	// Matched as a whole token, never as a substring. A plain Contains passed
+	// happily when the CSS selector was renamed to `.ov-stat-number`, because
+	// the old name is a PREFIX of the new one — so the guard reported the pair
+	// as intact at the exact moment it had come apart.
+	cssRef := regexp.MustCompile(`\.` + regexp.QuoteMeta(brandOptInClass) + `\b`)
+	jsRef := regexp.MustCompile(regexp.QuoteMeta(brandOptInClass) + `\b`)
+
+	if !cssRef.MatchString(section) {
+		t.Fatalf("the brand section no longer styles .%s — app.js still adds the class, so the "+
+			"Overview counts render with no gradient and nothing reports it", brandOptInClass)
+	}
+
+	js, err := os.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	switch n := len(jsRef.FindAllString(string(js), -1)); {
+	case n == 0:
+		t.Fatalf("style.css styles .%s but app.js never applies it: the rule is dead and the "+
+			"Overview counts are unstyled", brandOptInClass)
+	case n > 1:
+		t.Errorf("app.js mentions %q %d times. It is granted in one place on purpose — that "+
+			"expression is the gate that withholds the gradient from the semantic `danger` tile "+
+			"and from any modifier below the large-text bar; a second site bypasses it.",
+			brandOptInClass, n)
+	}
+}

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -2249,6 +2249,74 @@ try {
     ? ok("reduced motion: the dimmed-button stand-in does not leak into no-preference")
     : bad("reduced motion: the dimmed-button stand-in does not leak into no-preference", moved.spinOpacity);
 
+  // ── Scenario 17e — who may wear the brand gradient (#1385) ──
+  //
+  // The Go guards in assets_brandpaint_test.go prove the gradient is opt-in,
+  // that its transparent ink stays behind @supports, and that app.js grants the
+  // class from exactly one place. None of them can prove the gate in that one
+  // place points the right way: rewriting it to grant the class
+  // unconditionally keeps the count at one and leaves every text guard green.
+  // Verified by mutation, which is why this scenario exists.
+  //
+  // What is at stake is not decoration. The gradient's stops measure 3.70:1 to
+  // 5.16:1 on white, so they clear WCAG's LARGE-text bar of 3:1 and none of
+  // them clears the 4.5:1 body bar. A tile that takes the gradient without
+  // being large text is unreadable, and the deletes tile additionally carries
+  // the semantic --delete that the brand palette must never repaint.
+  //
+  // ovStat is called for real rather than synthesised: the gate lives inside
+  // it, so a hand-built div would test the stylesheet and skip the bug.
+  const brandProbe = () => page.evaluate(() => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const tile = (v, key, mod) => {
+      const n = ovStat(v, key, mod, "last 24 h");
+      host.appendChild(n);
+      return n.querySelector(".ov-stat-v");
+    };
+    const plain = tile("42", "changes indexed", "");
+    const danger = tile("7", "deletes", "danger");
+    // The `small` variant is built inline in fillOvEvents, not through ovStat.
+    // Mirrored here because it is the surface the gradient would hurt MOST:
+    // 19px at weight 500 is body text, so it is held to 4.5:1, which no stop
+    // in this gradient reaches.
+    const small = el("div", { class: "ov-stat-v small", text: "2026-08-20 11:00:00" });
+    host.appendChild(small);
+    // A reference for the semantic colour, computed through the same pipeline
+    // as the tile so the two strings are comparable whatever form the engine
+    // serialises oklch into.
+    const ref = el("span", { text: "x" });
+    ref.style.color = "var(--delete)";
+    host.appendChild(ref);
+    const cs = (n) => getComputedStyle(n);
+    const res = {
+      plainImage: cs(plain).backgroundImage,
+      plainColor: cs(plain).color,
+      dangerImage: cs(danger).backgroundImage,
+      dangerColor: cs(danger).color,
+      smallImage: cs(small).backgroundImage,
+      smallColor: cs(small).color,
+      deleteRef: cs(ref).color,
+    };
+    host.remove();
+    return res;
+  });
+
+  const brand = await brandProbe();
+  const transparent = "rgba(0, 0, 0, 0)";
+
+  (brand.plainImage.includes("gradient") && brand.plainColor === transparent)
+    ? ok("brand paint: the 32px Overview count wears the headline gradient")
+    : bad("brand paint: the 32px Overview count wears the headline gradient", JSON.stringify(brand));
+  // Both halves matter. No gradient is the gate doing its job; a colour that
+  // is still --delete is the cascade doing its job if the gate ever stops.
+  (brand.dangerImage === "none" && brand.dangerColor === brand.deleteRef)
+    ? ok("brand paint: the deletes tile keeps the semantic --delete and takes no gradient")
+    : bad("brand paint: the deletes tile keeps the semantic --delete and takes no gradient", JSON.stringify(brand));
+  (brand.smallImage === "none" && brand.smallColor !== transparent)
+    ? ok("brand paint: the 19px/500 timestamp tile is left as plain readable ink")
+    : bad("brand paint: the 19px/500 timestamp tile is left as plain readable ink", JSON.stringify(brand));
+
   // ── Scenario 18 — advisory severity split on the archive fixture (#1365) ──
   // The archive-elision record must render in the INFO register (muted line,
   // no ⚠ icon, no amber, no alert classes) while a real coverage-gap warning

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -2258,14 +2258,26 @@ try {
   // unconditionally keeps the count at one and leaves every text guard green.
   // Verified by mutation, which is why this scenario exists.
   //
-  // What is at stake is not decoration. The gradient's stops measure 3.70:1 to
-  // 5.16:1 on white, so they clear WCAG's LARGE-text bar of 3:1 and none of
-  // them clears the 4.5:1 body bar. A tile that takes the gradient without
-  // being large text is unreadable, and the deletes tile additionally carries
-  // the semantic --delete that the brand palette must never repaint.
+  // What is at stake is not decoration. A gradient has to satisfy its contrast
+  // bar at every point along the sweep, and this one dips to 3.70:1 on the
+  // tile ground it actually paints on — so it can be relied on at WCAG's
+  // LARGE-text bar of 3:1 and never at the 4.5:1 body bar. (Its violet stop
+  // alone would clear 4.5:1; that buys nothing, the other stops share the
+  // sweep.) A tile that takes the gradient without being large text is
+  // unreadable, and the deletes tile additionally carries the semantic
+  // --delete that the brand palette must never repaint.
   //
   // ovStat is called for real rather than synthesised: the gate lives inside
   // it, so a hand-built div would test the stylesheet and skip the bug.
+  //
+  // Two things this deliberately does NOT reach, so nobody reads more into a
+  // green run than it earns. The scenario passes "danger" itself, so it proves
+  // the GATE honours the modifier and not that fillOvEvents still sends one —
+  // drop that argument at its call site and the deletes tile takes the
+  // gradient with every check green. And the tiles are mounted on document.body
+  // rather than inside a rendered Overview, so a rule scoped to an .ov-stats
+  // or .view ancestor is invisible here in both directions. The wordmark
+  // assertion below has neither limit: it reads the real element in place.
   const brandProbe = () => page.evaluate(() => {
     const host = document.createElement("div");
     document.body.appendChild(host);
@@ -2278,8 +2290,11 @@ try {
     const danger = tile("7", "deletes", "danger");
     // The `small` variant is built inline in fillOvEvents, not through ovStat.
     // Mirrored here because it is the surface the gradient would hurt MOST:
-    // 19px at weight 500 is body text, so it is held to 4.5:1, which no stop
-    // in this gradient reaches.
+    // 19px at weight 500 is body text, held to 4.5:1, which the sweep as a
+    // whole does not hold. It is also the exclusion the CSS cascade does NOT
+    // protect — `.ov-stat-v.small` sets no colour, so the gradient rule would
+    // win outright. The gate in ovStat is the only thing standing there, which
+    // is precisely why this row is asserted.
     const small = el("div", { class: "ov-stat-v small", text: "2026-08-20 11:00:00" });
     host.appendChild(small);
     // A reference for the semantic colour, computed through the same pipeline
@@ -2296,6 +2311,8 @@ try {
       dangerColor: cs(danger).color,
       smallImage: cs(small).backgroundImage,
       smallColor: cs(small).color,
+      wordImage: cs(document.querySelector(".brand-name")).backgroundImage,
+      wordColor: cs(document.querySelector(".brand-name")).color,
       deleteRef: cs(ref).color,
     };
     host.remove();
@@ -2316,6 +2333,13 @@ try {
   (brand.smallImage === "none" && brand.smallColor !== transparent)
     ? ok("brand paint: the 19px/500 timestamp tile is left as plain readable ink")
     : bad("brand paint: the 19px/500 timestamp tile is left as plain readable ink", JSON.stringify(brand));
+  // The other painted surface. Read off the REAL sidebar wordmark rather than
+  // a copy — it is static markup that has been on screen since the first
+  // navigation, so there is nothing to synthesise. Dropping .brand-name from
+  // the gradient rule used to leave every check green.
+  (brand.wordImage.includes("gradient") && brand.wordColor === transparent)
+    ? ok("brand paint: the sidebar wordmark wears the headline gradient")
+    : bad("brand paint: the sidebar wordmark wears the headline gradient", JSON.stringify(brand));
 
   // ── Scenario 18 — advisory severity split on the archive fixture (#1365) ──
   // The archive-elision record must render in the INFO register (muted line,

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -2259,11 +2259,11 @@ try {
   // Verified by mutation, which is why this scenario exists.
   //
   // What is at stake is not decoration. A gradient has to satisfy its contrast
-  // bar at every point along the sweep, and this one dips to 3.70:1 on the
-  // tile ground it actually paints on — so it can be relied on at WCAG's
-  // LARGE-text bar of 3:1 and never at the 4.5:1 body bar. (Its violet stop
-  // alone would clear 4.5:1; that buys nothing, the other stops share the
-  // sweep.) A tile that takes the gradient without being large text is
+  // bar at every point along the sweep, and this one bottoms out at 3.53:1 on
+  // the studio tile ground it actually paints on (3.70:1 on white) — so it can
+  // be relied on at WCAG's LARGE-text bar of 3:1 and never at the 4.5:1 body
+  // bar. (Its violet stop alone would clear 4.5:1; that buys nothing, the
+  // other stops share the sweep.) A tile that takes the gradient without being large text is
   // unreadable, and the deletes tile additionally carries the semantic
   // --delete that the brand palette must never repaint.
   //
@@ -2272,8 +2272,8 @@ try {
   //
   // Two things this deliberately does NOT reach, so nobody reads more into a
   // green run than it earns. The scenario passes "danger" itself, so it proves
-  // the GATE honours the modifier and not that fillOvEvents still sends one —
-  // drop that argument at its call site and the deletes tile takes the
+  // the GATE honours the modifier and not that fillOvActivity still sends one
+  // — drop that argument at its call site and the deletes tile takes the
   // gradient with every check green. And the tiles are mounted on document.body
   // rather than inside a rendered Overview, so a rule scoped to an .ov-stats
   // or .view ancestor is invisible here in both directions. The wordmark
@@ -2293,8 +2293,9 @@ try {
     // 19px at weight 500 is body text, held to 4.5:1, which the sweep as a
     // whole does not hold. It is also the exclusion the CSS cascade does NOT
     // protect — `.ov-stat-v.small` sets no colour, so the gradient rule would
-    // win outright. The gate in ovStat is the only thing standing there, which
-    // is precisely why this row is asserted.
+    // win outright over it. Built by hand here on purpose, unlike the two
+    // tiles above: this row asserts the STYLESHEET, that a bare
+    // `.ov-stat-v.small` is left alone, which is the half no gate can supply.
     const small = el("div", { class: "ov-stat-v small", text: "2026-08-20 11:00:00" });
     host.appendChild(small);
     // A reference for the semantic colour, computed through the same pipeline


### PR DESCRIPTION
Second slice of #1385. #1393 landed the motion half; this lands the paint half.

Overview is the flattest page in the console and the first thing anyone sees, and the site's identity stopped at the favicon. This puts the site's headline gradient (`--brand-headline`) on the two surfaces that are pure chrome — the sidebar wordmark and the large Overview counts — and nothing else.

## Why it is opt-in per element

The gradient's stops were measured against white rather than assumed:

| stop | hex | white-on-it |
|---|---|---|
| `--brand-warm-a` | `#EA377C` | 3.92:1 |
| `--brand-warm-b` | `#D06819` | 3.70:1 |
| `--brand-canvas-3` | `#7B54D6` | 5.16:1 |

They clear WCAG's **large-text** bar of 3:1; none clears the 4.5:1 body bar. So the gradient may only land on large text, and the two 19px elements in this console fall on opposite sides of that line:

| surface | metrics | verdict |
|---|---|---|
| `.brand-name` | 19px / **700** — bold and ≥18.66px | large text ✓ |
| `.ov-stat-num` | 32px / 600 — ≥24px | large text ✓ |
| `.ov-stat-v.small` | 19px / **500** — not bold | body text ✗ |
| `.ov-stat-v.danger` | colour is `--delete` | semantic ✗ |

`ovStat` grants the class only when no modifier is present, so `mod` — which already names the disqualified set — is the whole gate.

The selector is `.ov-stat-num`, not `.ov-stat-v.ov-stat-num`, and the low specificity is load-bearing: it beats `.ov-stat-v`'s own `color` but deliberately **loses** to `.ov-stat-v.danger`, so a tile that wrongly received the class degrades to opaque red rather than to invisible text.

## Its own section

The motion section from #1393 is transform-and-shadow only and `TestMotionSectionAnimatesGeometryOnly` enforces that, so the colour half of "make it feel alive" has nowhere to live there. The new banner also **bounds** the motion section, which until now ran to end of file.

## Deliberately not done

- **No count-up on the tiles.** `ovStat` already carries the record of why one was removed: it writes intermediate numbers into the DOM, so a forensics surface briefly reports a wrong count.
- **No warm wash on the Restore-coverage card.** That card's job is to state degradation in red and amber; a brand wash behind *"Events were permanently lost"* competes with the most important alarm in this console.
- **No coverage bar.** The card states a *window*, not a fraction — a bar would have to invent a denominator.
- **The primary button keeps its blue-violet fill.** White text on the warm stops is 3.92:1 / 3.70:1, under the 4.5:1 body floor at 13.5px, and `--brand-rail` already ratifies that product blue stays the interactive accent.

## Guards

Every guard was mutated and confirmed red before being kept:

| mutation | caught by |
|---|---|
| `color: transparent` outside `@supports` | `TestGradientTextStaysBehindItsSupportsTest` |
| `background-clip: text` outside `@supports` | same |
| `--delete` referenced in the section | `TestBrandSectionPaintsFromTokensAndNeverSemantics` |
| raw `oklch()` literal instead of a token | same |
| `transition:` smuggled into the paint-only section | same |
| class renamed in CSS only / in app.js only | `TestBrandOptInClassIsGrantedInExactlyOnePlace` |
| a second grant site in app.js | same |
| **gate inverted — danger tile granted the gradient** | **e2e 17e only** |

That last row is why the browser scenario exists: rewriting the gate in place keeps the mention count at one and leaves every text guard green. Scenario 17e calls the real `ovStat` and reads computed styles back, proving the deletes tile keeps `--delete` and takes no gradient.

The rename mutation also found a real hole in the guard as first written: a plain `Contains` passed a rename to `.ov-stat-number`, of which the old name is a prefix. Both sides now match on a whole token.

## A guard that was removed

A `@media (forced-colors: active)` reset was written first, on the theory that Windows High Contrast strips the gradient while the transparent ink survives. Measured in Chromium, the computed pair under forced-colors is **byte-identical with and without it** — `color` is itself one of the properties forced-colors replaces, so that failure cannot occur. Deleting the block, its parity guard and its e2e assertion; the reasoning is recorded in the stylesheet so it is not re-added as cargo cult. (`@supports` is not the same case and stays: nothing in the platform substitutes for it, and its correctness follows from the at-rule's semantics rather than from a measurement.)

## Verification

- `go test ./internal/console/ -count=1` and `-race`: green
- `test/console-e2e/run.sh`: **245/245**
- mutation tables above, run against both harnesses

---

# Review pass 1 — what it changed

Three real guard defects, a rendering bug, and a set of overclaims. Every fix below was mutation-verified, **including negative controls** for the two findings that were about the guard crying wolf rather than missing something.

### Guard defects

| defect | evidence | fix |
|---|---|---|
| The `@supports` check matched the bare at-rule keyword | `@supports (display: grid)` around transparent ink passed — the exact state it forbids | reads the condition now, and is **whole-file** |
| The app.js count read raw bytes | a documentation line merely *naming* the class read as a second grant site and accused correct code | counts string literals only |
| `.brand-name` had no coverage at all | dropping it from the gradient rule left everything green while the wordmark reverted to flat ink | pinned CSS ↔ `index.html`, plus a browser assertion on the real element |

Making the clip guard whole-file also picked up the **pre-existing** login-panel title (`style.css:1485`), which uses the identical clip-to-text pair and was unguarded; and it now covers anything appended below this section's banner, which the section-scoped version silently did not. Precision held: `border-color: transparent` (9 in the file) and `background-clip: content-box` (4) are correctly not swept in.

The `oklch()` ban only blocked one notation — the hex form was open, and the hex values sit in a comment beside the tokens. All notations are banned now.

### A rendering bug

`background-clip: text` paints the **box**, not the glyphs. `.ov-stat-v` is a block that fills its tile, so a two-digit count sampled only the leading sliver of a ramp stretched across the whole tile and rendered as flat pink — the violet stop never reached the screen. `width: fit-content`, scoped to the opt-in class only: the loading tile puts a skeleton inside `.ov-stat-v`, which a shrink-to-fit parent would collapse.

### Overclaims corrected

- **The specificity belt covers one of the two exclusions, not both.** `.ov-stat-v.small` sets no `color`, so the gradient rule would win outright and render body text as transparent ink. `small` is protected by the gate in `ovStat` and by nothing else.
- **Two statements that no stop clears 4.5:1 were false** — `--brand-canvas-3` is 5.16:1. The operative fact is that a gradient must satisfy its bar at *every point*, and this sweep dips to 3.70:1.
- **"Measured against white" advertised rigour about the one input that was assumed.** None of the shipped grounds is white. Re-measured against the tile (`--surface-2`) and the studio sidebar: the real floor is **3.54:1**, still clear of 3:1.
- **The forced-colors note generalised one engine and one palette into platform law**, and stated a prediction with the same confidence as the measurement beside it.
- **`brandSection`'s back-up comment described a failure that does not happen.**

### Stated, not fixed

Scenario 17e now records the two things it does not reach: it passes `"danger"` itself, so it does not prove the call site still sends one; and its tiles mount outside a rendered Overview, so an ancestor-scoped rule is invisible to it.

**Verification after the fixes:** `go test ./internal/console/` green, `console-e2e` **246/246**, CI **17/17**.

---

# Review pass 2 — three of my pass-1 fixes were regressions

Pass 2 was aimed at whether the pass-1 fixes were real or inert. Three were **narrowings that closed a false positive and opened a false negative the pre-fix version had caught** — the worse trade, and invisible without mutation.

| regression I introduced | what stopped being caught | fix |
|---|---|---|
| leading-class guard on `color:` | `-webkit-text-fill-color: transparent` — also hyphen-prefixed, and the exact substitution the section's prose names as tempting | its own pattern |
| condition read, polarity not | `@supports **not** (background-clip: text)` — the failure inverted into a passing shape | reject `not` preludes |
| count narrowed to quoted strings | template-literal grants (57 backticks in app.js), **and** English contractions became delimiters: `Don't rename ov-stat-num, it's …` counted as two grants | strip whole-line comments, match the bare token |

The comment counter is deliberately **line-oriented, not a lexer**: app.js holds a regex containing a double quote (`/[",\r\n]/`) and another containing an escaped slash (`/^\//`). A character scanner tracking quote state desyncs on those and then blanks arbitrary code — silently, inside a guard.

### And then my own fix reopened the hole it was closing

Adding `.brand-name` to the width rule meant the class appears on **two** rules, so a guard asking *"is this class in the section"* passed with the class removed from the only rule that paints it. Caught by re-running the mutation, not by reading. Both guards now parse the selector list of the rule that declares `background-image` and compare selectors for **equality** — which subsumes the prefix trap the `\b` regex existed for, so that helper is deleted rather than kept as dead code.

### The contrast numbers were measured the wrong way

They are now read off **rendered pixels** in Chromium. This mattered: two independent oklch→sRGB conversions agreed with each other and both disagreed with the browser in the second decimal, because `--brand-warm-a` is outside the sRGB gamut and the mapping is the engine's to choose. The measured figures match the pre-existing login-panel comment exactly — the converted ones contradicted it, and I had been about to "correct" the comment that was right.

| ground | warm-a | warm-b | canvas-3 |
|---|---|---|---|
| white | 3.94 | **3.70** | 5.15 |
| `--surface-2`, the studio tile | 3.76 | **3.53** | 4.91 |
| the studio sidebar | 3.82 | **3.59** | 5.00 |

Also corrected: *"none of the shipped grounds is white"* was false (the login title clips onto `--surface`, and `paper`/`trail` resolve the tile to white); *"small is protected by the gate in ovStat"* was wrong (`small` never calls `ovStat` — its construction site simply doesn't grant the class); the skeleton-collapse rationale was invented (`.skel-stat` carries an explicit width a `fit-content` parent honours); `brandSection`'s comment named the wrong mechanism *again*; and 17e attributed the deletes tile to the wrong function.

**One pass-2 finding was not applied.** It reported that no guard bans paint properties in the motion section. `TestMotionSectionAnimatesGeometryOnly` does exactly that — the finding cited the reduced-motion file instead.

### Final verification

- **10 mutations caught**, including both classes the pre-fix guards had lost
- **4 cry-wolf controls confirmed silent** (contractions, block comments, `*-color: transparent`, `background-clip: content-box`)
- `console-e2e` **246/246**, `go test -race ./internal/console/` green
