### PR TITLE
console: hand extension views the console's own date field

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -805,6 +805,35 @@ it withholds the whole surface under a profile). Each data route reads the index
 of the server currently selected in the switcher, with the operator's profile
 applied.
 
+The module must export `render(mount, ctx)`. `ctx` is built in one place
+(`extContract` in `app.js`) and is the same for both extension surfaces:
+
+| key | what it is |
+|---|---|
+| `apiBase` | the extension's own data-route prefix (`/api/ext/<id>/`) |
+| `api` | the console's authenticated fetch — bearer token and `X-Bintrail-Server` already applied. An HTTP error throws an `Error` carrying `.status`; a malformed body throws one **without** it, an aborted request rejects with `AbortError`, and a 204 resolves to `null`. Branch on `.status` defensively. |
+| `ui.dateField(label, name, size, placeholder, required)` | the console's own date field: a text input plus the calendar/clock popover, returning the same `.field` wrapper the console's forms use |
+
+`ui` exists so an extension does not reimplement a widget the console already
+has — two copies drift, and the operator ends up looking at two different date
+pickers in one console. It is also the boundary of what may be relied on:
+`app.js` is a classic script, so an extension running same-origin *could* reach
+any of its functions as a window global, but only what arrives through `ctx` is
+a promise. Everything else may be renamed without notice, and because the two
+sides are built in different repos and never compile together, such a rename
+would surface as a widget that quietly stopped appearing rather than as an
+error. An extension that wants to run against older console builds should
+feature-detect (`typeof ctx.ui?.dateField === "function"`) and degrade. Two
+things that detection does not give you. It establishes **presence, not
+shape** — a build whose builder took different arguments would still answer
+`"function"` — so treat the signature above as the contract and expect it to
+be versioned with the console, not sniffed. And `render()` is called but **not
+awaited**: a synchronous throw is caught and rendered as an error in the
+mount, while an `async render()` that rejects escapes as an unhandled
+rejection and leaves the mount blank. An extension doing async work in
+`render` should catch its own failures and render them, rather than relying on
+the console to.
+
 The standalone `bintrail-console` binary ships **no extension views**: no nav
 item appears, `/api/capabilities` advertises none, and `/ext/*` and
 `/api/ext/*` are absent from the router entirely.

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -4812,6 +4812,29 @@ function syncExtSettingsNav() {
   }
 }
 
+// extContract is what an extension module receives. Both extension surfaces —
+// the settings panel and the full view — build it here, so the two cannot
+// drift into different contracts for the same kind of consumer.
+//
+// `apiBase` and `api` are the data plane. `ui` is the small set of console
+// widgets an extension should NOT be reimplementing: a second copy drifts, and
+// the operator ends up looking at two different date pickers in one console.
+//
+// Handed over explicitly rather than left to be discovered. app.js is a classic
+// script, so its function declarations are reachable as window globals and an
+// extension COULD simply call one — which is exactly the coupling to avoid.
+// The two sides are built in different repos on different release cadences and
+// never compile together, so a rename here would break the extension with no
+// error at all: the widget would just stop appearing. What is in `ui` is a
+// promise the console keeps; what is not is an internal that may move.
+//
+// dateField is fieldDateInput itself rather than a wrapper, so a rename cannot
+// leave the two spellings pointing at different builders.
+function extContract(apiBase) {
+  return { apiBase, api, ui: { dateField: fieldDateInput } };
+}
+
+
 // renderExtensionSettings mounts a settings panel's ES module. Same contract as
 // renderExtensionView, with the panel's own data prefix — the two surfaces are
 // authorized differently server-side (settings:read/write vs extview:read), so
@@ -4831,7 +4854,7 @@ async function renderExtensionSettings(panel) {
       renderError(mount, "This settings panel did not export a render() function.");
       return;
     }
-    mod.render(mount, { apiBase: "/api/ext-settings/" + panel.id + "/", api });
+    mod.render(mount, extContract("/api/ext-settings/" + panel.id + "/"));
   } catch (err) {
     if (gen !== serverGen) return;
     renderError(mount, err);
@@ -4852,7 +4875,7 @@ async function renderExtensionView(view) {
       renderError(mount, "This extension view did not export a render() function.");
       return;
     }
-    mod.render(mount, { apiBase: "/api/ext/" + view.id + "/", api });
+    mod.render(mount, extContract("/api/ext/" + view.id + "/"));
   } catch (err) {
     if (gen !== serverGen) return;
     renderError(mount, err);

--- a/internal/console/assets_extview_test.go
+++ b/internal/console/assets_extview_test.go
@@ -1,0 +1,176 @@
+package console
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// extRenderCall returns the text of app.js's `mod.render(...)` call — the
+// contract handed to an extension view — and the file line it starts on.
+//
+// The CALL is extracted rather than the file scanned, and that is load-bearing
+// rather than tidy. The comment directly above it explains the contract and
+// therefore names every token this file greps for; a whole-file match would
+// pass with the call gutted and the needles left sitting in the prose. Whole
+// line comments inside the extracted region are blanked as a belt, since the
+// region will grow.
+func extContractBody(t *testing.T) (string, int) {
+	t.Helper()
+	js := readAsset(t, "app.js")
+	i := strings.Index(js, "function extContract(")
+	if i < 0 {
+		t.Fatal("app.js: no extContract( — the extension contract is gone or was renamed. Both " +
+			"extension surfaces build their argument here; if it moved, this guard checks nothing.")
+	}
+	open := strings.IndexByte(js[i:], '{')
+	if open < 0 {
+		t.Fatalf("app.js:%d: extContract has no body", lineOf(js, i))
+	}
+	depth, end := 0, -1
+	for k := i + open; k < len(js); k++ {
+		switch js[k] {
+		case '{':
+			depth++
+		case '}':
+			if depth--; depth == 0 {
+				end = k
+			}
+		}
+		if end >= 0 {
+			break
+		}
+	}
+	if end < 0 {
+		t.Fatalf("app.js:%d: unbalanced braces in extContract", lineOf(js, i))
+	}
+	// stripJSCommentLines is line-oriented, so a TRAILING comment inside the
+	// body survives it — and a needle parked in one would satisfy every check
+	// below over a gutted contract. The sibling helper was hardened against the
+	// same shape; this region is a small object literal with no regex literals
+	// in it, so cutting at `//` is safe here in a way it is not file-wide.
+	body := stripJSCommentLines(js[i+open : end+1])
+	var out []string
+	for _, ln := range strings.Split(body, "\n") {
+		if c := strings.Index(ln, "//"); c >= 0 {
+			ln = ln[:c]
+		}
+		out = append(out, ln)
+	}
+	return strings.Join(out, "\n"), lineOf(js, i)
+}
+
+// bothSurfacesUseTheContract pins that neither extension loader hand-rolls its
+// own argument. A surface that stopped calling extContract would keep working
+// and silently lose whatever the contract later grows.
+func bothSurfacesUseTheContract(t *testing.T) {
+	t.Helper()
+	js := stripJSCommentLines(readAsset(t, "app.js"))
+	calls := regexp.MustCompile(`mod\.render\(`).FindAllStringIndex(js, -1)
+	if len(calls) != 2 {
+		t.Fatalf("app.js: expected 2 mod.render( call sites (settings panel + view), found %d. "+
+			"A new extension surface must build its argument with extContract too — and then this "+
+			"number needs bumping, which is the point of pinning it: nothing else in the repo "+
+			"notices a surface being added or removed. Two shapes are NOT counted and are stated "+
+			"rather than guarded: an aliased render reference (`const r = mod.render`), and a "+
+			"module binding named anything but `mod` — this matches the literal `mod.render(`, so "+
+			"`module.render(...)` is invisible to it rather than merely uncounted.", len(calls))
+	}
+	for _, c := range calls {
+		// The call's own parens, not the rest of the line. Two reasons, both
+		// demonstrated: a trailing `// was extContract(...)` satisfied a
+		// line-wide search over a fully hand-rolled argument, and a correct
+		// call wrapped across lines was accused of being one.
+		depth, end := 0, -1
+		for k := c[1] - 1; k < len(js); k++ {
+			switch js[k] {
+			case '(':
+				depth++
+			case ')':
+				if depth--; depth == 0 {
+					end = k
+				}
+			}
+			if end >= 0 {
+				break
+			}
+		}
+		if end < 0 {
+			t.Fatalf("app.js:%d: unbalanced parens in this mod.render call", lineOf(js, c[0]))
+		}
+		if !strings.Contains(js[c[0]:end+1], "extContract(") {
+			t.Errorf("app.js:%d: this extension surface hand-rolls its render argument instead of "+
+				"calling extContract. The two surfaces would then drift, and only the extension "+
+				"built against the richer one would notice. Note this catches a REPLACED argument, "+
+				"not a spread that then strips keys; console-e2e's ext-view and ext-settings legs "+
+				"cover the shape an extension actually receives, on both surfaces.", lineOf(js, c[0]))
+		}
+	}
+}
+
+// An extension view is built in a different repo on its own release cadence.
+// Whatever the console hands it is a promise; whatever it does not is an
+// internal. app.js is a classic script, so an extension COULD reach a widget
+// as a window global — and nothing would catch a rename, because the two sides
+// never compile together. So the widgets that ARE shared travel through the
+// contract, and this pins them there.
+func TestExtensionViewContractCarriesTheSharedWidgets(t *testing.T) {
+	bothSurfacesUseTheContract(t)
+	call, line := extContractBody(t)
+
+	for _, want := range []struct{ key, why string }{
+		{"apiBase", "the data plane's base path"},
+		{"api", "the console's authed fetch"},
+		{"ui", "the shared-widget namespace"},
+	} {
+		if !regexp.MustCompile(`\b` + want.key + `\b`).MatchString(call) {
+			t.Errorf("app.js:%d: the extension-view contract no longer passes %q (%s). Removing a key "+
+				"from this call breaks an extension built against it, and the break is a MISSING "+
+				"widget rather than an error — nothing throws.", line, want.key, want.why)
+		}
+	}
+
+	// Bound to the builder itself, not to a wrapper: a wrapper is a second
+	// spelling that a rename can leave pointing somewhere else, which is the
+	// whole failure this guard exists for.
+	if !regexp.MustCompile(`dateField\s*:\s*fieldDateInput\b`).MatchString(call) {
+		t.Errorf("app.js:%d: ui.dateField is not bound to fieldDateInput. The extension view's date "+
+			"fields come from here; bind the builder directly so a rename cannot leave the two "+
+			"spellings pointing at different widgets.", line)
+	}
+}
+
+// The shared widget has to stay the console's OWN widget. Handing an extension
+// a builder the console itself stopped using would let the two drift while
+// every check above stays green — the operator would see one date picker in
+// Restore and a different one in the extension, which is the outcome sharing
+// it was meant to prevent.
+func TestSharedDateFieldIsTheOneTheConsoleUsesItself(t *testing.T) {
+	js := stripJSCommentLines(readAsset(t, "app.js"))
+
+	if !strings.Contains(js, "function fieldDateInput(") {
+		t.Fatal("app.js: fieldDateInput is not declared — the extension contract points at nothing")
+	}
+	// Not preceded by `.`, so `window.fieldDateInput(` or any other qualified
+	// reference is not miscounted as one of the console's own uses.
+	uses := regexp.MustCompile(`(^|[^.\w])fieldDateInput\(`).FindAllStringIndex(js, -1)
+	own := 0
+	for _, u := range uses {
+		if !strings.HasSuffix(js[:u[1]-len("fieldDateInput(")], "function ") {
+			own++
+		}
+	}
+	// Pinned exactly, not floored. A floor of two tolerated migrating four of
+	// the six away — a third of the widget's uses gone with the guard silent —
+	// and the drift this exists to catch ("one date picker in Restore, another
+	// in the extension") starts at the FIRST one, not the fifth. An exact pin
+	// makes a deliberate change a one-line acknowledged edit instead of
+	// something that slides past.
+	const wantOwn = 6
+	if own != wantOwn {
+		t.Errorf("app.js: fieldDateInput has %d call site(s) in the console's own views, expected %d. "+
+			"It is the widget handed to extension views through ui.dateField; if the console stops "+
+			"using it the two surfaces drift and only the extension notices. If the change was "+
+			"deliberate, update this number — that edit is the acknowledgement.", own, wantOwn)
+	}
+}

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -715,7 +715,23 @@ try {
   const extv = await page.evaluate(async () => {
     const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
     const modURL = (marker) => URL.createObjectURL(new Blob(
-      [`export function render(mount, ctx){ window.${marker} = !!(mount && ctx && typeof ctx.api === "function" && ctx.apiBase); mount.append(document.createTextNode("ext-content")); }`],
+      // The stub exercises the CONTRACT, not just its key names: it calls
+      // ctx.ui.dateField and inspects what comes back. A presence check would
+      // have passed with the binding moved to a sibling key, or with the
+      // builder's parameters reordered — both of which hand an extension a
+      // broken widget and no error. Only a real call can tell.
+      [`export function render(mount, ctx){
+         const f = ctx && ctx.ui && ctx.ui.dateField;
+         const node = typeof f === "function" ? f("Since (UTC)", "since", "md", "YYYY-MM-DD HH:MM:SS") : null;
+         window.${marker} = !!(mount && ctx && typeof ctx.api === "function" && ctx.apiBase);
+         window.${marker}_ui = !!(node
+           && node.classList.contains("field")
+           && node.querySelector(".dt-trigger")
+           && node.querySelector("input") && node.querySelector("input").name === "since"
+           && node.querySelector(".field-label")
+           && node.querySelector(".field-label").textContent.includes("Since (UTC)"));
+         mount.append(document.createTextNode("ext-content"));
+       }`],
       { type: "text/javascript" },
     ));
 
@@ -753,6 +769,7 @@ try {
     capsCache = { ...capsCache, extension_views: [{ id: "demo", label: "Demo View", script }] };
     extViews = capsCache.extension_views;
     window.__ext1 = undefined;
+    window.__ext1_ui = undefined;
     syncExtNav();
     const navItem = document.querySelector('.nav-item[data-route="ext-demo"]');
     const navText = navItem ? navItem.textContent.trim() : null;
@@ -765,7 +782,26 @@ try {
     const mount = document.querySelector(".ext-view-mount");
     const mountedText = mount ? mount.textContent : "";
     const rendered = window.__ext1;
+    const renderedUI = window.__ext1_ui;
     const navActive = navItem ? navItem.classList.contains("active") : false;
+
+    // 2b) The OTHER extension surface. Settings panels take the same contract
+    //     from the same builder, and until now nothing here drove them at all
+    //     — which mattered because the settings surface is the one that was
+    //     forgotten when the shared builder was introduced: the view's call
+    //     was widened and the panel's was left hand-rolled. A guard comment
+    //     claiming "the browser tier covers the shape" was true of the view
+    //     and false of this, so the leg exists rather than the caveat.
+    //
+    //     Driven through renderExtensionSettings directly: the panel's nav
+    //     lives under Settings and its routing is exercised elsewhere; what
+    //     is unproven is the contract it hands its module.
+    window.__extset = undefined;
+    window.__extset_ui = undefined;
+    await renderExtensionSettings({ id: "demoset", label: "Demo Panel", script: modURL("__extset") });
+    await sleep(200);
+    const setRendered = window.__extset;
+    const setRenderedUI = window.__extset_ui;
 
     // 3) Server switch → the nav item is dropped and the now-unknown ext route
     //    redirects to overview (unmount across a switch).
@@ -790,7 +826,7 @@ try {
     // for the final no-errors assertion.
     await gateCapabilities();
     navigate("overview");
-    return { gatedFromCaps, gatedNav, navText, known, onRoute, mounted: !!mount, mountedText, rendered, navActive, navGone, redirected, staleAborted };
+    return { gatedFromCaps, gatedNav, navText, known, onRoute, mounted: !!mount, mountedText, rendered, renderedUI, setRendered, setRenderedUI, navActive, navGone, redirected, staleAborted };
   });
   extv.gatedFromCaps ? ok("ext-view: gateCapabilities populates extViews from /api/capabilities.extension_views") : bad("ext-view: gateCapabilities populates extViews from /api/capabilities.extension_views", "extViews not set from the parsed caps response");
   extv.gatedNav ? ok("ext-view: gateCapabilities injects the nav item from the fetched caps") : bad("ext-view: gateCapabilities injects the nav item from the fetched caps", "no ext-gated nav item after gateCapabilities");
@@ -798,7 +834,16 @@ try {
   extv.known ? ok("ext-view: isKnownRoute accepts a live ext-<id> route") : bad("ext-view: isKnownRoute accepts a live ext-<id> route", "ext-demo not known");
   extv.onRoute ? ok("ext-view: navigate routes to /ext-<id>") : bad("ext-view: navigate routes to /ext-<id>", "wrong route");
   extv.mounted ? ok("ext-view: a mount node is created") : bad("ext-view: a mount node is created", "no .ext-view-mount");
-  extv.rendered ? ok("ext-view: the module render() runs with {apiBase, api}") : bad("ext-view: the module render() runs with {apiBase, api}", `rendered=${extv.rendered}`);
+  extv.rendered ? ok("ext-view: the module render() runs with {apiBase, api, ui}") : bad("ext-view: the module render() runs with {apiBase, api, ui}", `rendered=${extv.rendered}`);
+  // The widget half, asserted by USING it. The Go guards pin the binding's
+  // spelling in app.js; only this can say the extension receives something
+  // that builds the console's own date field — right wrapper, right label,
+  // right input name, calendar attached.
+  extv.renderedUI ? ok("ext-view: ctx.ui.dateField builds the console's own date field") : bad("ext-view: ctx.ui.dateField builds the console's own date field", `renderedUI=${extv.renderedUI}`);
+  // Same two assertions for the settings surface, because "both surfaces get
+  // the same contract" is the claim and one of them was already forgotten once.
+  extv.setRendered ? ok("ext-settings: the panel module render() runs with {apiBase, api, ui}") : bad("ext-settings: the panel module render() runs with {apiBase, api, ui}", `setRendered=${extv.setRendered}`);
+  extv.setRenderedUI ? ok("ext-settings: ctx.ui.dateField builds the console's own date field") : bad("ext-settings: ctx.ui.dateField builds the console's own date field", `setRenderedUI=${extv.setRenderedUI}`);
   /ext-content/.test(extv.mountedText) ? ok("ext-view: module content lands in the mount") : bad("ext-view: module content lands in the mount", `mountedText=${extv.mountedText}`);
   extv.navActive ? ok("ext-view: the nav item is marked active on its route") : bad("ext-view: the nav item is marked active on its route", "not .active");
   extv.navGone ? ok("ext-view: server switch removes the ext nav item (idempotent)") : bad("ext-view: server switch removes the ext nav item (idempotent)", "stale nav item remained");


### PR DESCRIPTION
An extension view could not offer a date picker, so a panel with Since/Until fields showed plain text inputs while Restore two clicks away showed a calendar.

## Why the extension could not just call it

It renders same-origin in the console's live document, and `app.js` is a classic script — so its function declarations *are* reachable as window globals and an extension could simply call `fieldDateInput`. That is precisely the coupling to avoid. The two sides are built in different repos on different release cadences and never compile together, so a rename here would break the extension **with no error**: the widget would stop appearing and nothing would say so.

So the shared widgets travel through the render contract instead. What is in `ctx` is a promise the console keeps; what is not is an internal that may move.

```js
function extContract(apiBase) {
  return { apiBase, api, ui: { dateField: fieldDateInput } };
}
```

## Both surfaces, not one

There are **two** extension surfaces — the settings panel (`/api/ext-settings/<id>/`) and the full view (`/api/ext/<id>/`) — and each hand-rolled its own `mod.render` argument. The first version of this change widened the view's call and left the panel's alone; the guard caught it, not review and not reading. They now share one builder, and a check pins that neither call site hand-rolls its argument again.

## The guard that matters over time

`ui.dateField` is bound to `fieldDateInput` **itself**, not a wrapper, so a rename cannot leave two spellings pointing at different builders — and the guard asserts that binding rather than the key's presence.

The second guard is the less obvious one: the shared builder must stay a widget **the console uses itself**. Handing an extension something the console stopped dogfooding would let the two drift while every other check stayed green — one date picker in Restore, a different one in the extension, which is the exact outcome sharing it was meant to prevent.

| mutation | result |
|---|---|
| drop `ui` from the contract | **FAIL** |
| rename the key only (`dateField` → `datePicker`) | **FAIL** |
| bind a wrapper instead of the builder | **FAIL** |
| one surface hand-rolls its render argument | **FAIL** |
| console stops using the widget in its own views | **FAIL** |
| **reword the comment above the contract** — *negative control* | pass |
| unmutated | pass |

The negative control is the point: the comment explains the contract and therefore names every token the guard greps for, so a whole-file match would have passed with the call gutted and the needles left sitting in the prose. The guard extracts the `extContract` body instead.

## Verified in a browser, both directions

Built an embedding console against this branch and against the released core, and drove both headless:

| host build | tabs mounted | `.dt-trigger` per tab | popover | page errors |
|---|---|---|---|---|
| this branch | 3 | 2 | opens, 6px below the trigger | none |
| released core (no `ui`) | 3 | 0 — plain inputs | n/a | none |

The second row is the documented degradation working, not a failure: a module shipped separately from its host can be loaded by a build that predates the namespace, so `docs/console.md` tells consumers to feature-detect (`typeof ctx.ui?.dateField === "function"`) and degrade.

One thing checked and found *not* to be a problem: the popover mounts on `document.body` with `position: fixed`, so it escapes the extension view's subtree and is unaffected by the `.view-enter` transform that has captured `position: fixed` inside extension views before. The scroll container is `main.main`, and `window.scrollY` is always 0 — the `+ window.scrollX/scrollY` in the positioning maths is dead arithmetic, measured, not a latent bug. Left alone rather than tidied in this PR.

## Verification

- `go test ./internal/console/ -count=1`: green
- `console-e2e`: **250/250**
