### PR TITLE
console: make the Events loading skeleton visible (#1397)

### DIFF
--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -141,8 +141,9 @@
   --brand-wash-sun:  color-mix(in srgb, var(--sun) 12%, transparent);
   --brand-wash-pink: color-mix(in srgb, var(--brand-canvas-1) 3%, transparent);
   /* The OVERVIEW loading bars, warmed toward the hero pink (#1385). Not every
-     skeleton: the Events list uses .ev-skel-bar, a flat --surface-3 fill with a
-     pulse rather than a shimmer, and it is left alone.
+     skeleton: the Events list's .ev-skel-bar is a flat fill with a pulse
+     rather than a shimmer, and it stays NEUTRAL — see --skel-neutral below
+     for why the warmth stops here.
 
      A much stronger mix than the two washes above because the TOKEN is opaque
      — it mixes toward --line, where those mix toward transparent — so the
@@ -182,6 +183,57 @@
      replaced by the rows it stood in for — and a skeleton encodes nothing, so
      no brand colour is carrying data here. */
   --skel-warm: color-mix(in srgb, var(--brand-canvas-1) 26%, var(--line));
+  /* The EVENTS list's loading bars (#1397). The ground is plain white:
+     .events declares no background and every element between the bar and
+     <body> is transparent, in all three directions (they re-point
+     --panel-bg, which this list never consumes). Against it, read off
+     rendered pixels:
+
+       .ev-skel-bar, was --surface-3      1.09   (pulse trough 1.04)
+       the --line-soft divider beside it  1.17
+       this token                         1.64   (pulse trough 1.24)
+
+     The bar was fainter than the hairline separating the rows it stands in
+     for, so a loading list rendered as an empty list with dividers — the
+     "blank list" the .ev-skel-row comment says must never be the busy state,
+     on the page an operator opens mid-incident. The pulse made that worse
+     rather than better, and it is gated behind prefers-reduced-motion, so
+     with motion reduced there was nothing moving to suggest the bar was
+     there at all. The dip goes lower still (1.04), but the static case is the
+     one with nothing compensating for it, and it is the one the console-e2e
+     floor measures.
+
+     The pulse itself is left as it was: its dimmest point now clears the old
+     RESTING value, so the animation no longer carries the bar's visibility.
+     A separate assertion holds that, because deepening a pulse is an
+     ordinary polish edit and 0.45 -> 0.12 lands below where this started.
+
+     For scale, .skel-line — the Overview bar — peaks at 1.68 on this same
+     white ground, and 1.60 on the studio tile it usually sits on. Peaks
+     only: it is a gradient sweeping a TRANSPARENT mid-stop, so unlike this
+     bar it passes through roughly 1.0:1 once per cycle. An earlier draft of
+     this table gave it a "trough 1.25", which was this bar's opacity pulse
+     arithmetic applied to an element that has no opacity pulse.
+
+     color-mix across the two ends of the ramp the bar lives between, not a
+     new literal, so it tracks a retune of either. The erosive direction is
+     raising the --line share, which walks it back toward the page: 80% is
+     1.52 and 90% is 1.39. Lightening either input erodes it more gently
+     (--line at L 0.95 is 1.53, --ink-4 at L 0.72 is 1.54). The console-e2e
+     assertions hold the floor; these numbers are one moment's record.
+
+     NEUTRAL is the status quo, not a ratified rule, and nothing enforces it
+     — any hue clearing the floor would pass. #1385's close gives two reasons
+     for stopping the warmth here: that this is a flat pulse rather than a
+     shimmer and out of scope for an issue that named the shimmer, and a
+     strict reading of the rule as written above: "pink never lands on a
+     surface that carries a row". That comment argues the other way about
+     its OWN bars, which also sit in row-carrying panels — a placeholder
+     never coexists with a row, and encodes nothing. #1397 was filed as a
+     visibility fix and says so outright ("worth fixing whatever colour it
+     ends up"). So: a decline was recorded, no rule was ratified, and nothing
+     in the code holds either — which is why this is a comment. */
+  --skel-neutral: color-mix(in srgb, var(--line) 70%, var(--ink-4));
   /* The nav's active rail EXTENDS the blue->violet accent gradient into the
      sunset instead of replacing it: product blue stays the interactive accent.
      A separate token on purpose — .timeline::before is a DATA surface and
@@ -752,7 +804,7 @@ button { font-family: inherit; }
   align-items: center; gap: 12px;
   padding: 13px 14px; border-bottom: 1px solid var(--line-soft);
 }
-.ev-skel-bar { height: 12px; border-radius: 6px; background: var(--surface-3); }
+.ev-skel-bar { height: 12px; border-radius: 6px; background: var(--skel-neutral); }
 .ev-skel-time { width: 76%; }
 .ev-skel-table { width: 58%; }
 .ev-skel-type { width: 62%; }

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -2412,6 +2412,212 @@ try {
         JSON.stringify({ stop: brand.skelStop, ground: brand.skelGround || "NONE FOUND",
           ratio: Number(brand.skelRatio.toFixed(3)), parsed: brand.skelParsed }));
 
+  // ── Scenario 17f — the Events skeleton is visible (#1397) ──
+  //
+  // .ev-skel-bar stood in for event rows at 1.09:1 against the page — fainter
+  // than the 1.17:1 --line-soft hairline separating the rows it stood in for.
+  // A loading list therefore rendered as an empty list with dividers: the
+  // "blank list" that the #1353 comment introducing this feature says must
+  // never be the busy state, on the page an operator opens mid-incident.
+  //
+  // This reads SCREENSHOT PIXELS, not computed style, and that is the whole
+  // design. Two earlier drafts asserted a declared colour, and each time
+  // review produced a one-declaration edit that re-broke the rendering while
+  // the assertion sat unchanged at 1.64. `.ev-loading { opacity: .5 }` is the
+  // one that settled it: opacity does NOT inherit — it composites the group —
+  // so the bar's own computed opacity stays 1 while it renders at 1.267.
+  // Chasing that with an ancestor walk would have left `filter`, a covering
+  // ::after, and a background-image over the fill. A pixel has no such list.
+  //
+  // Every bar is measured (40 of them) because a rule can repaint SOME: the
+  // nth-child rule reaches only even rows, and the five .ev-skel-* width
+  // classes sit on the same element as .ev-skel-bar, so they repaint the bar
+  // without naming it. All three directions are measured because stripping
+  // fills is `paper`'s idiom — five existing rules do exactly that.
+  //
+  // The pulse is sampled rather than modelled. An earlier draft read the
+  // keyframes and folded the minimum opacity into the maths, which is blind
+  // to a pulse that animates any other property. Instead the animation is
+  // frozen at five phases with a negative delay and photographed, so whatever
+  // it animates is simply in the picture.
+  //
+  // Ground is sampled too, from the row's own padding a few pixels above the
+  // bar, so both halves of the ratio come from the same photograph.
+  //
+  // The limit worth naming, since nothing here reaches it: renderEventsLoading
+  // is called directly rather than through runEventsQuery. This proves the
+  // skeleton is visible, not that the fetch path still paints one.
+  const skelShot = async () => {
+    const png = (await page.screenshot({ fullPage: true })).toString("base64");
+    // Decoded by the browser's own PNG reader rather than a hand-rolled one:
+    // the image goes back into the page, onto a canvas, and comes out as bytes.
+    return page.evaluate(async (b64) => {
+      const img = new Image();
+      img.src = "data:image/png;base64," + b64;
+      await img.decode();
+      const cv = document.createElement("canvas");
+      cv.width = img.width; cv.height = img.height;
+      cv.getContext("2d").drawImage(img, 0, 0);
+      const ctx = cv.getContext("2d", { willReadFrequently: true });
+      const at = (x, y) => [...ctx.getImageData(Math.round(x), Math.round(y), 1, 1).data].slice(0, 3);
+      // Document coordinates, to match a full-page shot. The ground point sits
+      // inside the row's top padding, above the bar and well clear of the
+      // bottom border, so it photographs whatever the bar is drawn on.
+      return [...document.querySelectorAll(".ev-skel-bar")].map((b) => {
+        const r = b.getBoundingClientRect();
+        const row = b.closest(".ev-skel-row").getBoundingClientRect();
+        const x = r.left + r.width / 2 + scrollX;
+        return { bar: at(x, r.top + r.height / 2 + scrollY), ground: at(x, row.top + 3 + scrollY) };
+      });
+    }, png);
+  };
+  const relLum = (d) => {
+    const c = (v) => { v /= 255; return v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4); };
+    return 0.2126 * c(d[0]) + 0.7152 * c(d[1]) + 0.0722 * c(d[2]);
+  };
+  const skelWorst = (samples) => samples.length === 0 ? null : samples.reduce((worst, s) => {
+    const [hi, lo] = [relLum(s.bar), relLum(s.ground)].sort((a, b) => b - a);
+    const ratio = (hi + 0.05) / (lo + 0.05);
+    return !worst || ratio < worst.ratio ? { ratio, n: samples.length, bar: s.bar, ground: s.ground } : worst;
+  }, null);
+
+  // Resting first, under emulated reduced motion — a determinism choice, since
+  // mid-pulse a photograph catches whatever frame it lands on. It is also the
+  // honest worst case: the pulse is gated behind the same query, so a
+  // reduced-motion user gets no movement at all to suggest the bar is there,
+  // and the static value was the invisible one.
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  // Repainted before every shot, not once for the run: renderEvents ends by
+  // firing its own query, and that resolve calls buildEventRows, which clears
+  // #ev-rows. Asserting the skeleton survived an await would be a flake in the
+  // one scenario whose stated design is determinism.
+  const skelPaint = () => page.evaluate(async () => {
+    navigate("events");
+    await new Promise((r) => setTimeout(r, 300));
+    const rows = document.querySelector("#ev-rows");
+    if (!rows) return 0;
+    renderEventsLoading(rows);
+    return document.querySelectorAll(".ev-skel-bar").length;
+  });
+  const skelSetDir = (dir) => page.evaluate((d) => {
+    const root = document.documentElement;
+    d === null ? root.removeAttribute("data-dir") : root.setAttribute("data-dir", d);
+  }, dir);
+
+  const skelPrevDir = await page.evaluate(() => document.documentElement.getAttribute("data-dir"));
+  let skelBars = 0;
+  const skelRest = {};
+  for (const dir of ["studio", "paper", "trail"]) {
+    await skelSetDir(dir);
+    skelBars = await skelPaint();
+    skelRest[dir] = skelWorst(await skelShot());
+  }
+  await skelSetDir(skelPrevDir);
+
+  // Then the pulse, sampled rather than modelled: freeze the animation with a
+  // negative delay and photograph it. Whatever it animates is in the picture,
+  // so swapping the animated property cannot slip past — an earlier draft read
+  // the keyframes' opacity and was blind to exactly that.
+  //
+  // A uniform tenth-of-a-cycle grid rather than the phases this keyframe
+  // happens to use, since reading the offsets would put the sampler back
+  // inside the model it is meant to escape. The cost is stated rather than
+  // hidden: a dip narrower than a tenth of a cycle can fall between samples.
+  // An eased pulse is flat around its extreme, so the grid finds today's, and
+  // it would find one moved off 50% — which the previous five-phase grid,
+  // clustered around this keyframe's own minimum, would not have.
+  //
+  // One direction, not three: the pulse dims whatever the fill is, so sweeping
+  // it per direction would re-measure the same multiplier. A direction that
+  // strips the fill is caught by the resting floor above, in the direction
+  // that strips it.
+  //
+  // The freeze is verified rather than trusted. If the paused state or the
+  // delay silently failed to take, every photograph would land on the RESTING
+  // pixel, clear the floor, and report that the dimmest phase had been
+  // measured when nothing was. That is a vacuous pass — the failure this
+  // scenario exists to make impossible — so the computed values are read back
+  // after being set, which checks the instrument rather than the outcome.
+  await page.emulateMedia({ reducedMotion: "no-preference" });
+  await skelPaint();
+  const skelPhases = [];
+  for (const phase of [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]) {
+    const froze = await page.evaluate((p) => {
+      let name = "none", frozen = true;
+      for (const b of document.querySelectorAll(".ev-skel-bar")) {
+        const before = getComputedStyle(b);
+        name = before.animationName;
+        const secs = parseFloat(before.animationDuration) || 0;
+        b.style.animationPlayState = "paused";
+        b.style.animationDelay = `${-p * secs}s`;
+        const after = getComputedStyle(b);
+        if (after.animationPlayState !== "paused") frozen = false;
+        if (Math.abs(parseFloat(after.animationDelay) + p * secs) > 1e-6) frozen = false;
+      }
+      return { name, frozen };
+    }, phase);
+    skelPhases.push({ phase, ...froze, ...(skelWorst(await skelShot()) || {}) });
+  }
+  await page.emulateMedia({ reducedMotion: null });
+  await page.evaluate(() => { const r = document.querySelector("#ev-rows"); if (r) clear(r); });
+
+  const skelShots = Object.entries(skelRest);
+  const skelEnough = (s) => s && s.n >= 30;
+  const skelRestWorst = skelShots.every(([, s]) => skelEnough(s))
+    ? skelShots.reduce((w, [dir, s]) => (!w || s.ratio < w.ratio ? { dir, ...s } : w), null)
+    : null;
+  const skelPulseWorst = skelPhases.every(skelEnough)
+    ? skelPhases.reduce((w, s) => (!w || s.ratio < w.ratio ? s : w), null)
+    : null;
+  const skelR = (s) => s && +s.ratio.toFixed(3);
+  const skelDetail = () => JSON.stringify({
+    bars: skelBars,
+    rest: Object.fromEntries(skelShots.map(([d, s]) => [d, skelR(s)])),
+    pulse: skelPhases.map((p) => ({ at: p.phase, r: skelR(p), frozen: p.frozen, anim: p.name })),
+    worstRest: skelRestWorst && { dir: skelRestWorst.dir, ratio: skelR(skelRestWorst) },
+    worstPulse: skelPulseWorst && { at: skelPulseWorst.phase, ratio: skelR(skelPulseWorst) },
+  });
+
+  // Hoisted out of the two floors below so a broken fixture reads as a broken
+  // fixture. An empty sample list has no worst member, and every floor is
+  // satisfied by nothing at all — the vacuous direction. Each shot must also
+  // carry its own bars, since the list is repainted per direction.
+  (skelBars >= 30 && skelRestWorst && skelPulseWorst)
+    ? ok("events skeleton: the loading state paints bars this scenario can photograph")
+    : bad("events skeleton: the loading state paints bars this scenario can photograph", skelDetail());
+
+  // A floor placed BETWEEN the two measured states rather than at either:
+  // --surface-3 rendered 1.09 and the neutral mix renders 1.64, so 1.35 is
+  // what makes this bind. Reverting rings, and so does reaching for any
+  // weaker token on the ramp (--line-soft 1.17, --line 1.28). It tolerates an
+  // ordinary retune of the mix's two inputs — 80/20 is 1.52, 90/10 is 1.40 —
+  // and, like 17e's floor, it is NOT a general washout detector: a deliberate
+  // "make it subtler" edit has room to reach roughly 91% --line first — the
+  // PULSE floor below is what binds there, one point before this one. It has
+  // no opinion about hue either; --skel-warm measures 1.68 and would sail
+  // through, which is deliberate and explained at the token.
+  //
+  // Three directions, not four axes: [data-accent] is NOT swept, so an
+  // accent-scoped rule on these bars would go unphotographed. Said plainly
+  // because the directions ARE swept and a reader could assume the rest.
+  (skelRestWorst && skelRestWorst.ratio >= 1.35)
+    ? ok("events skeleton: every bar stays visible at rest, in every direction")
+    : bad("events skeleton: every bar stays visible at rest, in every direction", skelDetail());
+  // The pulse's own floor, separate because it fails to a different edit —
+  // deepening the dip rather than weakening the fill. 1.15 sits between the
+  // old RESTING value (1.09) and this bar's dip (1.24), so the claim that the
+  // animation no longer carries the bar's visibility is held by a measurement
+  // rather than by the comment making it. Deepening 0.45 -> 0.12 photographs
+  // at 1.06, below where this whole change started.
+  //
+  // A removed pulse is a legitimate pass, not a hole: with no animation the
+  // resting floor above already describes every frame there is. What is NOT
+  // allowed is an animation that exists while the freeze did not take.
+  (skelPulseWorst && skelPhases.every((p) => p.name === "none" || p.frozen) &&
+    skelPulseWorst.ratio >= 1.15)
+    ? ok("events skeleton: the pulse's dimmest phase stays above where the bar started")
+    : bad("events skeleton: the pulse's dimmest phase stays above where the bar started", skelDetail());
+
   // ── Scenario 18 — advisory severity split on the archive fixture (#1365) ──
   // The archive-elision record must render in the INFO register (muted line,
   // no ⚠ icon, no amber, no alert classes) while a real coverage-gap warning


### PR DESCRIPTION
Fixes #1397.

## The defect

`.ev-skel-bar` filled with `--surface-3`. Measured off rendered pixels against the page:

| | at rest | pulse floor |
|---|---|---|
| `.ev-skel-bar`, was `--surface-3` | **1.089** | 1.041 |
| the `--line-soft` hairline separating its rows | 1.168 | — |
| this change | **1.643** | 1.244 |

The placeholder was fainter than the furniture drawn around it, so a loading Events list rendered as an empty list with dividers — the "blank list" that the comment introducing this feature says must never be the busy state. The pulse made it worse rather than better, and it is gated behind `prefers-reduced-motion`, so with motion reduced the bar sat statically at 1.09 with nothing moving to suggest it was there.

The pulse is left alone. Its dimmest point now clears the old *resting* value, so the animation no longer carries the bar's visibility.

## The value

```css
--skel-neutral: color-mix(in srgb, var(--line) 70%, var(--ink-4));
```

A mix across the two ends of the ramp the bar lives between, not a new literal, so it tracks a retune of either. No single token lands in the band (`--surface-3` 1.09, `--line-soft` 1.17, `--line` 1.28, `--ink-4` 3.31), so a mix is forced, and `--ink-4` is the ramp's only neutral darker anchor.

## The guard measures pixels, and that is the substance

Two earlier drafts asserted a **declared colour**, and review defeated each with one declaration that re-broke the rendering while the assertion sat unchanged at 1.64. The second settled the design:

```css
.ev-loading { opacity: .5 }   /* renders 1.267. Probe still reported 1.643. */
```

`opacity` does not inherit — it composites the group — so the bar's own computed opacity stays `1`. Chasing that with an ancestor walk would have left `filter`, a covering `::after`, and an image over the fill. A pixel has no such list.

So the scenario takes screenshots and reads them back through the browser's own PNG decoder, sampling each bar's centre and a ground point in its row's padding. Three assertions:

1. **preconditions** — enough bars were photographed for the floors below to mean anything (an empty sample list satisfies every floor)
2. **at rest**, every bar, all three directions — floor **1.35**
3. **the pulse floor** — floor **1.15**

Every bar, because a rule can repaint only *some*: the nth-child rule reaches even rows, and the five `.ev-skel-*` width classes sit on the **same element** (`class: "ev-skel-bar ev-skel-" + c`), so they repaint the bar without naming it. All three directions, because stripping fills is `paper`'s idiom and five existing rules do it.

The pulse is **sampled, not modelled**: the animation is frozen at a tenth-of-a-cycle grid with a negative delay and photographed, so whatever property it animates is in the picture. An earlier draft read the keyframes' `opacity` and was blind to a pulse dimming by other means. The freeze is **verified by reading the computed values back** — without that, a freeze that failed to take would photograph the resting pixel ten times and report the dimmest phase as measured when nothing was.

## Mutation table

Each case edits the source stylesheet and rebuilds; assets are `//go:embed`ed, so a DOM override would not be the real path. The probe's body is sliced verbatim out of `console_e2e.mjs`.

| mutation | at rest | pulse |
|---|---|---|
| the original bug, literal: `--surface-3` | **FAIL** 1.089 | **FAIL** 1.041 |
| repaint half the bars (`nth-child(2n)`) | **FAIL** 1.089 | **FAIL** |
| repaint via a co-class (`.ev-skel-cols`) | **FAIL** 1.089 | **FAIL** |
| redefine `--skel-neutral` at `:root` | **FAIL** 1.089 | **FAIL** |
| `[data-dir="paper"]` strips the fill | **FAIL** paper 1.000 | pass |
| **ancestor** `opacity` on `.ev-loading` | **FAIL** 1.279 | **FAIL** |
| `filter: opacity(.5)` on the ancestor | **FAIL** 1.267 | **FAIL** |
| a covering `::after` | **FAIL** 1.000 | **FAIL** |
| `background-image` over the fill | **FAIL** 1.000 | **FAIL** |
| static `opacity: .6` on the bar | **FAIL** 1.336 | pass¹ |
| deepen the pulse to `0.12` | pass | **FAIL** 1.059 |
| move the keyframe minimum off 50%, to 60% | pass | **FAIL** 1.059 |
| break the freeze (`animation-play-state: running !important`) | pass | **FAIL** on liveness |
| pulse animates `background-color`, not `opacity` | pass | **FAIL** 1.089 |
| retune the mix to 90/10 — *tolerance control* | pass 1.395 | pass 1.161 |
| wash it out to 97/3 | **FAIL** 1.309 | **FAIL** |
| restore — *clean control* | pass 1.643 | pass 1.244 |

¹ Correct, not a miss: while the animation runs, the keyframes' `opacity` overrides the static declaration, so only the resting read sees it — and it does.

The broken-freeze case is why liveness is checked on the *instrument* rather than on the output: with the animation genuinely running, the ten photographs still varied, so a "do the phases differ?" check would have passed it.

The 1.35 floor sits between the two measured states. It tolerates an ordinary retune (80/20 is 1.52, 90/10 is 1.39) and is **not** a general washout detector — a deliberate "make it subtler" edit has room to reach roughly 91% `--line`, where the pulse floor binds first. Both comments say so.

## What was removed after review

An earlier revision added a Go guard banning the brand palette from `.ev-skel-bar` rules. It is gone:

- **It leaked three ways** — a co-class rule, a repointed token, and `--accent-b`, the file's own "brand violet".
- **A test was the wrong artifact.** #1385 recorded a *decline*, not a ratified rule, and its stronger reason — a strict reading of "pink never lands on a surface that carries a row" — is one the `--skel-warm` comment argues against for its own bars, which also sit in row-carrying panels. The decline is honoured, the reasoning is written at the token, and nothing enforces it: any hue clearing the floor passes.

## Method

Every figure is read off rendered pixels. The first probe scraped `getComputedStyle`, which returns colours in their **authored** space: `oklch(0.972 0.006 320)` parsed as a blue channel of 320 and gave a confident **6.125:1** for a bar that measures 1.089. Two claims were corrected the same way:

- **The issue as filed was wrong twice** — annotated there. The ground is plain white (`.events` declares no background and every ancestor up to `<body>` is transparent, in all three directions), and 1.04 was the pulse trough, not the resting value.
- **A draft of the token comment credited `.skel-line` with a "trough 1.25".** It has no opacity animation — it is a gradient sweeping a transparent mid-stop, so it passes through roughly 1.0:1 once per cycle, which the file already said thirty lines above. 1.25 was *this* bar's pulse arithmetic applied to an element that does not have one. Corrected, and the correction is recorded in the comment.

## Limits, stated rather than left to be assumed

- `[data-accent]` is not swept, so an accent-scoped rule on these bars would go unphotographed.
- The pulse is sampled in one direction; a direction that strips the fill is caught by the resting floor, in the direction that strips it.
- A dip narrower than a tenth of a cycle can fall between phase samples.
- `renderEventsLoading` is called directly, so this proves the skeleton is visible, not that the fetch path still paints one.

## Verification

- `go test ./internal/console/ -count=1`: green
- `console-e2e`: **250/250** (247 before, plus the three above)
