### PR TITLE
console: Undo reverses one change, not the row's whole history

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2070,7 +2070,7 @@ function renderRecover(params) {
   // Context banner when arriving via an event "Undo" (pendingRecover).
   const ctx = pendingRecover;
   if (ctx) {
-    const banner = el("div", { class: "ctx-banner" });
+    const banner = el("div", { class: "ctx-banner", id: "undo-ctx-banner" });
     banner.append(el("span", { class: "badge " + badgeClass(ctx.type), text: ctx.type }));
     banner.append(el("div", { class: "ctx-main" },
       // Scope, not target state — and the scope is a WINDOW OF TIME, not an
@@ -2100,7 +2100,7 @@ function renderRecover(params) {
       el("span", { class: "ctx-title", text: ctx.schema + "." + ctx.table + " · pk " + ctx.pk }),
       el("span", { class: "ctx-detail", text: "reverses the latest change to this row at or before the end of the second holding this "
         + ctx.type + " (" + ctx.time + " UTC)" }),
-      el("span", { class: "ctx-detail", text: "Latest per row is set to 1 — clear it to reverse this row's whole history up to that point. If the row changed more than once inside that second, the last of them is the one reversed." })));
+      el("span", { class: "ctx-detail", text: "Latest per row is set to 1 — clear it to reverse this row's whole history up to that point. If the row changed more than once inside that second, the last of them is the one reversed — not necessarily the one you clicked. A row created and deleted within one second comes back rather than going away." })));
     banner.append(el("span", { class: "spacer" }));
     banner.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Clear",
       onclick: () => { pendingRecover = null; navigate("recover"); } }));
@@ -2672,6 +2672,18 @@ function aimUndoAtInstant(form, at) {
   // reverse only the newest of them and land it somewhere else entirely,
   // silently, with the button still naming the state it did not produce.
   form.elements.limit_per_pk.value = "";
+  // …and retire the banner that describes the scope just replaced. It states
+  // "Latest per row is set to 1" as a fact about this form, and the line above
+  // makes that false: the operator would read a one-change scope over a script
+  // that reverses everything after `at`. The stale-label half of the same bug
+  // the comment above describes, one level up from the fields.
+  //
+  // By ID, not by `.ctx-banner`: generateUndo appends a second node with that
+  // class into #recover-out for the cascade notice, and an unscoped remove
+  // would take whichever came first.
+  pendingRecover = null;
+  const staleBanner = document.getElementById("undo-ctx-banner");
+  if (staleBanner) staleBanner.remove();
   previewRecover(form);
   form.scrollIntoView({ behavior: prefersReducedMotion() ? "auto" : "smooth", block: "start" });
   toast("Undo window set to everything after " + at + " UTC");

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2081,12 +2081,19 @@ function renderRecover(params) {
       // including events that happened AFTER the clicked one inside the same
       // second.
       //
-      // That is not a corner case, it is the case this wording exists for: on
-      // a row inserted and deleted inside one second, undoing from EITHER
-      // event reverses both and leaves no row at all. An earlier draft said
-      // "up to this point", which named the event as the boundary and was
-      // wrong the same way the phrasing it replaced was wrong, one revision
-      // later.
+      // That is not a corner case, it is the case this wording exists for —
+      // and #1404 INVERTED its outcome, which this paragraph went on claiming
+      // the opposite of until review caught it. It used to read "undoing from
+      // EITHER event reverses both and leaves no row at all", which was true
+      // when it was written and was falsified by the prefill below, sixteen
+      // lines away, in the same file. What happens now: the cap keeps the LAST
+      // event in that second — the DELETE — so undoing from either event
+      // RE-CREATES the row. The banner says so; this comment used to say the
+      // reverse of it.
+      //
+      // Worth knowing about the guard: it deliberately reads string literals
+      // only, so no test can ever see prose in this block. Stale comments here
+      // are a manual-review class, and this was a live instance of one.
       //
       // The remaining imprecision is stated rather than smoothed over. Latest
       // per row keeps the LATEST event at or before the ceiling, and the

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2088,15 +2088,19 @@ function renderRecover(params) {
       // wrong the same way the phrasing it replaced was wrong, one revision
       // later.
       //
-      // Since is offered AND its limit is stated: it parses at the same
-      // granularity, so it cannot split events inside one second. Naming a
-      // control without saying where it stops working is how an operator ends
-      // up believing they narrowed something they did not.
-      el("span", { class: "ctx-eyebrow", text: "Undoing every change in this window" }),
+      // The remaining imprecision is stated rather than smoothed over. Latest
+      // per row keeps the LATEST event at or before the ceiling, and the
+      // ceiling is a whole second, so on a row touched more than once inside
+      // that second the reversal lands on the last of them — which need not be
+      // the one the operator clicked. Since cannot fix it either: it parses at
+      // the same granularity. Naming a control without saying where it stops
+      // working is how an operator ends up believing they narrowed something
+      // they did not.
+      el("span", { class: "ctx-eyebrow", text: "Undoing one change" }),
       el("span", { class: "ctx-title", text: ctx.schema + "." + ctx.table + " · pk " + ctx.pk }),
-      el("span", { class: "ctx-detail", text: "reverses all events on this row through the end of the second holding this "
-        + ctx.type + " (" + ctx.time + " UTC), not only that one" }),
-      el("span", { class: "ctx-detail", text: "Set Since to narrow the window — timestamps are second-granular, so it cannot split events inside one second." })));
+      el("span", { class: "ctx-detail", text: "reverses the latest change to this row at or before the end of the second holding this "
+        + ctx.type + " (" + ctx.time + " UTC)" }),
+      el("span", { class: "ctx-detail", text: "Latest per row is set to 1 — clear it to reverse this row's whole history up to that point. If the row changed more than once inside that second, the last of them is the one reversed." })));
     banner.append(el("span", { class: "spacer" }));
     banner.append(el("button", { class: "btn btn-sm btn-ghost", type: "button", text: "Clear",
       onclick: () => { pendingRecover = null; navigate("recover"); } }));
@@ -2141,6 +2145,16 @@ function renderRecover(params) {
       form.elements.table.value = ctx.table;
       form.elements.pk.value = ctx.pk;
       if (ctx.time) form.elements.until.value = ctx.time;
+      // Undo means "undo THIS change", and until #1404 it did not: with only
+      // `until` set, the window ran from the beginning of time and the script
+      // reversed the row's ENTIRE history up to that second. On a row touched
+      // five times, undoing the third put it back to before the first.
+      //
+      // Prefilled rather than hardcoded: it lands in a visible, editable field
+      // and the banner states it, so widening the scope is one edit away and
+      // narrowing it was never a silent act. Clearing the field restores the
+      // old whole-history behaviour exactly.
+      form.elements.limit_per_pk.value = "1";
       generateUndo(form);
     });
   }
@@ -2650,6 +2664,14 @@ function aimUndoAtInstant(form, at) {
   if (!since) { toastError("Could not read the selected instant."); return; }
   form.elements.since.value = since;
   form.elements.until.value = "";
+  // Cleared for the same reason `until` is, and it became necessary with the
+  // same change that made `until` matter here: since #1404 the Undo bridge
+  // prefills limit_per_pk = 1, so an operator who used Undo first would arrive
+  // with a leftover cap. This action reverses EVERY change after `at` — that
+  // is what makes the row land on the state shown — and a cap of 1 would
+  // reverse only the newest of them and land it somewhere else entirely,
+  // silently, with the button still naming the state it did not produce.
+  form.elements.limit_per_pk.value = "";
   previewRecover(form);
   form.scrollIntoView({ behavior: prefersReducedMotion() ? "auto" : "smooth", block: "start" });
   toast("Undo window set to everything after " + at + " UTC");

--- a/internal/console/assets_recover_banner_test.go
+++ b/internal/console/assets_recover_banner_test.go
@@ -83,6 +83,21 @@ func TestAppJSUndoBannerStatesWhatIsReversed(t *testing.T) {
 			"reversal lands on the LAST change in that second, which need not be the clicked one — " +
 			"that is exactly the case this banner exists for, so the caveat is not optional.")
 	}
+
+	// (f) …and the OUTCOME of that imprecision, not only its mechanism. Stating
+	// "the last of them is the one reversed" is true and still leaves the
+	// reader to derive the inversion: on a row INSERTed and DELETEd inside one
+	// second the cap keeps the DELETE, so clicking Undo on the INSERT
+	// RE-CREATES the row instead of removing it — the opposite of the intent,
+	// with the badge above still reading INSERT. Review found this riding along
+	// undisclosed; deriving it is not the operator's job.
+	for _, want := range []string{"not necessarily the one you clicked", "comes back"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("the Undo banner dropped %q.\nDetail was: %s\n"+
+				"Without it the same-second caveat names a mechanism and hides the one outcome "+
+				"that is inverted from what the operator asked for.", want, detail)
+		}
+	}
 }
 
 // The banner is prose; this pins the behaviour it describes. They fail to
@@ -126,8 +141,22 @@ func TestUndoPrefillsLatestPerRow(t *testing.T) {
 // TRAILING comment on a gutted line (the strip only dropped whole-line
 // comments), and the stated reason for stripping at all was false — the
 // explanation it claimed to avoid firing on is lowercase and line-split, so it
-// never matched. Reading the actual `el(...)` calls removes the whole class:
-// comments, block or line, are simply not in the haystack.
+// never matched.
+//
+// Reading the `el(...)` calls was the right idea and the first version of it
+// only half-delivered: the eyebrow was parsed as a literal, but the DETAIL was
+// returned as a raw source slice from the first ctx-detail span to the end of
+// the append — so anything between the two spans, comments included, was back
+// in the haystack. That failed in both directions, and both were reproduced:
+// moving the required sentences into a comment above a gutted span kept the
+// guard GREEN over a banner that stated none of them, and adding one accurate
+// historical comment naming the old wording turned it RED over a correct
+// banner.
+//
+// So the haystack is now STRING LITERALS ONLY. A comment cannot appear inside
+// one, which retires the class rather than narrowing it — and a comment inside
+// a text expression, where a quote WOULD be scanned, is refused outright
+// instead of guessed at.
 func undoBannerText(t *testing.T) (eyebrow, detail string) {
 	t.Helper()
 	data, err := os.ReadFile("assets/app.js")
@@ -148,34 +177,92 @@ func undoBannerText(t *testing.T) (eyebrow, detail string) {
 	}
 	fn := js[start : start+end]
 
-	eyebrow = spanText(t, fn, "ctx-eyebrow")
-	// The detail is two spans; take everything from the first to the end of
-	// the append so both are covered.
-	i := strings.Index(fn, `class: "ctx-detail"`)
-	if i < 0 {
+	eyebrows := spanLiterals(t, fn, "ctx-eyebrow")
+	if len(eyebrows) == 0 {
+		t.Fatal("no ctx-eyebrow span in renderRecover — the Undo banner lost its heading")
+	}
+	details := spanLiterals(t, fn, "ctx-detail")
+	if len(details) == 0 {
 		t.Fatal("no ctx-detail span in renderRecover — the Undo banner lost its explanatory line")
 	}
-	j := strings.Index(fn[i:], "})));")
-	if j < 0 {
-		t.Fatal("could not find the end of the Undo banner's append")
-	}
-	return eyebrow, fn[i : i+j]
+	return eyebrows[0], strings.Join(details, " ")
 }
 
-// spanText pulls the literal text of `el("span", { class: "<cls>", text: "…" })`.
-func spanText(t *testing.T, fn, cls string) string {
+// spanLiterals returns, for every `el("span", { class: "<cls>", text: <expr> })`
+// in fn, the concatenation of the STRING LITERALS in that span's text
+// expression — dropping the interpolated identifiers, and structurally unable
+// to pick up a comment.
+//
+// Literal-only is the whole point. The first detail span reads
+// `"… holding this " + ctx.type + " (" + ctx.time + " UTC)"`, so a helper that
+// stops at the first closing quote truncates it, and one that slices raw
+// source to the end of the append swallows every comment in between. This
+// walks each text expression consuming quoted runs atomically and stopping at
+// the span's closing brace.
+func spanLiterals(t *testing.T, fn, cls string) []string {
 	t.Helper()
-	marker := `class: "` + cls + `", text: "`
-	i := strings.Index(fn, marker)
-	if i < 0 {
-		t.Fatalf("no %s span with a literal text in renderRecover", cls)
+	marker := `class: "` + cls + `"`
+	var out []string
+	for pos := 0; ; {
+		i := strings.Index(fn[pos:], marker)
+		if i < 0 {
+			return out
+		}
+		i += pos
+		k := strings.Index(fn[i:], "text:")
+		if k < 0 {
+			t.Fatalf("%s span at offset %d has no text: — this guard reads span text and found none", cls, i)
+		}
+		p := i + k + len("text:")
+		var b strings.Builder
+	scan:
+		for p < len(fn) {
+			switch fn[p] {
+			case '"':
+				lit, next := readJSString(t, fn, p)
+				b.WriteString(lit)
+				p = next
+			case '}':
+				break scan
+			case '/':
+				// A comment inside the text expression would put its quoted
+				// content into the haystack, which is exactly the defect this
+				// helper exists to retire. Refuse rather than guess.
+				if p+1 < len(fn) && (fn[p+1] == '/' || fn[p+1] == '*') {
+					t.Fatalf("a comment sits inside the %s span's text expression; move it above the "+
+						"el(...) call. Left here it lands in the guard's haystack and the guard "+
+						"stops meaning what it says.", cls)
+				}
+				p++
+			default:
+				p++
+			}
+		}
+		out = append(out, b.String())
+		pos = p
 	}
-	rest := fn[i+len(marker):]
-	j := strings.Index(rest, `"`)
-	if j < 0 {
-		t.Fatalf("unterminated text literal on the %s span", cls)
+}
+
+// readJSString consumes the double-quoted run starting at i and returns its
+// contents plus the offset just past the closing quote.
+func readJSString(t *testing.T, s string, i int) (string, int) {
+	t.Helper()
+	var b strings.Builder
+	for p := i + 1; p < len(s); p++ {
+		switch s[p] {
+		case '\\':
+			if p+1 < len(s) {
+				b.WriteByte(s[p+1])
+				p++
+			}
+		case '"':
+			return b.String(), p + 1
+		default:
+			b.WriteByte(s[p])
+		}
 	}
-	return rest[:j]
+	t.Fatalf("unterminated string literal at offset %d in renderRecover", i)
+	return "", len(s)
 }
 
 // The two bridges set opposite scopes on the SAME form, and #1404 is what put

--- a/internal/console/assets_recover_banner_test.go
+++ b/internal/console/assets_recover_banner_test.go
@@ -6,71 +6,114 @@ import (
 	"testing"
 )
 
-// The Restore "Undo" banner must describe the WINDOW it reverses, never a
-// target state and never a single event.
+// The Restore "Undo" banner must describe exactly what the generated script
+// reverses — and since #1404 that is ONE change, not a window.
 //
-// renderRecover's prefill sets `until` from the clicked event and never
-// `since`. `ctx.time` is second-granular (consoleTSFormat) and the predicate
-// is `event_timestamp <= ?`, so the ceiling is the END OF THAT SECOND: every
-// event on the row up to there is reversed, including ones that happened
-// AFTER the clicked event inside the same second.
+// The history is the point of the guard. renderRecover's prefill sets `until`
+// from the clicked event and never `since`, so the window ran from the
+// beginning of time: undoing the third of five changes to a row put it back to
+// before the FIRST. #1388 fixed the WORDING to match that behaviour; #1404
+// changed the behaviour instead, prefilling `limit_per_pk = 1` so the script
+// reverses the latest change at or before the ceiling.
 //
-// The failure is not hypothetical and not a corner case. A row INSERTed and
-// DELETEd inside one second (WordPress `_transient_doing_cron`) reverses BOTH
-// from either entry point, and the net effect is no row at all — correct for
-// the window, the opposite of what a banner naming one event announces.
-// `since` is no remedy there: it parses at the same granularity.
+// What did not change is the ceiling. `ctx.time` is second-granular
+// (consoleTSFormat) and the predicate is `event_timestamp <= ?`, so it is the
+// END of that second. On a row touched more than once inside it — a row
+// INSERTed and DELETEd in the same second, like WordPress
+// `_transient_doing_cron` — the reversal lands on the LAST of them, which need
+// not be the one the operator clicked. `since` is no remedy: it parses at the
+// same granularity. The banner has to say so.
 //
-// Two earlier drafts got this wrong in the same direction — "Reverting this
-// row to before this point" named a target state, then "Undoing every change
-// up to this point" named the clicked event as the boundary. Hence a guard.
-func TestAppJSUndoBannerStatesWindowScope(t *testing.T) {
+// Three drafts got this wrong in the same direction before the behaviour was
+// fixed: "Reverting this row to before this point" named a target state,
+// "Undoing every change up to this point" named the clicked event as the
+// boundary, and "Undoing every change in this window" was accurate only while
+// the whole history really was reversed. Hence a guard.
+func TestAppJSUndoBannerStatesWhatIsReversed(t *testing.T) {
 	eyebrow, detail := undoBannerText(t)
+	all := eyebrow + detail
 
-	// (a) The retired phrasings must not come back. Checked against the banner
-	// text ONLY — see undoBannerText: a needle in a comment can neither
-	// satisfy nor trip these.
-	for _, banned := range []string{
-		"Reverting this row to before this point",
-		"undoing changes up to ",
-		// Names the clicked event as the ceiling. It is not; the second is.
-		"up to this point",
+	// (a) Retired phrasings, including the one that was correct until the
+	// behaviour changed under it. Checked against the banner text ONLY — see
+	// undoBannerText: a needle in a comment can neither satisfy nor trip these.
+	for _, banned := range []struct{ text, why string }{
+		{"Reverting this row to before this point", "names a target state the script does not produce"},
+		{"up to this point", "names the clicked event as the ceiling; the ceiling is its whole second"},
+		{"Undoing every change", "the prefill reverses ONE change now, not every change on the row"},
+		{"not only that one", "was the whole-history caveat; with limit_per_pk=1 it is simply false"},
 	} {
-		if strings.Contains(eyebrow+detail, banned) {
-			t.Errorf("the Undo banner reintroduces %q.\n"+
-				"That phrasing makes the clicked event (or the state before it) the boundary. The window "+
-				"actually closes at the END of that event's second, and every event on the row up to there "+
-				"is reversed. State the window.", banned)
+		if strings.Contains(all, banned.text) {
+			t.Errorf("the Undo banner reintroduces %q — %s.\nBanner was: %s", banned.text, banned.why, all)
 		}
 	}
 
-	// (b) The eyebrow names a window, not a point.
-	if !strings.Contains(eyebrow, "window") {
-		t.Errorf("the Undo banner eyebrow no longer says it is undoing a window (%q) — "+
-			"without that word it reads as a single-event reversal, which is not what generateUndo does", eyebrow)
+	// (b) The eyebrow states the singular scope.
+	if !strings.Contains(eyebrow, "one change") {
+		t.Errorf("the Undo banner eyebrow no longer says it undoes ONE change (%q). With "+
+			"limit_per_pk prefilled to 1 that is what the script does, and an eyebrow promising a "+
+			"window would over-state the blast radius in the safe direction — which still teaches "+
+			"the operator to distrust the banner.", eyebrow)
 	}
 
-	// (c) The detail states the real ceiling and that the clicked event is not
-	// alone. Asserted as source fragments: the sentence is concatenated around
-	// ctx.type/ctx.time, so the rendered sentence never appears contiguously in
-	// the source and searching for it whole would fail on every run.
-	for _, want := range []string{"end of the second", "not only that one"} {
+	// (c) The ceiling is stated. Asserted as source fragments: the sentence is
+	// concatenated around ctx.type/ctx.time, so the rendered sentence never
+	// appears contiguously in the source.
+	for _, want := range []string{"latest change to this row", "end of the second"} {
 		if !strings.Contains(detail, want) {
-			t.Errorf("the Undo banner detail dropped %q.\n"+
-				"Detail was: %s\nA reader cannot tell how far the reversal reaches without it.", want, detail)
+			t.Errorf("the Undo banner detail dropped %q.\nDetail was: %s\n"+
+				"Without it a reader cannot tell which change is reversed, or how far the ceiling reaches.", want, detail)
 		}
 	}
 
-	// (d) Since is offered AND its limit is stated. Offering it alone is worse
-	// than silence on the motivating case: an operator narrows the window,
-	// gets the identical script, and concludes the tool is broken.
-	if !strings.Contains(detail, "Set Since to narrow the window") {
-		t.Error("the Undo banner no longer points at Since — stating the window is wide without naming " +
-			"the way to narrow it leaves the operator with a warning and no action")
+	// (d) The control is named AND its escape hatch is offered. A prefill the
+	// banner does not mention is a silent narrowing — the thing #1388 was
+	// about not doing.
+	if !strings.Contains(detail, "Latest per row is set to 1") {
+		t.Error("the Undo banner no longer states that Latest per row was prefilled. The prefill " +
+			"changes what the button reverses; leaving it unsaid makes it a silent narrowing.")
 	}
-	if !strings.Contains(detail, "second-granular") {
-		t.Error("the Undo banner points at Since without saying it cannot split events inside one second. " +
-			"That is exactly the case this banner exists for, so the caveat is not optional.")
+	if !strings.Contains(detail, "clear it") {
+		t.Error("the Undo banner states the prefill without saying how to undo it. The old " +
+			"whole-history behaviour is one cleared field away and the operator has to know that.")
+	}
+
+	// (e) The residual imprecision, which no control fixes.
+	if !strings.Contains(detail, "more than once inside that second") {
+		t.Error("the Undo banner dropped the same-second caveat. With a one-second ceiling the " +
+			"reversal lands on the LAST change in that second, which need not be the clicked one — " +
+			"that is exactly the case this banner exists for, so the caveat is not optional.")
+	}
+}
+
+// The banner is prose; this pins the behaviour it describes. They fail to
+// different edits — dropping the prefill leaves a banner promising something
+// the script no longer does, and nothing throws either way.
+func TestUndoPrefillsLatestPerRow(t *testing.T) {
+	data, err := os.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := string(data)
+	start := strings.Index(js, "function renderRecover(")
+	if start < 0 {
+		t.Fatal("renderRecover is gone from assets/app.js — this guard covers nothing")
+	}
+	end := strings.Index(js[start:], "\nfunction ")
+	if end < 0 {
+		end = len(js) - start
+	}
+	fn := stripJSCommentLines(js[start : start+end])
+
+	if !strings.Contains(fn, `form.elements.limit_per_pk.value = "1";`) {
+		t.Error("renderRecover's Undo prefill no longer sets limit_per_pk. Without it the window " +
+			"has no lower bound and no per-row cap, so the script reverses the row's ENTIRE history " +
+			"up to the clicked second — the #1404 defect — while the banner still says one change.")
+	}
+	// The ceiling has to survive alongside it: limit_per_pk without `until`
+	// would reverse the row's most recent change, not the clicked one.
+	if !strings.Contains(fn, "form.elements.until.value = ctx.time;") {
+		t.Error("renderRecover's Undo prefill no longer sets `until`. Paired with limit_per_pk=1 " +
+			"that reverses the row's LATEST change instead of the one the operator clicked.")
 	}
 }
 
@@ -133,4 +176,43 @@ func spanText(t *testing.T, fn, cls string) string {
 		t.Fatalf("unterminated text literal on the %s span", cls)
 	}
 	return rest[:j]
+}
+
+// The two bridges set opposite scopes on the SAME form, and #1404 is what put
+// them in conflict: Undo now prefills a per-row cap of 1, while
+// "Restore to this state" reverses every change after an instant — which is
+// the only reason the row lands on the state the button names.
+//
+// An operator who uses Undo and then Restore-to-this-state arrives with the
+// leftover cap. The result is a row left in a state nobody asked for, with no
+// error and a button still naming the state it did not produce. This is the
+// same class as the leftover `until` the function already clears, and it is
+// pinned because the two clears look like boilerplate and read as removable.
+func TestRestoreToStateClearsTheUndoBridgesPerRowCap(t *testing.T) {
+	data, err := os.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := string(data)
+	start := strings.Index(js, "function aimUndoAtInstant(")
+	if start < 0 {
+		t.Fatal("aimUndoAtInstant is gone from assets/app.js — this guard covers nothing")
+	}
+	end := strings.Index(js[start:], "\nfunction ")
+	if end < 0 {
+		end = len(js) - start
+	}
+	fn := stripJSCommentLines(js[start : start+end])
+
+	for _, want := range []struct{ line, why string }{
+		{`form.elements.limit_per_pk.value = "";`,
+			"a cap inherited from the Undo bridge reverses only the newest change after the instant, so the row does not land on the state shown"},
+		{`form.elements.until.value = "";`,
+			"a leftover upper bound silently drops the newest damage from the window"},
+	} {
+		if !strings.Contains(fn, want.line) {
+			t.Errorf("aimUndoAtInstant no longer clears a field the other bridge sets: missing %q.\n%s",
+				want.line, want.why)
+		}
+	}
 }

--- a/internal/console/assets_recover_banner_test.go
+++ b/internal/console/assets_recover_banner_test.go
@@ -100,6 +100,37 @@ func TestAppJSUndoBannerStatesWhatIsReversed(t *testing.T) {
 	}
 }
 
+// The other half of the retirement, and it fails SILENTLY on its own: the
+// removal above looks up "undo-ctx-banner", so dropping the id from the node
+// leaves getElementById returning null, the `if` short-circuiting, and the
+// banner surviving with nothing anywhere reporting it. Review demonstrated
+// exactly that mutation passing the whole package.
+//
+// The id is checked, not the class: generateUndo appends a SECOND .ctx-banner
+// into #recover-out for the cascade notice, so an unscoped removal would take
+// whichever came first.
+func TestUndoBannerCarriesTheIdItIsRetiredBy(t *testing.T) {
+	data, err := os.ReadFile("assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := string(data)
+	start := strings.Index(js, "function renderRecover(")
+	if start < 0 {
+		t.Fatal("renderRecover is gone from assets/app.js — this guard covers nothing")
+	}
+	end := strings.Index(js[start:], "\nfunction ")
+	if end < 0 {
+		end = len(js) - start
+	}
+	fn := stripJSCommentLines(js[start : start+end])
+	if !strings.Contains(fn, `id: "undo-ctx-banner"`) {
+		t.Error(`the Undo banner no longer carries id: "undo-ctx-banner". aimUndoAtInstant removes ` +
+			"it by that id when it replaces the scope the banner describes; without it that removal " +
+			"is a no-op and the stale banner stays on screen, with no error anywhere.")
+	}
+}
+
 // The banner is prose; this pins the behaviour it describes. They fail to
 // different edits — dropping the prefill leaves a banner promising something
 // the script no longer does, and nothing throws either way.
@@ -197,8 +228,19 @@ func undoBannerText(t *testing.T) (eyebrow, detail string) {
 // `"… holding this " + ctx.type + " (" + ctx.time + " UTC)"`, so a helper that
 // stops at the first closing quote truncates it, and one that slices raw
 // source to the end of the append swallows every comment in between. This
-// walks each text expression consuming quoted runs atomically and stopping at
-// the span's closing brace.
+// walks each text expression consuming quoted runs atomically.
+//
+// It stops at the end of the EXPRESSION — a top-level comma or closing brace —
+// not merely at the next `}`. The first version stopped at `}` alone, and
+// review showed that is not the same thing: the scan ran on past `text:` into
+// every later literal of the same object, so moving the required sentences
+// into a sibling `title:` (which el() sets as an attribute, not as visible
+// text) kept the guard GREEN over a banner reading "See tooltip." — the exact
+// class the literal-only rewrite was supposed to retire, just one property
+// over. A probe with `text:` written before `class:` made the reach visible:
+// the extracted "detail" picked up `text: "Clear"` from the button below AND
+// the "recover" literal from inside its onclick arrow body, because `{` never
+// stopped the scan.
 func spanLiterals(t *testing.T, fn, cls string) []string {
 	t.Helper()
 	marker := `class: "` + cls + `"`
@@ -215,6 +257,7 @@ func spanLiterals(t *testing.T, fn, cls string) []string {
 		}
 		p := i + k + len("text:")
 		var b strings.Builder
+		depth := 0
 	scan:
 		for p < len(fn) {
 			switch fn[p] {
@@ -222,8 +265,28 @@ func spanLiterals(t *testing.T, fn, cls string) []string {
 				lit, next := readJSString(t, fn, p)
 				b.WriteString(lit)
 				p = next
+			case '(', '[':
+				depth++
+				p++
+			case ')', ']':
+				depth--
+				p++
+			case ',':
+				// Top-level comma ends the property's value. Inside a call's
+				// argument list it does not, hence the depth counter.
+				if depth <= 0 {
+					break scan
+				}
+				p++
+			case '{':
+				depth++
+				p++
 			case '}':
-				break scan
+				if depth <= 0 {
+					break scan
+				}
+				depth--
+				p++
 			case '/':
 				// A comment inside the text expression would put its quoted
 				// content into the haystack, which is exactly the defect this
@@ -296,6 +359,15 @@ func TestRestoreToStateClearsTheUndoBridgesPerRowCap(t *testing.T) {
 			"a cap inherited from the Undo bridge reverses only the newest change after the instant, so the row does not land on the state shown"},
 		{`form.elements.until.value = "";`,
 			"a leftover upper bound silently drops the newest damage from the window"},
+		// The label, not a field — and it is a claim about the fields above.
+		// The banner states "Latest per row is set to 1" as a fact about this
+		// form; the first clear in this list makes that false, so leaving it up
+		// shows a one-change scope over a script that reverses everything after
+		// the instant.
+		{`pendingRecover = null;`,
+			"renderRecover rebuilds the banner from pendingRecover, so leaving it set puts the contradicting banner back on the next render"},
+		{`document.getElementById("undo-ctx-banner")`,
+			"the banner already on screen is not removed, so it outlives the scope it describes"},
 	} {
 		if !strings.Contains(fn, want.line) {
 			t.Errorf("aimUndoAtInstant no longer clears a field the other bridge sets: missing %q.\n%s",

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1262,6 +1262,18 @@ try {
   // plus a navigate — rather than by calling the prefill, since the prefill
   // runs inside setSelectWhenReady's schema callback and a direct call would
   // skip the path that can actually break.
+  //
+  // And watch the POST while it happens. Every other check here reads
+  // `limit_per_pk` off the form, which is order-blind: swapping the prefill
+  // and the generateUndo call beneath it restores the original #1404 defect —
+  // a request with no cap — while leaving the field holding "1" by the time
+  // anything polls it. generateUndo snapshots the form synchronously at entry,
+  // so the only witness that dies on that swap is the body it sent.
+  const sentBodies = [];
+  await page.route("**/api/recover", async (route) => {
+    sentBodies.push(route.request().postData() || "");
+    await route.continue();
+  });
   const undoBridge = await page.evaluate(async (fixSchema) => {
     // Snapshot every field, not the schema alone: the scenarios below inherit
     // whatever this form already held (the timeline one sets only `pk` and
@@ -1289,17 +1301,55 @@ try {
   (undoBridge.cap === "1" && undoBridge.until === "2026-01-01 00:00:00")
     ? ok("restore: the Undo bridge prefills a per-row cap of 1 alongside the ceiling")
     : bad("restore: the Undo bridge prefills a per-row cap of 1 alongside the ceiling", JSON.stringify(undoBridge));
+  // Give the generate its POST, then stop intercepting.
+  for (let i = 0; i < 40 && !sentBodies.length; i++) await new Promise((r) => setTimeout(r, 100));
+  await page.unroute("**/api/recover");
+  {
+    const parsed = sentBodies.map((b) => { try { return JSON.parse(b); } catch { return {}; } });
+    const capped = parsed.filter((b) => b.limit_per_pk === 1);
+    (sentBodies.length > 0 && capped.length === parsed.length)
+      ? ok("restore: the Undo bridge's generate SENDS limit_per_pk — the cap is on the wire, not just in the field")
+      : bad("restore: the Undo bridge's generate SENDS limit_per_pk — the cap is on the wire, not just in the field",
+            JSON.stringify({ sent: sentBodies }));
+  }
   // The prefill changes what the button reverses, so the banner has to say it.
   // A prefill the banner does not mention is a silent narrowing.
   (/one change/.test(undoBridge.eyebrow) && /Latest per row is set to 1/.test(undoBridge.detail) && /clear it/.test(undoBridge.detail))
     ? ok("restore: the Undo banner states the cap it prefilled and how to clear it")
     : bad("restore: the Undo banner states the cap it prefilled and how to clear it", JSON.stringify(undoBridge));
+  // The two bridges collide one level above the fields. With the Undo banner
+  // on screen — the only place in the run where it really is — driving
+  // "Restore to this state" must retire it: the banner states "Latest per row
+  // is set to 1" as a fact about this form, and that action clears the field.
+  // Left up, the operator reads a one-change scope over a script that reverses
+  // everything after the instant.
+  const staleBanner = await page.evaluate(async () => {
+    const f = document.getElementById("recover-form");
+    const before = !!document.getElementById("undo-ctx-banner");
+    f.elements.pk.value = "1";
+    await runState(f, false);
+    const btn = document.querySelector(".state-actions .btn-primary");
+    if (!btn) return { err: "no Restore-to-this-state button on a found row" };
+    btn.click();
+    return { before, after: !!document.getElementById("undo-ctx-banner"),
+             cap: f.elements.limit_per_pk.value };
+  });
+  if (staleBanner.err) {
+    bad("restore: 'Restore to this state' retires the Undo banner it contradicts", staleBanner.err);
+  } else {
+    // `before` is asserted too: if the banner were never up, `after === false`
+    // would pass while proving nothing.
+    (staleBanner.before === true && staleBanner.after === false && staleBanner.cap === "")
+      ? ok("restore: 'Restore to this state' retires the Undo banner it contradicts")
+      : bad("restore: 'Restore to this state' retires the Undo banner it contradicts", JSON.stringify(staleBanner));
+  }
+
   // Leave the page as this scenario found it. pendingRecover survives a
   // re-render, and the prefilled cap makes every later generate 400 with
   // "the latest-per-row filter needs a PK" the moment a scenario clears the PK
   // — which is a correct server refusal and a wrong reason for fourteen
   // unrelated checks to go red.
-  await page.evaluate(async (fixSchema) => {
+  const undoRestore = await page.evaluate(async (fixSchema) => {
     pendingRecover = null;
     navigate("recover");
     for (let i = 0; i < 40; i++) {
@@ -1308,7 +1358,7 @@ try {
       await new Promise((r) => setTimeout(r, 100));
     }
     const f = document.getElementById("recover-form");
-    if (!f || !window.__preUndo) return;
+    if (!f || !window.__preUndo) return { schemaReady: false, want: null, got: null };
     // Schema first and on its own tick: the cascade listener repopulates the
     // table datalist and CLEARS a stale table value, so restoring table before
     // the cascade settles loses it again.
@@ -1317,15 +1367,25 @@ try {
     // value the select does not yet carry silently leaves it blank — which is
     // what the Time-travel scenarios below then read as "no rows". The app
     // already owns this wait; using it is also what the real prefill does.
-    await new Promise((resolve) => {
-      setSelectWhenReady(f, "schema", fixSchema, resolve);
-      setTimeout(resolve, 5000);
+    const schemaReady = await new Promise((resolve) => {
+      setSelectWhenReady(f, "schema", fixSchema, () => resolve(true));
+      setTimeout(() => resolve(false), 5000);
     });
     await new Promise((r) => setTimeout(r, 300));
     for (const n of ["table", "pk", "limit_per_pk", "since", "until"]) {
       if (f.elements[n]) f.elements[n].value = window.__preUndo[n] || "";
     }
+    // Report what the restore actually achieved instead of proceeding as if it
+    // had. The schema is compared against the SNAPSHOT, not against fixSchema:
+    // reinstalling a hardcoded value while claiming to restore is how this
+    // silently installs the wrong schema the day a preceding scenario picks
+    // another one.
+    return { schemaReady, want: window.__preUndo.schema, got: f.elements.schema.value };
   }, FIX);
+  (undoRestore && undoRestore.schemaReady && undoRestore.got === undoRestore.want)
+    ? ok("restore: the Undo scenario hands the form back as it found it")
+    : bad("restore: the Undo scenario hands the form back as it found it — the checks below inherit it",
+          JSON.stringify(undoRestore));
 
   // The timeline is how an operator picks an instant without leaving to read
   // one off Events. Its own restore button used to route through undoEvent,

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1234,8 +1234,11 @@ try {
     const btn = document.querySelector(".state-actions .btn-primary");
     if (!btn) return { err: "no Restore-to-this-state button on a found row" };
     const at = (document.querySelector("#state-out .meta-line") || {}).textContent || "";
+    // Arrive carrying the Undo bridge's per-row cap, which is what an operator
+    // who used Undo first would have in the field.
+    f.elements.limit_per_pk.value = "1";
     btn.click();
-    return { since: f.elements.since.value, until: f.elements.until.value, at };
+    return { since: f.elements.since.value, until: f.elements.until.value, cap: f.elements.limit_per_pk.value, at };
   });
   {
     const m = /as of (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/.exec(bridge.at || "");
@@ -1243,7 +1246,86 @@ try {
     (want && bridge.since === want && bridge.until === "")
       ? ok("restore: 'Restore to this state' sets the undo window to at+1s")
       : bad("restore: 'Restore to this state' sets the undo window to at+1s", JSON.stringify({ ...bridge, want }));
+    // The two bridges set opposite scopes on one form. This action reverses
+    // EVERY change after the instant — that is what makes the row land on the
+    // state shown — so a cap inherited from Undo would reverse only the newest
+    // and land it elsewhere, silently, with the button still naming the state
+    // it did not produce.
+    bridge.cap === ""
+      ? ok("restore: 'Restore to this state' clears the Undo bridge's per-row cap")
+      : bad("restore: 'Restore to this state' clears the Undo bridge's per-row cap", `limit_per_pk=${bridge.cap}`);
   }
+
+  // The other direction: arriving through Undo must land the cap in the field,
+  // because that prefill is what makes the button reverse ONE change instead
+  // of the row's whole history. Driven through the real bridge — pendingRecover
+  // plus a navigate — rather than by calling the prefill, since the prefill
+  // runs inside setSelectWhenReady's schema callback and a direct call would
+  // skip the path that can actually break.
+  const undoBridge = await page.evaluate(async (fixSchema) => {
+    // Snapshot every field, not the schema alone: the scenarios below inherit
+    // whatever this form already held (the timeline one sets only `pk` and
+    // relies on schema+table being filled), and a re-render blanks all of it.
+    {
+      const f0 = document.getElementById("recover-form");
+      window.__preUndo = {};
+      if (f0) for (const n of ["schema", "table", "pk", "limit_per_pk", "since", "until"]) {
+        window.__preUndo[n] = f0.elements[n] ? f0.elements[n].value : "";
+      }
+    }
+    pendingRecover = { schema: fixSchema, table: "orders", pk: "1", type: "update", time: "2026-01-01 00:00:00" };
+    navigate("recover");
+    for (let i = 0; i < 40; i++) {
+      const f = document.getElementById("recover-form");
+      if (f && f.elements.pk.value === "1") break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    const f = document.getElementById("recover-form");
+    if (!f) return { err: "no recover form" };
+    const eyebrow = (document.querySelector(".ctx-banner .ctx-eyebrow") || {}).textContent || "";
+    const detail = Array.from(document.querySelectorAll(".ctx-banner .ctx-detail")).map((n) => n.textContent).join(" ");
+    return { cap: f.elements.limit_per_pk.value, until: f.elements.until.value, eyebrow, detail };
+  }, FIX);
+  (undoBridge.cap === "1" && undoBridge.until === "2026-01-01 00:00:00")
+    ? ok("restore: the Undo bridge prefills a per-row cap of 1 alongside the ceiling")
+    : bad("restore: the Undo bridge prefills a per-row cap of 1 alongside the ceiling", JSON.stringify(undoBridge));
+  // The prefill changes what the button reverses, so the banner has to say it.
+  // A prefill the banner does not mention is a silent narrowing.
+  (/one change/.test(undoBridge.eyebrow) && /Latest per row is set to 1/.test(undoBridge.detail) && /clear it/.test(undoBridge.detail))
+    ? ok("restore: the Undo banner states the cap it prefilled and how to clear it")
+    : bad("restore: the Undo banner states the cap it prefilled and how to clear it", JSON.stringify(undoBridge));
+  // Leave the page as this scenario found it. pendingRecover survives a
+  // re-render, and the prefilled cap makes every later generate 400 with
+  // "the latest-per-row filter needs a PK" the moment a scenario clears the PK
+  // — which is a correct server refusal and a wrong reason for fourteen
+  // unrelated checks to go red.
+  await page.evaluate(async (fixSchema) => {
+    pendingRecover = null;
+    navigate("recover");
+    for (let i = 0; i < 40; i++) {
+      const f = document.getElementById("recover-form");
+      if (f && !document.querySelector(".ctx-banner")) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    const f = document.getElementById("recover-form");
+    if (!f || !window.__preUndo) return;
+    // Schema first and on its own tick: the cascade listener repopulates the
+    // table datalist and CLEARS a stale table value, so restoring table before
+    // the cascade settles loses it again.
+    // Through setSelectWhenReady, not by assigning .value: populateSchemas
+    // fills the options asynchronously after the re-render, and assigning a
+    // value the select does not yet carry silently leaves it blank — which is
+    // what the Time-travel scenarios below then read as "no rows". The app
+    // already owns this wait; using it is also what the real prefill does.
+    await new Promise((resolve) => {
+      setSelectWhenReady(f, "schema", fixSchema, resolve);
+      setTimeout(resolve, 5000);
+    });
+    await new Promise((r) => setTimeout(r, 300));
+    for (const n of ["table", "pk", "limit_per_pk", "since", "until"]) {
+      if (f.elements[n]) f.elements[n].value = window.__preUndo[n] || "";
+    }
+  }, FIX);
 
   // The timeline is how an operator picks an instant without leaving to read
   // one off Events. Its own restore button used to route through undoEvent,


### PR DESCRIPTION
Closes #1404.

Clicking Undo on an event prefilled `until` and nothing else, so the window ran
from the beginning of time: undoing the third of five changes to a row put it
back to before the FIRST. #1388 fixed the WORDING to match that; this changes
the behaviour instead. The prefill now sets `limit_per_pk = 1`, so the script
reverses the latest change at or before the ceiling — which is what "Undo this
change" means.

It also stops the request being unboundedly expensive. With no lower bound the
planner covers every archived hour: measured on an index with ~1200 of them,
27.6s to produce one statement. Paired with #1403 the same reversal is answered
from the live index.

Prefilled rather than hardcoded. The value lands in a visible, editable field
and the banner states it, so widening the scope is one edit away and narrowing
it was never a silent act — which is the thing #1388 was about not doing.
Clearing the field restores the old whole-history behaviour exactly.

The banner says what is left imprecise instead of smoothing it: the ceiling is
still a whole second, so on a row touched more than once inside it the reversal
lands on the LAST of them, which need not be the one the operator clicked.
Since is no remedy — it parses at the same granularity.

The interaction worth reviewing hardest is not the prefill itself. Two bridges
now set OPPOSITE scopes on the same form: Undo caps at one change, while
"Restore to this state" reverses every change after an instant — and reversing
every one is precisely what makes the row land on the state the button names.
An operator who used Undo first arrived carrying the cap, and the result would
be a row left somewhere nobody asked for, with no error and the button still
naming the state it did not produce. aimUndoAtInstant now clears the cap for
the same reason it already cleared `until`, and both clears are pinned — they
look like boilerplate and read as removable.

Seven mutations: dropping the prefill, dropping the ceiling, reverting each of
the three banner claims, and dropping the cross-bridge clear each fail;
rewording a comment does not.

The console-e2e diff is larger than the feature because the new leg drives the
real bridge — pendingRecover plus a navigate, not a direct call to the prefill,
since the prefill runs inside setSelectWhenReady's schema callback and calling
it directly would skip the path that can break. Driving it re-renders the
shared form, and fourteen later scenarios inherit that form; the leg therefore
snapshots and restores it. Restoring the schema needs setSelectWhenReady rather
than an assignment, because populateSchemas fills the options after the
re-render and assigning a value the select does not yet carry silently leaves
it blank.

One consequence worth naming: the cap is sticky within a rendered form, so
clearing the PK after an Undo now trips the server's existing refusal, "the
latest-per-row filter needs a PK". That is an actionable 4xx rather than a
wrong result, and it is the same guard that has always protected the pair.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>