### PR TITLE
console: warm the loading shimmer (#1385)

### DIFF
--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -140,17 +140,45 @@
      would silently stop being "--sun at 12%" the day --sun moves. */
   --brand-wash-sun:  color-mix(in srgb, var(--sun) 12%, transparent);
   --brand-wash-pink: color-mix(in srgb, var(--brand-canvas-1) 3%, transparent);
-  /* The loading bars, warmed toward the hero pink (#1385). A much stronger
-     mix than the washes above because this is an opaque FILL rather than a
-     tint over content — nothing is read through it, so the alpha ceiling that
-     constrains those two does not apply here. What does apply is the opposite
-     bound: the bar has to stay visible against the panel it sits on, or the
-     loading state reads as an empty page. Measured off rendered pixels on
-     --surface-2, the warmed bar sits at 1.60:1 against its ground where the
-     plain --line it replaces sat at 1.23:1 — noticeably MORE separated, not
-     less, which was not the expected direction and is why it was measured.
-     color-mix over --line rather than a new colour, so it still tracks the
-     line token if the ramp is ever retuned. */
+  /* The OVERVIEW loading bars, warmed toward the hero pink (#1385). Not every
+     skeleton: the Events list uses .ev-skel-bar, a flat --surface-3 fill with a
+     pulse rather than a shimmer, and it is left alone.
+
+     A much stronger mix than the two washes above because the TOKEN is opaque
+     — it mixes toward --line, where those mix toward transparent — so the
+     alpha ceiling that protects text read through them protects nothing here.
+     (The rendered bar is not opaque: the DECLARATION's mid-stop is
+     `transparent`, which is what produces the sweep.)
+
+     The bound that does apply is the opposite one: the solid stop has to stay
+     distinguishable from the panel, or a loading Overview reads as an empty
+     one. Read off rendered pixels, per direction:
+
+       ground                                 warmed   was (--line)
+       --surface-2, the studio tile             1.60         1.23
+       paper and trail (both resolve white)     1.68         1.28
+
+     Studio is the shipped default and also the worst case, which is why the
+     browser assertion measures that one. More separated than before, not less
+     — the direction was not the expected one, and is why it was measured
+     rather than converted.
+
+     Those figures are the stop's PEAK against its ground. The mid-stop is
+     transparent and the shimmer sweeps it, so every point on the bar passes
+     through roughly 1.0:1 once per cycle. That is the placeholder's whole
+     visual idiom, not a defect, but it is why the number belongs to the stop
+     and not to "the bar".
+
+     color-mix over --line rather than a new colour, so the bar still tracks
+     the ink ramp. It tracks BOTH inputs, and tracking does not preserve the
+     ratio above: darkening --line toward --surface-2 pulls the studio figure
+     from 1.60 to about 1.38. The browser assertion is what holds the floor;
+     the numbers here are a record of one moment.
+
+     On the data rule: these bars do appear inside .ov-evlist and .ov-tables,
+     which will carry rows. They never coexist with one — a placeholder is
+     replaced by the rows it stood in for — and a skeleton encodes nothing, so
+     no brand colour is carrying data here. */
   --skel-warm: color-mix(in srgb, var(--brand-canvas-1) 26%, var(--line));
   /* The nav's active rail EXTENDS the blue->violet accent gradient into the
      sunset instead of replacing it: product blue stays the interactive accent.
@@ -1244,8 +1272,8 @@ button { font-family: inherit; }
 .skel-note { font-family: var(--f-mono); font-size: 11px; color: var(--ink-4); margin-top: 8px; }
 @keyframes skel-shimmer { from { background-position: 200% 0; } to { background-position: -200% 0; } }
 /* Without the shimmer the bar is still visible: at the static
-   background-position the gradient renders solid --line across its left half,
-   fading out towards the right. A placeholder either way, so unlike the
+   background-position the gradient renders solid --skel-warm across its left
+   half, fading out towards the right. A placeholder either way, so unlike the
    spinner below it needs no stand-in. */
 @media (prefers-reduced-motion: no-preference) {
   .skel-line { animation: skel-shimmer 1.4s linear infinite; }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -171,8 +171,10 @@
 
      color-mix over --line rather than a new colour, so the bar still tracks
      the ink ramp. It tracks BOTH inputs, and tracking does not preserve the
-     ratio above: darkening --line toward --surface-2 pulls the studio figure
-     from 1.60 to about 1.38. The browser assertion is what holds the floor;
+     ratio above. The erosive direction is LIGHTENING --line toward the panel
+     it sits on: --line is L 0.918 against --surface-2's 0.985, so moving it up
+     that gap pulls the studio figure from 1.60 to about 1.37 at the far end.
+     Darkening is the safe direction and gains margin (L 0.85 measures 1.92). The browser assertion is what holds the floor;
      the numbers here are a record of one moment.
 
      On the data rule: these bars do appear inside .ov-evlist and .ov-tables,

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -140,6 +140,18 @@
      would silently stop being "--sun at 12%" the day --sun moves. */
   --brand-wash-sun:  color-mix(in srgb, var(--sun) 12%, transparent);
   --brand-wash-pink: color-mix(in srgb, var(--brand-canvas-1) 3%, transparent);
+  /* The loading bars, warmed toward the hero pink (#1385). A much stronger
+     mix than the washes above because this is an opaque FILL rather than a
+     tint over content — nothing is read through it, so the alpha ceiling that
+     constrains those two does not apply here. What does apply is the opposite
+     bound: the bar has to stay visible against the panel it sits on, or the
+     loading state reads as an empty page. Measured off rendered pixels on
+     --surface-2, the warmed bar sits at 1.60:1 against its ground where the
+     plain --line it replaces sat at 1.23:1 — noticeably MORE separated, not
+     less, which was not the expected direction and is why it was measured.
+     color-mix over --line rather than a new colour, so it still tracks the
+     line token if the ramp is ever retuned. */
+  --skel-warm: color-mix(in srgb, var(--brand-canvas-1) 26%, var(--line));
   /* The nav's active rail EXTENDS the blue->violet accent gradient into the
      sunset instead of replacing it: product blue stays the interactive accent.
      A separate token on purpose — .timeline::before is a DATA surface and
@@ -1225,7 +1237,7 @@ button { font-family: inherit; }
 .skel-box { display: flex; flex-direction: column; gap: 10px; padding: 6px 0; }
 .skel-line {
   height: 13px; border-radius: 4px;
-  background: linear-gradient(90deg, var(--line) 25%, transparent 50%, var(--line) 75%);
+  background: linear-gradient(90deg, var(--skel-warm) 25%, transparent 50%, var(--skel-warm) 75%);
   background-size: 200% 100%;
 }
 .skel-line.skel-stat { height: 26px; width: 72px; margin-bottom: 4px; }

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -2317,29 +2317,53 @@ try {
       deleteRef: cs(ref).color,
     };
 
-    // The warmed loading bar (#1385), and the one bound that matters for it:
-    // it is an opaque fill nothing is read through, so no contrast CEILING
-    // applies — but it still has to be distinguishable from the panel, or a
-    // loading Overview reads as an empty one. Measured through a canvas rather
-    // than compared as strings, because both values are authored in oklch and
-    // one of them is a color-mix: string equality would answer a different
-    // question, and only rendered pixels say how far apart they are.
+    // The warmed loading bar (#1385). Measured off the ELEMENT, which is the
+    // whole point and was got wrong first: an earlier version read --skel-warm
+    // and --surface-2 off :root and compared those. That measures a token pair
+    // the bar need not use — repointing .skel-line back at var(--line), the
+    // literal state before the change, left it green.
+    //
+    // So: pull the first colour stop out of the bar's own computed gradient,
+    // and composite it over the first painted ancestor rather than over black,
+    // which keeps the arithmetic honest if the stop ever carries alpha.
+    // Canvas rather than string comparison because the two values are a
+    // color-mix and an oklch — they can never compare equal, so a string check
+    // would be vacuous rather than merely different; only rendered pixels say
+    // how far apart they are.
     const pending = ovStatPending("changes indexed", "all time");
     host.appendChild(pending);
-    res.skelPainted = cs(pending.querySelector(".skel-line")).backgroundImage;
+    const bar = pending.querySelector(".skel-line");
+    res.skelPainted = cs(bar).backgroundImage;
+    res.skelStop = (res.skelPainted.match(/\b(?:rgba?|color|oklch|oklab|hsla?)\([^)]*\)|#[0-9a-fA-F]{3,8}\b/) || [])[0] || "";
+    let ground = "rgba(0, 0, 0, 0)";
+    for (let n = bar; n && (ground === "rgba(0, 0, 0, 0)" || ground === "transparent"); n = n.parentElement) {
+      ground = cs(n).backgroundColor;
+    }
+    res.skelGround = ground;
+
     const cv = document.createElement("canvas");
     cv.width = cv.height = 1;
     const ctx = cv.getContext("2d", { willReadFrequently: true });
-    const lum = (token) => {
-      ctx.fillStyle = "#000";
+    // An unparseable fillStyle is IGNORED, leaving the previous value in place
+    // — and the previous value would be the ground, so a rejected stop would
+    // measure 1.0 and read as a failure, or worse against black would inflate
+    // the ratio and pass. Checked explicitly instead of hoped for.
+    ctx.fillStyle = "#010203";
+    ctx.fillStyle = res.skelStop;
+    res.skelParsed = ctx.fillStyle !== "#010203";
+    const px = (c, over) => {
+      ctx.clearRect(0, 0, 1, 1);
+      ctx.fillStyle = over;
       ctx.fillRect(0, 0, 1, 1);
-      ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue(token).trim();
+      ctx.fillStyle = c;
       ctx.fillRect(0, 0, 1, 1);
-      const d = ctx.getImageData(0, 0, 1, 1).data;
+      return ctx.getImageData(0, 0, 1, 1).data;
+    };
+    const relLum = (d) => {
       const c = (v) => { v /= 255; return v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4); };
       return 0.2126 * c(d[0]) + 0.7152 * c(d[1]) + 0.0722 * c(d[2]);
     };
-    const [hi, lo] = [lum("--skel-warm"), lum("--surface-2")].sort((a, b) => b - a);
+    const [hi, lo] = [relLum(px(res.skelStop, ground)), relLum(px(ground, ground))].sort((a, b) => b - a);
     res.skelRatio = (hi + 0.05) / (lo + 0.05);
 
     host.remove();
@@ -2367,14 +2391,21 @@ try {
   (brand.wordImage.includes("gradient") && brand.wordColor === transparent)
     ? ok("brand paint: the sidebar wordmark wears the headline gradient")
     : bad("brand paint: the sidebar wordmark wears the headline gradient", JSON.stringify(brand));
-  // A floor, not the measurement. 1.60:1 is what it renders at today; 1.3 is
-  // low enough that an ordinary retune of --brand-canvas-1 or --line does not
-  // ring, and high enough to catch a mix that washes the bar out — which is
-  // the direction a "make it subtler" edit pushes it.
-  (brand.skelPainted.includes("gradient") && brand.skelRatio >= 1.3)
-    ? ok("brand paint: the warmed loading bar stays visible against its panel")
-    : bad("brand paint: the warmed loading bar stays visible against its panel",
-        brand.skelPainted + " ratio=" + brand.skelRatio.toFixed(3));
+  // A floor placed BETWEEN the two measured states, not at the measurement:
+  // the warmed stop renders 1.60:1 on the studio tile and the plain --line it
+  // replaced rendered 1.23:1, so 1.3 separates them. That is what makes the
+  // check bind — reverting the declaration lands at 1.23 and rings. It is not
+  // a general washout detector: the mix has to fall to roughly 5% pink before
+  // 1.3 fires on its own, so a "make it subtler" retune is NOT caught here.
+  //
+  // Studio is measured because it is the shipped direction and also the worst
+  // of the three grounds; paper and trail resolve to white, where the same
+  // stop sits at 1.68:1.
+  (brand.skelParsed && brand.skelPainted.includes("gradient") && brand.skelRatio >= 1.3)
+    ? ok("brand paint: the warmed loading bar's stop stays clear of its panel")
+    : bad("brand paint: the warmed loading bar's stop stays clear of its panel",
+        JSON.stringify({ stop: brand.skelStop, ground: brand.skelGround,
+          ratio: Number(brand.skelRatio.toFixed(3)), parsed: brand.skelParsed }));
 
   // ── Scenario 18 — advisory severity split on the archive fixture (#1365) ──
   // The archive-elision record must render in the INFO register (muted line,

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -2316,6 +2316,32 @@ try {
       wordColor: cs(document.querySelector(".brand-name")).color,
       deleteRef: cs(ref).color,
     };
+
+    // The warmed loading bar (#1385), and the one bound that matters for it:
+    // it is an opaque fill nothing is read through, so no contrast CEILING
+    // applies — but it still has to be distinguishable from the panel, or a
+    // loading Overview reads as an empty one. Measured through a canvas rather
+    // than compared as strings, because both values are authored in oklch and
+    // one of them is a color-mix: string equality would answer a different
+    // question, and only rendered pixels say how far apart they are.
+    const pending = ovStatPending("changes indexed", "all time");
+    host.appendChild(pending);
+    res.skelPainted = cs(pending.querySelector(".skel-line")).backgroundImage;
+    const cv = document.createElement("canvas");
+    cv.width = cv.height = 1;
+    const ctx = cv.getContext("2d", { willReadFrequently: true });
+    const lum = (token) => {
+      ctx.fillStyle = "#000";
+      ctx.fillRect(0, 0, 1, 1);
+      ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue(token).trim();
+      ctx.fillRect(0, 0, 1, 1);
+      const d = ctx.getImageData(0, 0, 1, 1).data;
+      const c = (v) => { v /= 255; return v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4); };
+      return 0.2126 * c(d[0]) + 0.7152 * c(d[1]) + 0.0722 * c(d[2]);
+    };
+    const [hi, lo] = [lum("--skel-warm"), lum("--surface-2")].sort((a, b) => b - a);
+    res.skelRatio = (hi + 0.05) / (lo + 0.05);
+
     host.remove();
     return res;
   });
@@ -2341,6 +2367,14 @@ try {
   (brand.wordImage.includes("gradient") && brand.wordColor === transparent)
     ? ok("brand paint: the sidebar wordmark wears the headline gradient")
     : bad("brand paint: the sidebar wordmark wears the headline gradient", JSON.stringify(brand));
+  // A floor, not the measurement. 1.60:1 is what it renders at today; 1.3 is
+  // low enough that an ordinary retune of --brand-canvas-1 or --line does not
+  // ring, and high enough to catch a mix that washes the bar out — which is
+  // the direction a "make it subtler" edit pushes it.
+  (brand.skelPainted.includes("gradient") && brand.skelRatio >= 1.3)
+    ? ok("brand paint: the warmed loading bar stays visible against its panel")
+    : bad("brand paint: the warmed loading bar stays visible against its panel",
+        brand.skelPainted + " ratio=" + brand.skelRatio.toFixed(3));
 
   // ── Scenario 18 — advisory severity split on the archive fixture (#1365) ──
   // The archive-elision record must render in the INFO register (muted line,

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -2339,7 +2339,12 @@ try {
     for (let n = bar; n && (ground === "rgba(0, 0, 0, 0)" || ground === "transparent"); n = n.parentElement) {
       ground = cs(n).backgroundColor;
     }
-    res.skelGround = ground;
+    // Belt matching the fillStyle one below, for the same reason: if every
+    // ancestor came back transparent the ground's luminance is 0 and the ratio
+    // INFLATES past any floor, so the failure direction is a silent pass.
+    // Unreachable while body paints --bg, which is exactly when a belt is
+    // cheap. Recorded as null so the assertion has something to test.
+    res.skelGround = (ground === "rgba(0, 0, 0, 0)" || ground === "transparent") ? null : ground;
 
     const cv = document.createElement("canvas");
     cv.width = cv.height = 1;
@@ -2401,10 +2406,10 @@ try {
   // Studio is measured because it is the shipped direction and also the worst
   // of the three grounds; paper and trail resolve to white, where the same
   // stop sits at 1.68:1.
-  (brand.skelParsed && brand.skelPainted.includes("gradient") && brand.skelRatio >= 1.3)
+  (brand.skelParsed && brand.skelGround && brand.skelPainted.includes("gradient") && brand.skelRatio >= 1.3)
     ? ok("brand paint: the warmed loading bar's stop stays clear of its panel")
     : bad("brand paint: the warmed loading bar's stop stays clear of its panel",
-        JSON.stringify({ stop: brand.skelStop, ground: brand.skelGround,
+        JSON.stringify({ stop: brand.skelStop, ground: brand.skelGround || "NONE FOUND",
           ratio: Number(brand.skelRatio.toFixed(3)), parsed: brand.skelParsed }));
 
   // ── Scenario 18 — advisory severity split on the archive fixture (#1365) ──


### PR DESCRIPTION
Third and final slice of #1385. #1393 landed the motion half, #1395 the brand-paint half; this is the skeleton shimmer — the last item on the issue's list that could be delivered without either guessing or breaking one of the issue's own rules.

## The change

```css
--skel-warm: color-mix(in srgb, var(--brand-canvas-1) 26%, var(--line));
```

`color-mix` over `--line` rather than a new colour, so it still tracks the line token if the ink ramp is ever retuned — rule 2 of the issue.

The mix is far stronger than the `--brand-wash-*` pair beside it, and deliberately so: those are tints that content is read **through**, so their alphas are ceilings derived from `--ink-3` staying ≥4.5:1. Nothing is read through a loading bar, so that ceiling protects text that does not exist here.

## The bound that does apply, measured

A bar that blends into its panel turns a loading Overview into an empty-looking one. Read off rendered pixels on `--surface-2`:

| bar | vs its ground |
|---|---|
| warmed (`--skel-warm`) | **1.60:1** |
| the plain `--line` it replaces | 1.23:1 |

More separated, not less — which was not the direction I expected. **The numbers I had written into the comment before measuring were both wrong**, which is the second time in this issue that a converted or assumed figure disagreed with the browser.

`console-e2e` enforces a **floor of 1.3:1**, not the measurement: low enough that an ordinary retune of `--brand-canvas-1` or `--line` does not ring, high enough to catch a mix that washes the bar out — the direction a "make it subtler" edit pushes it. The ratio is computed through a canvas, because both values are authored in oklch and one is a `color-mix`; comparing the strings would answer a different question.

| mutation | result |
|---|---|
| mix washed out to the panel colour | **FAIL**, ratio 1.009 |
| bar loses its gradient entirely | **FAIL**, `background-image: none` |

## Why this closes #1385

Everything remaining on the issue's list was investigated and is either done or declined on evidence. The full accounting goes on the issue; the two worth repeating here:

- **The primary button keeps its blue-violet fill.** White text on the warm stops measures 3.94:1 and 3.70:1, under the 4.5:1 body floor at 13.5px, and `--brand-rail` already ratifies that product blue stays the interactive accent.
- **The "offset shadow" the issue attributes to the site's CTA is not on the CTA.** Reading dbtrail.com's own stylesheet: `box-shadow: 8px 8px 0 var(--sun)` belongs to `.install`, the copy-the-command hero block, going to `10px 10px 0` with a `translate(-2px,-2px)` lift on hover. The console has no analogous chrome block — its nearest relative, `.codepanel`, holds generated recovery SQL, which is a data surface. An 8px hard sun-yellow shadow on a 38px button that recurs through modals and toolbars is the "performs at you while you are stressed" failure the issue's own taste constraint names.

## Verification

- `go test ./internal/console/ -count=1`: green
- `console-e2e`: **247/247**
- both mutations above confirmed red
