### PR TITLE
query: skip the archives when every named PK already has its latest N live

### DIFF
--- a/internal/cli/recover.go
+++ b/internal/cli/recover.go
@@ -338,7 +338,15 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	rows, _, err := query.FetchMerged(cmd.Context(), db, engine, query.FetchMergedOptions{
+	// FetchMergedFull, not FetchMerged: the wrapper discards archivesElided,
+	// and this surface has to be able to SAY the registered archives went
+	// unread. Before #1403 that was near-theoretical here — the newest-first
+	// short-circuit needs a filled page, which a reversal scoped to one row
+	// never produces — but the per-PK proof makes it the NORMAL outcome of
+	// `recover --pk X --limit-per-pk N`. A reversal that quietly skipped
+	// registered archives, with the only trace at slog.Debug, is exactly the
+	// audit hole the flag was added to close (#1353).
+	rows, _, _, _, archivesElided, err := query.FetchMergedFull(cmd.Context(), db, engine, query.FetchMergedOptions{
 		Opts:           opts,
 		DBName:         dbName,
 		NoArchive:      rNoArchive || rProfile != "",
@@ -367,6 +375,13 @@ func runRecover(cmd *cobra.Command, args []string) error {
 	// generation, so the warning fires even when generation later refuses —
 	// then restore ascending order: GenerateSQLFromRows expects ASC input and
 	// reverses it internally to undo most-recent first.
+	// Said at INFO, not Debug: this is the audit record, not a planner detail.
+	// It reports what scope was read, which is the one thing an operator
+	// reviewing a reversal script cannot reconstruct from the script itself.
+	if archivesElided {
+		slog.Info("registered archives were not read: nothing they hold could have survived this " +
+			"request's filters. Widening the time range, or clearing --limit-per-pk, reads them")
+	}
 	truncated := rLimit > 0 && len(rows) >= rLimit
 	if truncated {
 		slog.Warn("matched events truncated at --limit; only the most recent events of the window are reversed",

--- a/internal/console/coverage_warnings.go
+++ b/internal/console/coverage_warnings.go
@@ -66,9 +66,18 @@ func appendDivergenceWarning(w []string, diverged int) []string {
 
 // archiveElisionNote is the response-level record of the newest-first
 // short-circuit (#1353): registered archives were deliberately not read
-// because they provably could not change this page — every archived hour sits
-// below the live rotation floor, and the live index filled the requested page
-// with events newer than that floor. Unlike archiveExclusion's notices this
+// because they provably could not change this page. There are now TWO proofs
+// that reach here — the live index filled a newest-first page from a
+// contiguous live range, or every named PK already held its latest N live
+// (#1403) — and the flag does not say which.
+//
+// That is why the wording below states the FACT and not the reason, which it
+// used to. Inferring the reason from the request is wrong: the newest-first
+// proof is tried first and can fire on a request that also carries a per-row
+// limit. The old text asserted the window reason ("every archived event is
+// older than this page reaches") and offered a remedy that is inert under the
+// per-PK proof, which never reads the limit at all. An audit note naming the
+// wrong reason is worse than one naming none. Unlike archiveExclusion's notices this
 // describes a CORRECTNESS-PRESERVING optimization, not a scope reduction, and
 // since #1365 that distinction is carried on the wire: this is a NOTE (info),
 // never a warning — a benign audit fact rendered in one alarm register with
@@ -80,8 +89,8 @@ func appendDivergenceWarning(w []string, diverged int) []string {
 // read this string too.
 func archiveElisionNote() string {
 	return "This page was answered from the live index; the registered archives were not read. " +
-		"Every archived event is older than this page reaches, so nothing is missing here. " +
-		"Paging further back, or filtering to a time range that reaches archived hours, searches the archives too."
+		"Nothing they hold could have survived this request's filters, so nothing is missing here. " +
+		"Widening the time range, or clearing a per-row limit, reads them."
 }
 
 // recoverArchiveElisionNote is archiveElisionNote in the recover surface's own
@@ -91,8 +100,8 @@ func archiveElisionNote() string {
 // both strings are pinned verbatim by TestArchiveElisionNote.
 func recoverArchiveElisionNote() string {
 	return "This reversal was built from the live index; the registered archives were not read. " +
-		"Every archived event is older than the window this request reaches, so nothing is missing here. " +
-		"A time range that reaches archived hours, or a higher limit, searches the archives too."
+		"Nothing they hold could have survived this request's filters, so nothing is missing here. " +
+		"Widening the time range, or clearing the per-row limit, reads them."
 }
 
 // archiveElisionNotes returns the response Notes list for a fetch that

--- a/internal/console/coverage_warnings_test.go
+++ b/internal/console/coverage_warnings_test.go
@@ -74,18 +74,24 @@ func TestAppendDivergenceWarning(t *testing.T) {
 // carrying the audit fact (archives skipped, and why), and never worded or
 // shaped like an incident. Both surface strings are pinned VERBATIM (PR #1367
 // review): fragment checks alone let a rewording that keeps the fragments —
-// e.g. one dropping the "older than this page reaches" justification — ship
-// green. Changing the copy is fine; changing it without looking here is not.
+// e.g. one dropping the justification — ship green. Changing the copy is fine;
+// changing it without looking here is not.
+//
+// The copy stopped naming WHY the archives were skipped when #1403 added a
+// second short-circuit: the flag reaching this function is a bool, and the two
+// proofs have different remedies (a wider window vs clearing the per-row
+// limit). Stating one reason would be wrong half the time, so it states the
+// fact and names both levers.
 func TestArchiveElisionNote(t *testing.T) {
 	if n := archiveElisionNotes(false, archiveElisionNote()); len(n) != 0 {
 		t.Fatalf("no elision must produce no note, got %#v", n)
 	}
 	const wantEvents = "This page was answered from the live index; the registered archives were not read. " +
-		"Every archived event is older than this page reaches, so nothing is missing here. " +
-		"Paging further back, or filtering to a time range that reaches archived hours, searches the archives too."
+		"Nothing they hold could have survived this request's filters, so nothing is missing here. " +
+		"Widening the time range, or clearing a per-row limit, reads them."
 	const wantRecover = "This reversal was built from the live index; the registered archives were not read. " +
-		"Every archived event is older than the window this request reaches, so nothing is missing here. " +
-		"A time range that reaches archived hours, or a higher limit, searches the archives too."
+		"Nothing they hold could have survived this request's filters, so nothing is missing here. " +
+		"Widening the time range, or clearing the per-row limit, reads them."
 	if got := archiveElisionNote(); got != wantEvents {
 		t.Errorf("events elision note drifted from the pinned copy:\ngot:  %s\nwant: %s", got, wantEvents)
 	}

--- a/internal/console/extview.go
+++ b/internal/console/extview.go
@@ -65,6 +65,16 @@ func (s *Server) consoleQueryContext(r *http.Request) (ext.ConsoleQueryContext, 
 // profile (#699/#838) — the same signal the guard now keys on. The field type
 // on ext.ConsoleQueryContext.Fetch is an alias of this signature, so the
 // returned value assigns directly.
+//
+// One thing it does NOT carry: the archive-elision signal. s.fetch goes through
+// query.FetchMerged, which discards archivesElided, so a view that set
+// PKValues/PKValuesIn together with LimitPerPK would have its archives skipped
+// (#1403) with no note reaching the operator — the audit hole the CLI recover
+// path was changed to close in that same PR. No view in dbtrail-ee sets
+// LimitPerPK today, verified by grep, so this is unreachable rather than fixed.
+// A view that starts setting it must move this seam to FetchMergedFull and
+// surface the flag; the closure's signature is the reason that is a change here
+// and not in the view.
 func (s *Server) consoleFetch(b *bundle) func(ctx context.Context, opts query.Options) ([]query.ResultRow, *query.QueryPlan, error) {
 	return func(ctx context.Context, opts query.Options) ([]query.ResultRow, *query.QueryPlan, error) {
 		opts.DenyTables = s.denyTables

--- a/internal/console/extview.go
+++ b/internal/console/extview.go
@@ -67,14 +67,24 @@ func (s *Server) consoleQueryContext(r *http.Request) (ext.ConsoleQueryContext, 
 // returned value assigns directly.
 //
 // One thing it does NOT carry: the archive-elision signal. s.fetch goes through
-// query.FetchMerged, which discards archivesElided, so a view that set
-// PKValues/PKValuesIn together with LimitPerPK would have its archives skipped
-// (#1403) with no note reaching the operator — the audit hole the CLI recover
-// path was changed to close in that same PR. No view in dbtrail-ee sets
-// LimitPerPK today, verified by grep, so this is unreachable rather than fixed.
-// A view that starts setting it must move this seam to FetchMergedFull and
-// surface the flag; the closure's signature is the reason that is a change here
-// and not in the view.
+// query.FetchMerged, which discards archivesElided, so when fetchPage decides
+// the live rows already satisfy a request and skips the registered archives,
+// no note reaches the operator through this seam — the audit hole the CLI
+// recover path closes by using FetchMergedFull instead (#1403).
+//
+// This is REACHABLE, not theoretical, and the reachable shape is the ordinary
+// one rather than the exotic one. A provider that fetches a bounded newest-first
+// page — Limit set, Order DESC — satisfies topNSatisfiedLive as soon as that
+// page fills from live partitions, which is what a "recent activity" listing
+// does by construction. The per-PK shape (PKValues plus LimitPerPK) is the
+// narrower door and no installed provider is known to use it; the top-N door is
+// wide open.
+//
+// Left as a note rather than fixed because the remedy is a signature change on
+// the seam — this closure's return shape is fixed by ext.ConsoleQueryContext,
+// so surfacing the flag means changing the contract every provider compiles
+// against, not editing a view. Adjacent to #1353/#1295, which is where the
+// console's own surfaces solved the same problem.
 func (s *Server) consoleFetch(b *bundle) func(ctx context.Context, opts query.Options) ([]query.ResultRow, *query.QueryPlan, error) {
 	return func(ctx context.Context, opts query.Options) ([]query.ResultRow, *query.QueryPlan, error) {
 		opts.DenyTables = s.denyTables

--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -277,6 +277,106 @@ func topNSatisfiedLive(opts Options, rows []ResultRow, plan *QueryPlan) bool {
 	return !cutoff.Before(plan.MySQLRanges[0].Start)
 }
 
+// perPKSatisfiedLive is topNSatisfiedLive's sibling for a query that asks for
+// the latest N events PER ROW rather than the newest N overall, so the archive
+// sources can be skipped for the same reason: they cannot change the answer.
+//
+// It exists because the page-fullness proof cannot reach the surface that pays
+// most for the archive leg. A reversal scoped to one PK returns a handful of
+// events against recover's default limit of 1000, so `len(rows) < opts.Limit`
+// is true essentially always and topNSatisfiedLive declines — on a window with
+// no lower bound that meant reading every registered archive hour to produce a
+// single statement. Measured on an index with ~1200 archived hours: 27.6s,
+// against 0.3s for the same reversal with the archives skipped.
+//
+// LimitPerPK is a whole-result-set trim applied AFTER the merge
+// (MergeAndTrimReport below), so the proof is that the trim would discard
+// everything the archives could contribute. All four conditions carry weight:
+//
+//   - LimitPerPK > 0. Without the trim the archives are not discarded, they
+//     are the answer's older half.
+//   - The query NAMES its PKs (PKValues or PKValuesIn). This is the condition
+//     with no counterpart in topNSatisfiedLive and the one that makes the rest
+//     sound: with an unscoped filter, a pk_values that appears ONLY in the
+//     archives is a legitimate result row, and skipping the archives would
+//     drop it entirely rather than trim it. A filled top-N page has no such
+//     hole, because everything it omits sorts below the cutoff; here what
+//     would be omitted is a whole row's history.
+//   - Every named PK already holds LimitPerPK rows live, checked BY NAME. A PK
+//     short of its N can still be extended by the archives, and one short PK
+//     is enough to make the whole skip wrong — so this is an ALL, not a
+//     majority. A PK that is simply absent counts as short.
+//   - One contiguous live range, with the oldest kept row inside it. Same
+//     reasoning as the sibling: it is what rules out an archived hour sitting
+//     ABOVE that row on a restored or hand-surgered index, which would make a
+//     live-only answer the wrong N. Worth knowing how much each path proves:
+//     on the unbounded browse path browsePlanFromHours returns nil outright if
+//     an archived content hour sits at or above the oldest live hour, so the
+//     check is verified; on the Plan path (a `until` with no `since`, which is
+//     the shape this was written for) buildPlan infers the range start FROM
+//     the oldest live hour, so the comparison is satisfied by construction and
+//     the real work is done by the per-PK condition. The single-range
+//     requirement still rules out an archived hour interleaved BELOW the live
+//     top, which is the layout rotation can actually produce.
+//
+// Order is deliberately NOT constrained, unlike the sibling's DESC-only rule,
+// and the difference is not an oversight. That rule protects a page CUTOFF;
+// there is no cutoff here. Satisfaction implies each named PK holds exactly N
+// rows and the result contains only named PKs, so the SQL LIMIT dropped
+// nothing and the set is the same either direction. Refusing ASC would cost
+// coverage and buy nothing.
+//
+// The engine has already applied LimitPerPK in SQL (a ROW_NUMBER window), so
+// the rows handed back here are the trim's output for the live half and need
+// no further trimming — which is why the caller returns them whole rather than
+// slicing to Limit as the top-N path does.
+func perPKSatisfiedLive(opts Options, rows []ResultRow, plan *QueryPlan) bool {
+	if opts.LimitPerPK <= 0 {
+		return false
+	}
+	// PKValuesAlt is a SECOND spelling of the same logical key, and the trim
+	// partitions by the stored pk_values — so one row's history can be split
+	// across two partitions and "this PK has its N" stops being well defined.
+	// Refused rather than approximated.
+	if opts.PKValuesAlt != "" {
+		return false
+	}
+	names := opts.PKValuesIn
+	if opts.PKValues != "" {
+		names = []string{opts.PKValues}
+	}
+	if len(names) == 0 {
+		return false
+	}
+	if plan == nil || len(plan.MySQLRanges) != 1 {
+		return false
+	}
+
+	perPK := make(map[string]int, len(names))
+	var oldest time.Time
+	for i := range rows {
+		perPK[rows[i].PKValues]++
+		if oldest.IsZero() || rows[i].EventTimestamp.Before(oldest) {
+			oldest = rows[i].EventTimestamp
+		}
+	}
+	// Walked by NAME, not by counting distinct keys in the result: a named PK
+	// that is simply absent must fail here, and a count comparison would let
+	// an unexpected key stand in for a missing one.
+	for _, pk := range names {
+		// The empty key is LimitPerPK's own carve-out: merge.go buckets every
+		// PKValues=="" row under its own synthetic key, so the trim discards
+		// NOTHING there and this predicate's whole proof evaporates. No caller
+		// pairs an empty name with LimitPerPK today, but internal/shim builds
+		// PKValuesIn{""} deliberately and its sibling paths do set LimitPerPK
+		// — only the two never meeting keeps that safe, and nothing pins it.
+		if pk == "" || perPK[pk] < opts.LimitPerPK {
+			return false
+		}
+	}
+	return !oldest.Before(plan.MySQLRanges[0].Start)
+}
+
 // DefaultStreamBatchSize is the page size FetchMergedStream uses when the
 // caller passes 0. Chosen as a compromise between resident memory (a page of
 // ResultRows carries both decoded JSON row images, so roughly 1-2 KB per event
@@ -631,6 +731,11 @@ func fetchPage(
 		slog.Debug("planner: skipping archive sources (newest-first page filled from contiguous live coverage)",
 			"limit", o.Opts.Limit, "sources", len(src.archSources))
 		return rows[:o.Opts.Limit], nil, nil, 0, true, nil
+	}
+	if perPKSatisfiedLive(o.Opts, rows, src.plan) {
+		slog.Debug("planner: skipping archive sources (every named PK already has its latest N live)",
+			"limit_per_pk", o.Opts.LimitPerPK, "sources", len(src.archSources))
+		return rows, nil, nil, 0, true, nil
 	}
 
 	// Archive fetches get the misfiled-archive file-scoping hint (#1037); the

--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -277,7 +277,7 @@ func topNSatisfiedLive(opts Options, rows []ResultRow, plan *QueryPlan) bool {
 	// read), so the hole was latent here and load-bearing in the sibling —
 	// closing only the sibling would have left the two reasoning differently
 	// about the same layout.
-	if plan == nil || len(plan.MySQLRanges) != 1 || !plan.ArchivesBelowLive {
+	if plan == nil || len(plan.MySQLRanges) != 1 || !plan.ArchivesBelowLive || plan.ArchiveCoverageUnavailable {
 		return false
 	}
 	// rows are already sorted newest-first, so the limit-th row is the cutoff.
@@ -356,6 +356,18 @@ func perPKSatisfiedLive(opts Options, rows []ResultRow, plan *QueryPlan) bool {
 	if len(names) == 0 {
 		return false
 	}
+	// Three requirements that look like one.
+	//
+	// ArchiveCoverageUnavailable is the third and the quietest: when the
+	// archive_state read fails for a reason other than a missing table, Plan
+	// hands buildPlan an EMPTY archive hour list, and archivesBelowLive then
+	// returns vacuously true over it. The plan would simultaneously say
+	// "coverage was never evaluated" and "every archived hour is below live".
+	// Sources can still have been resolved — that is a separate query — so this
+	// is reachable on a statement timeout or lock wait between the two round
+	// trips, and under AllowGaps the resulting gap hours are only a warning.
+	// Refusing the skip there costs an archive read on a degraded index.
+	//
 	// Two separate requirements that look like one.
 	//
 	// A single range says the LIVE hours have no interior hole —
@@ -372,7 +384,7 @@ func perPKSatisfiedLive(opts Options, rows []ResultRow, plan *QueryPlan) bool {
 	// complete, which is the worst output this package can produce.
 	// browsePlanFromHours has refused that layout since it was written; this
 	// path now refuses it too, rather than the two rules disagreeing.
-	if plan == nil || len(plan.MySQLRanges) != 1 || !plan.ArchivesBelowLive {
+	if plan == nil || len(plan.MySQLRanges) != 1 || !plan.ArchivesBelowLive || plan.ArchiveCoverageUnavailable {
 		return false
 	}
 
@@ -399,20 +411,25 @@ func perPKSatisfiedLive(opts Options, rows []ResultRow, plan *QueryPlan) bool {
 		}
 	}
 
-	// A belt, and labelled as one. This was the ORIGINAL fourth condition, and
-	// review showed it proves nothing: buildPlan sets Start to the oldest live
-	// partition HOUR, and a row in partition p_H has ts >= H, so a live row can
-	// essentially never fall below it. Believing it was the soundness argument
-	// is what let an archive sitting above the live range go unnoticed —
-	// ArchivesBelowLive, above, is the condition that actually carries the
-	// proof.
+	// The other half of the proof, and NOT redundant — an earlier revision of
+	// this comment called it that, and deleting the line fails
+	// TestPerPKSatisfiedLive in this same package.
 	//
-	// Kept anyway, because it is one comparison and it fails CLOSED. The one
-	// shape that reaches it is a backfilled event (#1037) whose timestamp
-	// undercuts its partition's label; the archives-below-live check already
-	// covers that case, so this is redundant rather than load-bearing. Removing
-	// a check on the strength of "I proved it cannot fire" is how the hole
-	// above got in, so it stays — demoted, not deleted.
+	// The two conditions guard opposite sides and neither subsumes the other.
+	// ArchivesBelowLive is computed from partition LABELS and archive hours; it
+	// never sees a row timestamp, so it structurally cannot see a backfilled
+	// event (#1037) sitting INSIDE the oldest live partition with a timestamp
+	// below that partition's label. Concretely: live {10:00, 11:00}, archived
+	// {09:00} — flag true — with PK "A" holding a normal row at 10:15 and a
+	// backfilled one at 08:30, while the archive holds an "A" row at 09:00. The
+	// true latest-2 is {10:15, 09:00}; the live-only latest-2 is {10:15, 08:30}.
+	// Only this comparison refuses that skip.
+	//
+	// It IS true that the shape is rare and that this fires almost never on a
+	// normally-rotated index. That was the whole content of the previous
+	// comment, and it was the wrong thing to emphasise: "I proved it cannot
+	// fire" is precisely the reasoning that let an archive above the live range
+	// go unchecked in the first version of this predicate.
 	return !oldest.Before(plan.MySQLRanges[0].Start)
 }
 

--- a/internal/query/fetchmerged.go
+++ b/internal/query/fetchmerged.go
@@ -269,7 +269,15 @@ func topNSatisfiedLive(opts Options, rows []ResultRow, plan *QueryPlan) bool {
 	if opts.Limit <= 0 || len(rows) < opts.Limit || OrderDirection(opts.Order) != "DESC" {
 		return false
 	}
-	if plan == nil || len(plan.MySQLRanges) != 1 {
+	// ArchivesBelowLive for the same reason its per-PK sibling requires it: a
+	// single range proves the LIVE hours are contiguous and says nothing about
+	// an archived hour sitting above them, and a full page of live rows is not
+	// the true top N when an archive holds newer ones. This one could not fire
+	// on `recover` (its 1000-row default page is never filled by a PK-scoped
+	// read), so the hole was latent here and load-bearing in the sibling —
+	// closing only the sibling would have left the two reasoning differently
+	// about the same layout.
+	if plan == nil || len(plan.MySQLRanges) != 1 || !plan.ArchivesBelowLive {
 		return false
 	}
 	// rows are already sorted newest-first, so the limit-th row is the cutoff.
@@ -348,7 +356,23 @@ func perPKSatisfiedLive(opts Options, rows []ResultRow, plan *QueryPlan) bool {
 	if len(names) == 0 {
 		return false
 	}
-	if plan == nil || len(plan.MySQLRanges) != 1 {
+	// Two separate requirements that look like one.
+	//
+	// A single range says the LIVE hours have no interior hole —
+	// buildContiguousRanges reads liveHours and nothing else, so it is silent
+	// about where the archives sit. ArchivesBelowLive is the premise this
+	// predicate actually rests on: that no archived hour is at or above the
+	// live floor. Review caught the first version asserting only the first and
+	// believing it had the second.
+	//
+	// Without it, an index whose archives sit ABOVE the live range — a restored
+	// or hand-surgered index, a rotate that archived without dropping — lets a
+	// PK with its N newest LIVE rows skip an archive holding rows NEWER than
+	// all of them. On `recover` that is a short reversal script reported as
+	// complete, which is the worst output this package can produce.
+	// browsePlanFromHours has refused that layout since it was written; this
+	// path now refuses it too, rather than the two rules disagreeing.
+	if plan == nil || len(plan.MySQLRanges) != 1 || !plan.ArchivesBelowLive {
 		return false
 	}
 
@@ -374,6 +398,21 @@ func perPKSatisfiedLive(opts Options, rows []ResultRow, plan *QueryPlan) bool {
 			return false
 		}
 	}
+
+	// A belt, and labelled as one. This was the ORIGINAL fourth condition, and
+	// review showed it proves nothing: buildPlan sets Start to the oldest live
+	// partition HOUR, and a row in partition p_H has ts >= H, so a live row can
+	// essentially never fall below it. Believing it was the soundness argument
+	// is what let an archive sitting above the live range go unnoticed —
+	// ArchivesBelowLive, above, is the condition that actually carries the
+	// proof.
+	//
+	// Kept anyway, because it is one comparison and it fails CLOSED. The one
+	// shape that reaches it is a backfilled event (#1037) whose timestamp
+	// undercuts its partition's label; the archives-below-live check already
+	// covers that case, so this is redundant rather than load-bearing. Removing
+	// a check on the strength of "I proved it cannot fire" is how the hole
+	// above got in, so it stays — demoted, not deleted.
 	return !oldest.Before(plan.MySQLRanges[0].Start)
 }
 

--- a/internal/query/perpk_skip_test.go
+++ b/internal/query/perpk_skip_test.go
@@ -1,0 +1,281 @@
+package query
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+// pkRowsAt builds n rows for one pk_values, newest-first, a minute apart,
+// with the oldest at `oldest`.
+func pkRowsAt(pk string, n int, oldest time.Time) []ResultRow {
+	out := make([]ResultRow, n)
+	for i := range out {
+		out[i] = ResultRow{
+			EventID:        uint64(n - i),
+			PKValues:       pk,
+			EventTimestamp: oldest.Add(time.Duration(n-1-i) * time.Minute),
+		}
+	}
+	return out
+}
+
+func TestPerPKSatisfiedLive(t *testing.T) {
+	now := time.Now().UTC()
+	live := hourRange(24*time.Hour, 0, now)
+	inside := now.Add(-2 * time.Hour)
+	below := now.Add(-30 * time.Hour) // older than the live range's start
+
+	tests := []struct {
+		name string
+		opts Options
+		rows []ResultRow
+		plan *QueryPlan
+		want bool
+		why  string
+	}{
+		{
+			name: "one named PK with its latest N already live",
+			opts: Options{LimitPerPK: 1, PKValues: "42"},
+			rows: pkRowsAt("42", 1, inside),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: true,
+			why:  "the trim keeps this row and discards every older archived one",
+		},
+		{
+			name: "several named PKs, all satisfied",
+			opts: Options{LimitPerPK: 2, PKValuesIn: []string{"1", "2"}},
+			rows: append(pkRowsAt("1", 2, inside), pkRowsAt("2", 2, inside)...),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: true,
+		},
+		{
+			name: "one PK short of its N",
+			opts: Options{LimitPerPK: 2, PKValuesIn: []string{"1", "2"}},
+			rows: append(pkRowsAt("1", 2, inside), pkRowsAt("2", 1, inside)...),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "the archives can still extend PK 2 — one short PK invalidates the whole skip",
+		},
+		{
+			name: "a named PK absent from the live result",
+			opts: Options{LimitPerPK: 1, PKValuesIn: []string{"1", "2"}},
+			rows: pkRowsAt("1", 1, inside),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "PK 2's entire history may be archived; skipping would drop the row, not trim it",
+		},
+		{
+			name: "the empty PK name",
+			opts: Options{LimitPerPK: 1, PKValuesIn: []string{""}},
+			rows: pkRowsAt("", 1, inside),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "merge.go buckets every empty-PK row under its own synthetic key, so the trim discards nothing there and the proof does not hold — see the #318 drift carve-out in LimitPerPK",
+		},
+		{
+			name: "an alternate PK encoding is in play",
+			opts: Options{LimitPerPK: 1, PKValues: "42", PKValuesAlt: "0x2A"},
+			rows: pkRowsAt("42", 1, inside),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "the same logical row can be stored under either spelling, and the trim partitions by the stored one — so its N is not well defined",
+		},
+		{
+			name: "a different PK than the one named",
+			opts: Options{LimitPerPK: 1, PKValues: "42"},
+			rows: pkRowsAt("99", 3, inside),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "PK 42 is absent; counting distinct keys instead of walking the named ones would let 99 stand in for it",
+		},
+		{
+			name: "no PK named",
+			opts: Options{LimitPerPK: 1},
+			rows: pkRowsAt("42", 1, inside),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "this is the unsound case: an archive-only pk_values is a legitimate result row, and nothing here names the set that would have to be complete",
+		},
+		{
+			name: "no per-PK trim",
+			opts: Options{PKValues: "42"},
+			rows: pkRowsAt("42", 5, inside),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "without the trim the archives are not discarded, they are the older half of the answer",
+		},
+		{
+			name: "oldest kept row sits below the live range",
+			opts: Options{LimitPerPK: 2, PKValues: "42"},
+			rows: pkRowsAt("42", 2, below),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "the span above the kept rows is not provably live-covered",
+		},
+		{
+			name: "two live ranges",
+			opts: Options{LimitPerPK: 1, PKValues: "42"},
+			rows: pkRowsAt("42", 1, inside),
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live, hourRange(72*time.Hour, 48*time.Hour, now)}},
+			want: false,
+			why:  "an archived hour could sit between them, above the kept row",
+		},
+		{
+			name: "no plan",
+			opts: Options{LimitPerPK: 1, PKValues: "42"},
+			rows: pkRowsAt("42", 1, inside),
+			plan: nil,
+			want: false,
+			why:  "no plan, no proof",
+		},
+		{
+			name: "no live rows at all",
+			opts: Options{LimitPerPK: 1, PKValues: "42"},
+			rows: nil,
+			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "the whole history may be archived",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := perPKSatisfiedLive(tc.opts, tc.rows, tc.plan); got != tc.want {
+				t.Errorf("perPKSatisfiedLive = %v, want %v — %s", got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// The predicate above is pure; this drives the real fetchPage, because a
+// predicate that is never consulted passes every test it has. Mirrors
+// TestFetchPageSkipsArchivesOnFilledTopN for the per-PK proof.
+func TestFetchPageSkipsArchivesWhenEveryNamedPKIsSatisfiedLive(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	live := sqlmock.NewRows([]string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
+	})
+	live.AddRow(uint64(7), "mysql-bin.000001", 100, 200, now.Add(-2*time.Hour),
+		nil, nil, "shop", "orders", 3, "93921",
+		nil, nil, nil, 1, nil, nil, nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(live)
+
+	var archiveCalls int
+	src := mergeSources{
+		archSources: []string{"s3://bucket/bintrail_id=x"},
+		plan:        &QueryPlan{MySQLRanges: []TimeRange{{Start: now.Add(-24 * time.Hour), End: now.Add(time.Hour)}}},
+	}
+	o := FetchMergedOptions{
+		// The shape the console sends for a scoped reversal: one PK, latest
+		// one per row, no lower bound.
+		Opts:      Options{LimitPerPK: 1, PKValues: "93921", Limit: 1000, Order: "DESC"},
+		AllowGaps: true,
+		ArchiveFetcher: func(context.Context, Options, string) ([]ResultRow, error) {
+			archiveCalls++
+			return []ResultRow{{EventID: 999, PKValues: "93921", EventTimestamp: now.Add(-72 * time.Hour)}}, nil
+		},
+	}
+
+	rows, _, _, _, elided, err := fetchPage(context.Background(), New(db), o, src)
+	if err != nil {
+		t.Fatalf("fetchPage: %v", err)
+	}
+	if archiveCalls != 0 {
+		t.Errorf("archive fetcher called %d time(s); the named PK already had its latest event live, "+
+			"so the archives could only contribute rows the per-PK trim discards", archiveCalls)
+	}
+	// Reported, not just skipped: a reversal that silently dropped registered
+	// archives is the audit failure archivesElided exists to prevent (#1353).
+	if !elided {
+		t.Error("archivesElided is false after skipping the archive sources — the surface rendering " +
+			"this has no way to say the archives went unread")
+	}
+	if len(rows) != 1 || rows[0].EventID != 7 {
+		t.Errorf("rows = %+v, want just the live event", rows)
+	}
+}
+
+// The other direction, and the one that must never be traded for speed: a
+// named PK with nothing live has its whole history in the archives, so the
+// skip is refused and the fetcher runs.
+func TestFetchPageReadsArchivesWhenANamedPKHasNothingLive(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	empty := sqlmock.NewRows([]string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
+	})
+	mock.ExpectQuery("SELECT").WillReturnRows(empty)
+
+	var archiveCalls int
+	src := mergeSources{
+		archSources: []string{"s3://bucket/bintrail_id=x"},
+		plan:        &QueryPlan{MySQLRanges: []TimeRange{{Start: now.Add(-24 * time.Hour), End: now.Add(time.Hour)}}},
+	}
+	o := FetchMergedOptions{
+		Opts:      Options{LimitPerPK: 1, PKValues: "93921", Limit: 1000, Order: "DESC"},
+		AllowGaps: true,
+		ArchiveFetcher: func(context.Context, Options, string) ([]ResultRow, error) {
+			archiveCalls++
+			return []ResultRow{{EventID: 999, PKValues: "93921", EventTimestamp: now.Add(-72 * time.Hour)}}, nil
+		},
+	}
+
+	rows, _, _, _, elided, err := fetchPage(context.Background(), New(db), o, src)
+	if err != nil {
+		t.Fatalf("fetchPage: %v", err)
+	}
+	if archiveCalls != 1 {
+		t.Errorf("archive fetcher called %d time(s), want 1 — the row's entire history is archived", archiveCalls)
+	}
+	if elided {
+		t.Error("archivesElided is true on a path that read the archives")
+	}
+	if len(rows) != 1 || rows[0].EventID != 999 {
+		t.Errorf("rows = %+v, want the archived event", rows)
+	}
+}
+
+// The premise behind the empty-name refusal, asserted against the real trim
+// rather than taken from its comment. If LimitPerPK ever stops carving empty
+// PKs out, the refusal becomes needlessly conservative and this says so.
+func TestLimitPerPKDoesNotTrimEmptyPKs(t *testing.T) {
+	now := time.Now().UTC()
+	rows := []ResultRow{
+		{EventID: 1, PKValues: "", EventTimestamp: now.Add(-72 * time.Hour)},
+		{EventID: 2, PKValues: "", EventTimestamp: now.Add(-71 * time.Hour)},
+		{EventID: 3, PKValues: "", EventTimestamp: now.Add(-2 * time.Hour)},
+	}
+	if got := LimitPerPK(rows, 1); len(got) != 3 {
+		t.Fatalf("LimitPerPK(empty PKs, 1) kept %d rows, want all 3 — the drift carve-out is what "+
+			"makes perPKSatisfiedLive refuse the empty name; if it is gone, revisit that refusal", len(got))
+	}
+	// And the contrast, so the test is about the carve-out and not about
+	// LimitPerPK being a no-op.
+	named := []ResultRow{
+		{EventID: 1, PKValues: "42", EventTimestamp: now.Add(-72 * time.Hour)},
+		{EventID: 2, PKValues: "42", EventTimestamp: now.Add(-2 * time.Hour)},
+	}
+	if got := LimitPerPK(named, 1); len(got) != 1 {
+		t.Fatalf("LimitPerPK(named PK, 1) kept %d rows, want 1", len(got))
+	}
+}

--- a/internal/query/perpk_skip_test.go
+++ b/internal/query/perpk_skip_test.go
@@ -121,7 +121,22 @@ func TestPerPKSatisfiedLive(t *testing.T) {
 			rows: pkRowsAt("42", 1, inside),
 			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live, hourRange(72*time.Hour, 48*time.Hour, now)}},
 			want: false,
-			why:  "an archived hour could sit between them, above the kept row",
+			why:  "two live ranges mean the planner saw a hole in the live hours; what fills it is not\n\t\t\t\t\t\tknowable from here, so no live result proves anything about the span above it",
+		},
+		{
+			// Plan sets this when the archive_state read fails for a reason
+			// other than a missing table, and then hands buildPlan an EMPTY
+			// hour list — over which archivesBelowLive is vacuously true. The
+			// plan would say "coverage was never evaluated" and "every
+			// archived hour is below live" at the same time. Sources come
+			// from a SEPARATE query, so they can still be resolved and
+			// waiting to be skipped.
+			name: "archive coverage could not be read",
+			opts: Options{LimitPerPK: 1, PKValues: "42"},
+			rows: pkRowsAt("42", 1, inside),
+			plan: &QueryPlan{ArchivesBelowLive: true, ArchiveCoverageUnavailable: true, MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "a vacuous premise over an unread archive_state is not a premise",
 		},
 		{
 			name: "no plan",

--- a/internal/query/perpk_skip_test.go
+++ b/internal/query/perpk_skip_test.go
@@ -40,7 +40,7 @@ func TestPerPKSatisfiedLive(t *testing.T) {
 			name: "one named PK with its latest N already live",
 			opts: Options{LimitPerPK: 1, PKValues: "42"},
 			rows: pkRowsAt("42", 1, inside),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: true,
 			why:  "the trim keeps this row and discards every older archived one",
 		},
@@ -48,14 +48,14 @@ func TestPerPKSatisfiedLive(t *testing.T) {
 			name: "several named PKs, all satisfied",
 			opts: Options{LimitPerPK: 2, PKValuesIn: []string{"1", "2"}},
 			rows: append(pkRowsAt("1", 2, inside), pkRowsAt("2", 2, inside)...),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: true,
 		},
 		{
 			name: "one PK short of its N",
 			opts: Options{LimitPerPK: 2, PKValuesIn: []string{"1", "2"}},
 			rows: append(pkRowsAt("1", 2, inside), pkRowsAt("2", 1, inside)...),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: false,
 			why:  "the archives can still extend PK 2 — one short PK invalidates the whole skip",
 		},
@@ -63,7 +63,7 @@ func TestPerPKSatisfiedLive(t *testing.T) {
 			name: "a named PK absent from the live result",
 			opts: Options{LimitPerPK: 1, PKValuesIn: []string{"1", "2"}},
 			rows: pkRowsAt("1", 1, inside),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: false,
 			why:  "PK 2's entire history may be archived; skipping would drop the row, not trim it",
 		},
@@ -71,7 +71,7 @@ func TestPerPKSatisfiedLive(t *testing.T) {
 			name: "the empty PK name",
 			opts: Options{LimitPerPK: 1, PKValuesIn: []string{""}},
 			rows: pkRowsAt("", 1, inside),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: false,
 			why:  "merge.go buckets every empty-PK row under its own synthetic key, so the trim discards nothing there and the proof does not hold — see the #318 drift carve-out in LimitPerPK",
 		},
@@ -79,7 +79,7 @@ func TestPerPKSatisfiedLive(t *testing.T) {
 			name: "an alternate PK encoding is in play",
 			opts: Options{LimitPerPK: 1, PKValues: "42", PKValuesAlt: "0x2A"},
 			rows: pkRowsAt("42", 1, inside),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: false,
 			why:  "the same logical row can be stored under either spelling, and the trim partitions by the stored one — so its N is not well defined",
 		},
@@ -87,7 +87,7 @@ func TestPerPKSatisfiedLive(t *testing.T) {
 			name: "a different PK than the one named",
 			opts: Options{LimitPerPK: 1, PKValues: "42"},
 			rows: pkRowsAt("99", 3, inside),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: false,
 			why:  "PK 42 is absent; counting distinct keys instead of walking the named ones would let 99 stand in for it",
 		},
@@ -95,7 +95,7 @@ func TestPerPKSatisfiedLive(t *testing.T) {
 			name: "no PK named",
 			opts: Options{LimitPerPK: 1},
 			rows: pkRowsAt("42", 1, inside),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: false,
 			why:  "this is the unsound case: an archive-only pk_values is a legitimate result row, and nothing here names the set that would have to be complete",
 		},
@@ -103,7 +103,7 @@ func TestPerPKSatisfiedLive(t *testing.T) {
 			name: "no per-PK trim",
 			opts: Options{PKValues: "42"},
 			rows: pkRowsAt("42", 5, inside),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: false,
 			why:  "without the trim the archives are not discarded, they are the older half of the answer",
 		},
@@ -111,7 +111,7 @@ func TestPerPKSatisfiedLive(t *testing.T) {
 			name: "oldest kept row sits below the live range",
 			opts: Options{LimitPerPK: 2, PKValues: "42"},
 			rows: pkRowsAt("42", 2, below),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: false,
 			why:  "the span above the kept rows is not provably live-covered",
 		},
@@ -119,7 +119,7 @@ func TestPerPKSatisfiedLive(t *testing.T) {
 			name: "two live ranges",
 			opts: Options{LimitPerPK: 1, PKValues: "42"},
 			rows: pkRowsAt("42", 1, inside),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live, hourRange(72*time.Hour, 48*time.Hour, now)}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live, hourRange(72*time.Hour, 48*time.Hour, now)}},
 			want: false,
 			why:  "an archived hour could sit between them, above the kept row",
 		},
@@ -135,7 +135,7 @@ func TestPerPKSatisfiedLive(t *testing.T) {
 			name: "no live rows at all",
 			opts: Options{LimitPerPK: 1, PKValues: "42"},
 			rows: nil,
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: false,
 			why:  "the whole history may be archived",
 		},
@@ -175,7 +175,7 @@ func TestFetchPageSkipsArchivesWhenEveryNamedPKIsSatisfiedLive(t *testing.T) {
 	var archiveCalls int
 	src := mergeSources{
 		archSources: []string{"s3://bucket/bintrail_id=x"},
-		plan:        &QueryPlan{MySQLRanges: []TimeRange{{Start: now.Add(-24 * time.Hour), End: now.Add(time.Hour)}}},
+		plan:        &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{{Start: now.Add(-24 * time.Hour), End: now.Add(time.Hour)}}},
 	}
 	o := FetchMergedOptions{
 		// The shape the console sends for a scoped reversal: one PK, latest
@@ -229,7 +229,7 @@ func TestFetchPageReadsArchivesWhenANamedPKHasNothingLive(t *testing.T) {
 	var archiveCalls int
 	src := mergeSources{
 		archSources: []string{"s3://bucket/bintrail_id=x"},
-		plan:        &QueryPlan{MySQLRanges: []TimeRange{{Start: now.Add(-24 * time.Hour), End: now.Add(time.Hour)}}},
+		plan:        &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{{Start: now.Add(-24 * time.Hour), End: now.Add(time.Hour)}}},
 	}
 	o := FetchMergedOptions{
 		Opts:      Options{LimitPerPK: 1, PKValues: "93921", Limit: 1000, Order: "DESC"},
@@ -277,5 +277,90 @@ func TestLimitPerPKDoesNotTrimEmptyPKs(t *testing.T) {
 	}
 	if got := LimitPerPK(named, 1); len(got) != 1 {
 		t.Fatalf("LimitPerPK(named PK, 1) kept %d rows, want 1", len(got))
+	}
+}
+
+// The negative control #1403 asked for by name — "an index whose archived hour
+// sits above the live range" — and the one the first version of this file
+// substituted a different layout for, because the predicate as written could
+// not pass it.
+//
+// This is the layout that makes the short-circuit dangerous rather than merely
+// wrong: live partitions 10:00–17:00, an archived hour at 18:00 ABOVE them
+// (a restored index, or a rotate that archived without dropping), and the
+// archive holding an event NEWER than anything live. The named PK has its one
+// live row, so a per-PK count alone says "satisfied" — and the reversal would
+// be built from the 15:00 event while the 18:05 one that limit_per_pk=1 should
+// have kept is never read. Short reversal script, reported complete.
+//
+// The plan comes from the REAL buildPlan rather than a literal. That is the
+// point: every other case here hands the predicate an ArchivesBelowLive it
+// chose, so without this one the field could be computed wrongly — or not at
+// all — and the suite would not notice.
+func TestFetchPageReadsArchivesWhenAnArchivedHourSitsAboveLive(t *testing.T) {
+	base := time.Date(2026, 3, 4, 0, 0, 0, 0, time.UTC)
+	hr := func(h int) time.Time { return base.Add(time.Duration(h) * time.Hour) }
+
+	var liveHours []time.Time
+	for h := 10; h <= 17; h++ {
+		liveHours = append(liveHours, hr(h))
+	}
+	plan := buildPlan(liveHours, []time.Time{hr(18)}, hr(10), hr(20), false)
+	if plan == nil {
+		t.Fatal("buildPlan returned nil for a live+archived layout")
+	}
+	if len(plan.MySQLRanges) != 1 {
+		t.Fatalf("MySQLRanges = %v, want one contiguous range — the fixture is meant to have no "+
+			"interior hole, so that condition cannot be what refuses the skip", plan.MySQLRanges)
+	}
+	if plan.ArchivesBelowLive {
+		t.Fatal("buildPlan says ArchivesBelowLive with an archived hour at 18:00 above a live " +
+			"range topping out at 17:00 — the flag is not being computed from the hours")
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	live := sqlmock.NewRows([]string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
+	})
+	live.AddRow(uint64(1), "mysql-bin.000001", 100, 200, hr(15),
+		nil, nil, "shop", "orders", 3, "A",
+		nil, nil, nil, 1, nil, nil, nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(live)
+
+	var archiveCalls int
+	until := hr(20)
+	o := FetchMergedOptions{
+		Opts:      Options{LimitPerPK: 1, PKValues: "A", Limit: 1000, Order: "DESC", Until: &until},
+		AllowGaps: true,
+		ArchiveFetcher: func(context.Context, Options, string) ([]ResultRow, error) {
+			archiveCalls++
+			// NEWER than the live row, which is the whole hazard.
+			return []ResultRow{{EventID: 99, PKValues: "A", EventTimestamp: hr(18).Add(5 * time.Minute)}}, nil
+		},
+	}
+	rows, _, _, _, elided, err := fetchPage(context.Background(), New(db), o,
+		mergeSources{archSources: []string{"s3://bucket/bintrail_id=x"}, plan: plan})
+	if err != nil {
+		t.Fatalf("fetchPage: %v", err)
+	}
+	if archiveCalls != 1 {
+		t.Fatalf("archive fetcher called %d time(s); with an archived hour above the live range the "+
+			"skip is unsound — the archive holds the newest event for this PK", archiveCalls)
+	}
+	if elided {
+		t.Error("archivesElided is true on a page that DID read the archives; the console renders " +
+			"that as \"nothing is missing here\", which would be a false assurance on a short reversal")
+	}
+	// The trim keeps the newest per PK: the archived event, not the live one.
+	if len(rows) != 1 || rows[0].EventID != 99 {
+		t.Errorf("rows = %+v, want the archived event 99 — it is newer than the live one and "+
+			"limit_per_pk=1 keeps the newest", rows)
 	}
 }

--- a/internal/query/planner.go
+++ b/internal/query/planner.go
@@ -42,6 +42,26 @@ type QueryPlan struct {
 	// "gap" that was never captured in the first place (#1126).
 	OldestKnownHour time.Time
 
+	// ArchivesBelowLive reports that every archived hour the planner saw sits
+	// strictly below the oldest live partition hour — the "archives are older
+	// than live" invariant. It is the premise every archive short-circuit
+	// silently rests on, and it does NOT always hold: a restored or
+	// hand-surgered index, or an archived-but-not-yet-dropped partition after a
+	// rotate crash, can leave archived hours at or above the live floor.
+	//
+	// browsePlanFromHours has checked exactly this since it was written, and
+	// returns nil rather than a plan when it fails. Plan did not, so a caller
+	// that reasoned "the live rows already satisfy this request" could skip an
+	// archive holding NEWER rows than anything live. That is a short reversal
+	// script, reported as complete — see topNSatisfiedLive/perPKSatisfiedLive,
+	// which now both require this.
+	//
+	// Deliberately as strict as the browse sibling: every archived hour, not
+	// just the ones inside the queried window. Over-strict costs an archive
+	// read; the two rules disagreeing costs a wrong answer on one path only,
+	// which is how this bug existed in the first place.
+	ArchivesBelowLive bool
+
 	// MisfiledArchiveHours are the hour LABELS of archived partitions whose
 	// content-derived time range (archive_state.min/max_event_ts, #1037)
 	// escapes the label hour AND overlaps the queried range. Backfilled
@@ -233,6 +253,13 @@ func browsePlanFromHours(liveHours, archivedHours []time.Time) *QueryPlan {
 			plan.OldestKnownHour = h
 		}
 	}
+	// True by CONSTRUCTION here, not by a second check: the loop above returned
+	// nil for every archived hour at or above oldestLive, so reaching this line
+	// IS the invariant. Stated explicitly because the field defaults to false —
+	// deliberately, so a hand-built plan never claims safety it has not earned —
+	// and leaving it unset would silently disable topNSatisfiedLive on the
+	// browse path, the one path where the proof was already being done.
+	plan.ArchivesBelowLive = true
 	plan.MySQLRanges = []TimeRange{{Start: oldestLive, End: newestLive.Add(time.Hour)}}
 	return plan
 }
@@ -316,7 +343,34 @@ func buildPlan(liveHours, archivedHours []time.Time, rangeStart, rangeEnd time.T
 		plan.MySQLRanges = buildContiguousRanges(liveHours, rangeStart, rangeEnd)
 	}
 
+	// buildContiguousRanges reads liveHours ONLY, so a single range proves the
+	// live hours have no interior hole and says nothing about where the
+	// archives sit. That distinction is the whole reason this flag exists.
+	plan.ArchivesBelowLive = archivesBelowLive(liveHours, archivedHours)
+
 	return plan
+}
+
+// archivesBelowLive reports whether every archived hour is strictly older than
+// the oldest live one. Empty archives satisfy it vacuously (there is nothing a
+// short-circuit could skip); no live hours also satisfies it, and is moot —
+// every caller that consults this also requires a live range.
+func archivesBelowLive(liveHours, archivedHours []time.Time) bool {
+	if len(liveHours) == 0 || len(archivedHours) == 0 {
+		return true
+	}
+	oldestLive := liveHours[0]
+	for _, h := range liveHours[1:] {
+		if h.Before(oldestLive) {
+			oldestLive = h
+		}
+	}
+	for _, h := range archivedHours {
+		if !h.Before(oldestLive) {
+			return false
+		}
+	}
+	return true
 }
 
 // FormatGapWarning returns a human-readable warning string for gap hours,

--- a/internal/query/planner_test.go
+++ b/internal/query/planner_test.go
@@ -503,3 +503,55 @@ func TestMisfiledHours(t *testing.T) {
 		}
 	})
 }
+
+// The POSITIVE direction of ArchivesBelowLive, which the short-circuit tests
+// cannot cover: every one of those hands the predicate a plan literal with the
+// flag it chose, so hardwiring buildPlan to `false` left the entire repo green
+// while quietly disabling the optimization the whole feature exists for. A
+// silently absent speed-up is a worse failure than a noisy one — nothing tells
+// the operator the 0.3s path became 27.6s.
+//
+// The interleaved case is here for a different mutation: swapping the
+// reference point from the OLDEST live hour to the newest also survived
+// everything else. Newest would be unsound exactly on the layout the feature
+// refuses — an archived-but-not-dropped hour whose live partition was later
+// truncated — so the doc's "oldest live partition hour" needs a test that
+// distinguishes them, and only an archive sitting BETWEEN live hours does.
+func TestBuildPlanComputesArchivesBelowLive(t *testing.T) {
+	var live []time.Time
+	for i := 10; i <= 17; i++ {
+		live = append(live, h(5, i))
+	}
+	tests := []struct {
+		name     string
+		archived []time.Time
+		want     bool
+		why      string
+	}{
+		{"strictly below live", []time.Time{h(5, 8), h(5, 9)}, true,
+			"the ordinary rotated index — this is the layout the short-circuit exists for, " +
+				"and a flag stuck at false disables it everywhere with no signal"},
+		{"no archives at all", nil, true,
+			"nothing to skip, so the premise holds vacuously"},
+		{"one archived hour above the live range", []time.Time{h(5, 18)}, false,
+			"a restored index or a rotate that archived without dropping — the archive can hold " +
+				"rows newer than anything live"},
+		{"archived hour interleaved between live hours", []time.Time{h(5, 13)}, false,
+			"below the NEWEST live hour but not below the oldest; a reference point of newest " +
+				"would call this safe and it is not"},
+		{"archived hour equal to the oldest live hour", []time.Time{h(5, 10)}, false,
+			"strictly below, not at-or-below: the same hour on both sides means the partition " +
+				"was archived and not dropped"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := buildPlan(live, tc.archived, h(5, 8), h(5, 20), false)
+			if plan == nil {
+				t.Fatal("buildPlan returned nil")
+			}
+			if plan.ArchivesBelowLive != tc.want {
+				t.Errorf("ArchivesBelowLive = %v, want %v — %s", plan.ArchivesBelowLive, tc.want, tc.why)
+			}
+		})
+	}
+}

--- a/internal/query/topn_skip_test.go
+++ b/internal/query/topn_skip_test.go
@@ -44,6 +44,18 @@ func TestTopNSatisfiedLive(t *testing.T) {
 			why:  "the archives are all below the cutoff and cannot survive the limit",
 		},
 		{
+			// The sibling of the perPK case: an unread archive_state makes
+			// archivesBelowLive vacuously true over an empty hour list, so the
+			// plan claims the premise it never got to evaluate. Sources are
+			// resolved by a separate query and can still be present.
+			name: "archive coverage could not be read",
+			opts: Options{Limit: 100, Order: "DESC"},
+			rows: rowsAt(100, cutoffInside),
+			plan: &QueryPlan{ArchivesBelowLive: true, ArchiveCoverageUnavailable: true, MySQLRanges: []TimeRange{live}},
+			want: false,
+			why:  "a vacuous premise over an unread archive_state is not a premise",
+		},
+		{
 			name: "short page",
 			opts: Options{Limit: 100, Order: "DESC"},
 			rows: rowsAt(40, cutoffInside),
@@ -84,7 +96,7 @@ func TestTopNSatisfiedLive(t *testing.T) {
 				hourRange(24*time.Hour, 0, now),
 			}},
 			want: false,
-			why:  "two live ranges mean an archived hour can sit ABOVE the cutoff",
+			why:  "two live ranges mean the planner saw a hole in the live hours, so a filled page is\n\t\t\t\t\t\tnot provably the true top N whatever the archive layout is",
 		},
 		{
 			name: "cutoff below the live range",

--- a/internal/query/topn_skip_test.go
+++ b/internal/query/topn_skip_test.go
@@ -39,7 +39,7 @@ func TestTopNSatisfiedLive(t *testing.T) {
 			name: "filled DESC page inside one live range",
 			opts: Options{Limit: 100, Order: "DESC"},
 			rows: rowsAt(100, cutoffInside),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: true,
 			why:  "the archives are all below the cutoff and cannot survive the limit",
 		},
@@ -47,7 +47,7 @@ func TestTopNSatisfiedLive(t *testing.T) {
 			name: "short page",
 			opts: Options{Limit: 100, Order: "DESC"},
 			rows: rowsAt(40, cutoffInside),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: false,
 			why:  "live did not fill the limit, so the archives genuinely extend the result",
 		},
@@ -55,7 +55,7 @@ func TestTopNSatisfiedLive(t *testing.T) {
 			name: "ASC asks for the oldest rows",
 			opts: Options{Limit: 100, Order: "ASC"},
 			rows: rowsAt(100, cutoffInside),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: false,
 			why:  "oldest-first is exactly where the archives live",
 		},
@@ -63,7 +63,7 @@ func TestTopNSatisfiedLive(t *testing.T) {
 			name: "empty order defaults to ASC",
 			opts: Options{Limit: 100},
 			rows: rowsAt(100, cutoffInside),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: false,
 			why:  "OrderDirection defaults to ASC, which must not take the skip",
 		},
@@ -71,7 +71,7 @@ func TestTopNSatisfiedLive(t *testing.T) {
 			name: "no limit",
 			opts: Options{Order: "DESC"},
 			rows: rowsAt(100, cutoffInside),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: false,
 			why:  "without a limit every archived row is still wanted",
 		},
@@ -79,7 +79,7 @@ func TestTopNSatisfiedLive(t *testing.T) {
 			name: "interleaved live coverage",
 			opts: Options{Limit: 100, Order: "DESC"},
 			rows: rowsAt(100, now.Add(-200*time.Hour)),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{
 				hourRange(300*time.Hour, 250*time.Hour, now),
 				hourRange(24*time.Hour, 0, now),
 			}},
@@ -90,7 +90,7 @@ func TestTopNSatisfiedLive(t *testing.T) {
 			name: "cutoff below the live range",
 			opts: Options{Limit: 100, Order: "DESC"},
 			rows: rowsAt(100, now.Add(-48*time.Hour)),
-			plan: &QueryPlan{MySQLRanges: []TimeRange{live}},
+			plan: &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{live}},
 			want: false,
 			why:  "the page reaches below live coverage, so the span above it is not provably live",
 		},
@@ -144,7 +144,7 @@ func TestFetchPageSkipsArchivesOnFilledTopN(t *testing.T) {
 	var archiveCalls int
 	src := mergeSources{
 		archSources: []string{"s3://bucket/bintrail_id=x"},
-		plan:        &QueryPlan{MySQLRanges: []TimeRange{{Start: now.Add(-24 * time.Hour), End: now.Add(time.Hour)}}},
+		plan:        &QueryPlan{ArchivesBelowLive: true, MySQLRanges: []TimeRange{{Start: now.Add(-24 * time.Hour), End: now.Add(time.Hour)}}},
 	}
 	o := FetchMergedOptions{
 		Opts:      Options{Limit: limit, Order: "DESC"},
@@ -173,3 +173,76 @@ func TestFetchPageSkipsArchivesOnFilledTopN(t *testing.T) {
 }
 
 var _ = sql.ErrNoRows
+
+// The mirror of TestFetchPageReadsArchivesWhenAnArchivedHourSitsAboveLive, and
+// it exists because adding the requirement to this predicate without a test
+// left it inert: mutating it back out kept the whole suite green.
+//
+// The layouts are the same — live 10:00–17:00, an archived hour at 18:00 above
+// them, and an archived event NEWER than anything live — but the proof being
+// attacked is different. Here a FILLED newest-first page claims to be the true
+// top N, which it is not when an archive holds newer rows.
+//
+// Worth stating why the browse path is not enough coverage: PlanBrowse refuses
+// this layout by returning a nil plan, so on that path the skip was always
+// declined. It is the buildPlan path that hands a non-nil plan over the same
+// layout, and that is the one under test here.
+func TestFetchPageReadsArchivesOnFilledTopNWhenAnArchivedHourSitsAboveLive(t *testing.T) {
+	base := time.Date(2026, 3, 4, 0, 0, 0, 0, time.UTC)
+	hr := func(h int) time.Time { return base.Add(time.Duration(h) * time.Hour) }
+
+	var liveHours []time.Time
+	for h := 10; h <= 17; h++ {
+		liveHours = append(liveHours, hr(h))
+	}
+	plan := buildPlan(liveHours, []time.Time{hr(18)}, hr(10), hr(20), false)
+	if plan == nil || len(plan.MySQLRanges) != 1 || plan.ArchivesBelowLive {
+		t.Fatalf("fixture premise broken: plan=%+v — it must be one contiguous live range with the "+
+			"archives NOT below live, or this test is not attacking the top-N proof", plan)
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	live := sqlmock.NewRows([]string{
+		"event_id", "binlog_file", "start_pos", "end_pos", "event_timestamp",
+		"gtid", "connection_id", "schema_name", "table_name", "event_type", "pk_values",
+		"changed_columns", "row_before", "row_after", "schema_version", "query_text", "query_hash",
+		"commit_ts_us",
+	})
+	// Two rows for a Limit of 2: the page is FULL, which is the whole basis of
+	// the top-N claim.
+	live.AddRow(uint64(2), "mysql-bin.000001", 100, 200, hr(16),
+		nil, nil, "shop", "orders", 3, "A", nil, nil, nil, 1, nil, nil, nil)
+	live.AddRow(uint64(1), "mysql-bin.000001", 100, 200, hr(15),
+		nil, nil, "shop", "orders", 3, "B", nil, nil, nil, 1, nil, nil, nil)
+	mock.ExpectQuery("SELECT").WillReturnRows(live)
+
+	var archiveCalls int
+	until := hr(20)
+	o := FetchMergedOptions{
+		Opts:      Options{Limit: 2, Order: "DESC", Until: &until},
+		AllowGaps: true,
+		ArchiveFetcher: func(context.Context, Options, string) ([]ResultRow, error) {
+			archiveCalls++
+			return []ResultRow{{EventID: 99, PKValues: "C", EventTimestamp: hr(18).Add(5 * time.Minute)}}, nil
+		},
+	}
+	rows, _, _, _, elided, err := fetchPage(context.Background(), New(db), o,
+		mergeSources{archSources: []string{"s3://bucket/bintrail_id=x"}, plan: plan})
+	if err != nil {
+		t.Fatalf("fetchPage: %v", err)
+	}
+	if archiveCalls != 1 {
+		t.Fatalf("archive fetcher called %d time(s); a filled live page is not the true top N when "+
+			"an archived hour sits above the live range", archiveCalls)
+	}
+	if elided {
+		t.Error("archivesElided is true on a page that DID read the archives")
+	}
+	if len(rows) == 0 || rows[0].EventID != 99 {
+		t.Errorf("rows = %+v, want the archived event 99 first — it is the newest in the window", rows)
+	}
+}


### PR DESCRIPTION
Closes #1403.

A reversal scoped to one row read every registered archive source, even when
the answer was entirely in the live partitions. Measured on an index with ~1200
archived hourly partitions and one live day: 27.6s with the archive leg, 0.3s
without, for the same single statement.

topNSatisfiedLive (#1295) already exists for exactly this cost and is why the
Events view is fast, but its proof is a FILLED page — and a PK-scoped reversal
returns a handful of events against recover's default limit of 1000, so it can
never qualify. The optimization could not reach the surface paying most for its
absence.

perPKSatisfiedLive is the sibling proof. LimitPerPK is a whole-result-set trim
applied after the merge, so when every named PK already holds its N live and
the span above the oldest kept row is provably live-covered, the archives can
only contribute rows the trim discards.

The condition with no counterpart in the sibling is the one that makes the rest
sound: the query must NAME its PKs. With an unscoped filter a pk_values that
appears only in the archives is a legitimate result row, and skipping them
would DROP it rather than trim it. A filled top-N page has no such hole —
everything it omits sorts below the cutoff; here what would be omitted is a
whole row's history.

Two shapes are refused rather than approximated. PKValuesAlt is a second
spelling of the same logical key while the trim partitions by the stored one,
so "this PK has its N" stops being well defined. And the named PKs are walked
BY NAME rather than compared by count, so an unexpected key cannot stand in for
a missing one.

archivesElided is set, so the #1353 elision record still reaches the response.
A reversal that silently skipped registered archives is the audit failure that
return value exists to prevent.

Ten mutations, each condition killed independently, negative control survives.
Two of them are worth recording because they were my own errors rather than
hypotheticals. A `named == 0` guard I first wrote was UNREACHABLE — the count
comparison beside it already returned false for every input that reached it —
so no mutation could kill it; the fix was to restructure until the requirement
lived in exactly one place, not to add a test. And one mutation reported GREEN
after the restructure because its anchor no longer matched and the patch was a
silent no-op; the harness now asserts the source actually changed, since a
no-op reads exactly like a survivor.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>