### PR TITLE
console: show a row's state and history in a dialog

### DIFF
--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2641,7 +2641,7 @@ async function runState(form, history) {
     const mwarns = el("div", { class: "warnings" });
     dlg.body.append(mwarns);
     renderWarnings(mwarns, data.warnings);
-    if (history) renderTimeline(dlg.body, data);
+    if (history) renderTimeline(dlg.body, data, dlg.close);
     else {
       renderStateAt(dlg.body, data);
       // The action retargets the form UNDERNEATH this dialog, so the dialog
@@ -2782,6 +2782,12 @@ function renderTimetravel(params) {
   viewEnter();
 }
 
+// runReconstruct is the standalone Time-travel view, NOT the Restore view's
+// embedded panel. It renders inline and keeps doing so: #1405 moved runState
+// into a dialog because its output was wedged between a filter form and the
+// reversal panel it was pushing off screen. Here the reconstructed state IS
+// the page, with nothing below it to displace, so a dialog would add a scrim
+// and buy nothing.
 async function runReconstruct(form, history) {
   const gen = serverGen;
   const warns = $("#tt-warnings", VIEW());
@@ -2827,7 +2833,12 @@ function stateTable(state) {
   return table;
 }
 
-function renderTimeline(container, data) {
+// onDone, when given, is the caller's dismissal — the timeline is rendered
+// into a dialog from runState and inline from runReconstruct, and only the
+// first has anything to close. Each node carries its OWN restore button, so
+// unlike the state panel there is no single footer to pin outside the scroll;
+// the button travels with the node it names, which is where it belongs.
+function renderTimeline(container, data, onDone) {
   const entries = data.history || [];
   container.append(reconstructMeta(data, "history through " + data.at + " · " + entries.length + " state(s)"));
   if (!entries.length) { container.append(el("div", { class: "deleted-note", text: "No history for this primary key in the time range that's been indexed." })); return; }
@@ -2877,6 +2888,13 @@ function renderTimeline(container, data) {
         class: "btn btn-sm tl-restore", type: "button", text: "Restore to this state",
         title: "Reverse every change after " + e.time + " UTC, leaving the row as shown here",
         onclick: () => {
+          // Same reason the state panel's action closes first: aimUndoAtInstant
+          // scrolls the form into view and previews the rows, and both are
+          // invisible behind a scrim. This one used to be carried by accident —
+          // previewRecover's busy dialog happens to replace the mount — which
+          // held right up until previewRecover took one of its two early
+          // returns and left the error rendering behind the scrim.
+          if (onDone) onDone();
           const form = document.getElementById("recover-form");
           if (form) aimUndoAtInstant(form, e.time);
         },

--- a/internal/console/assets/app.js
+++ b/internal/console/assets/app.js
@@ -2615,20 +2615,54 @@ async function runState(form, history) {
   const atVal = atField && atField.value.trim();
   if (atVal) params.at = atVal;
   if (history) params.history = "true";
+  clear(out);
+  clear(warns);
   try {
     const data = await api("/api/reconstruct?" + new URLSearchParams(params).toString());
     if (gen !== serverGen) return;
-    renderWarnings(warns, data.warnings);
-    clear(out);
-    if (history) renderTimeline(out, data);
+    // Into a modal, not between the filter form and the reversal panel
+    // (#1405). The output is unbounded — a busy row's history is a long table
+    // — and it is consulted on the way to the script, so rendering it inline
+    // pushed the artifact the page exists to produce off screen.
+    //
+    // The WARNINGS come with it. They used to render into a sibling container
+    // that would now sit behind the scrim, and a reconstruct can return
+    // stale_baseline or a capture-gap caveat: an operator reading a row state
+    // with the caveat hidden behind the dialog is worse off than before this
+    // change, not better.
+    const dlg = openModal({
+      class: "state-modal",
+      label: history ? "Row history" : "Row at a point in time",
+      title: f.schema + "." + f.table + " · pk " + f.pk,
+      desc: [history
+        ? "Every recorded change to this row, newest last."
+        : "The row as of " + (atVal || "now") + " UTC — your latest snapshot plus every change since."],
+    });
+    const mwarns = el("div", { class: "warnings" });
+    dlg.body.append(mwarns);
+    renderWarnings(mwarns, data.warnings);
+    if (history) renderTimeline(dlg.body, data);
     else {
-      renderStateAt(out, data);
-      out.append(restoreToStateAction(form, data));
+      renderStateAt(dlg.body, data);
+      // The action retargets the form UNDERNEATH this dialog, so the dialog
+      // has to get out of the way — leaving it open hides the change it just
+      // made, which is the same complaint that moved this output in here.
+      const action = restoreToStateAction(form, data, dlg.close);
+      // Empty on a not-found/deleted row, and an empty footer is a stray
+      // divider with padding under it, so only mount one that has a button.
+      if (action.firstChild) dlg.panel.append(action);
     }
   } catch (err) {
     if (gen !== serverGen) return;
-    clear(warns);
-    renderError(out, err);
+    // The fetch failed rather than the form being wrong, so the answer belongs
+    // where the answer would have been. A 422 gap refusal is a result about
+    // the request, not a hint about the fields.
+    const dlg = openModal({
+      class: "state-modal",
+      label: history ? "Row history" : "Row at a point in time",
+      title: f.schema + "." + f.table + " · pk " + f.pk,
+    });
+    renderError(dlg.body, err);
   }
 }
 
@@ -2668,13 +2702,18 @@ function aimUndoAtInstant(form, at) {
 // these indexes routinely carry dozens (a single write burst stamps them all
 // alike). Until is cleared for the same reason it is set by the Undo bridge:
 // a leftover upper bound would silently drop the newest damage from the window.
-function restoreToStateAction(form, data) {
+function restoreToStateAction(form, data, onDone) {
   const row = el("div", { class: "state-actions" });
   if (!data.found) return row;
   row.append(el("button", {
     class: "btn btn-primary", type: "button", text: "Restore to this state",
     title: "Reverse every change after " + data.at + " UTC, leaving the row exactly as shown",
-    onclick: () => aimUndoAtInstant(form, data.at),
+    onclick: () => {
+      // Close BEFORE retargeting: aimUndoAtInstant scrolls the form into view
+      // and previews the rows, and both are invisible behind a scrim.
+      if (onDone) onDone();
+      aimUndoAtInstant(form, data.at);
+    },
   }));
   row.append(el("span", { class: "state-actions-note", text:
     "Sets the undo window to every change after this instant. Review the rows, then generate the SQL." }));
@@ -4228,6 +4267,52 @@ async function openVerifyExplain(id, schema, table, btn) {
 }
 
 function closeVerifyExplain() { document.getElementById("modal").replaceChildren(); }
+
+// openModal builds the scrim/panel/head boilerplate the console's dialogs all
+// repeat, and returns the body to fill plus the close it wired.
+//
+// Extracted rather than copied a seventh time (#1405), and it has ONE caller
+// today — which is worth stating plainly rather than dressing up as a shared
+// abstraction.
+//
+// The six existing dialogs are not migrated, and the reason is structural, not
+// caution: they append their body, footer and extras as SIBLINGS of the panel,
+// while this returns a body div nested inside it. Adopting it would move their
+// content one level deeper and put their .modal-foot and body rules on
+// different ancestors — a DOM change to working recovery-adjacent UI, for
+// tidiness, with no browser coverage of most of them to catch a layout break.
+//
+// What it does own is the part that is genuinely identical everywhere: the
+// mount, the scrim, scrim-click dismissal, the ✕, and the focus handoff.
+// Escape still comes from globalKeydown keyed off the shared #modal slot, so
+// nothing here re-implements it.
+function openModal(opts) {
+  const mount = document.getElementById("modal");
+  const scrim = el("div", { class: "modal-scrim show" });
+  const modal = el("div", { class: "modal" + (opts.class ? " " + opts.class : ""),
+    role: "dialog", "aria-label": opts.label });
+  const close = () => {
+    if (mount) mount.replaceChildren();
+    if (opts.onClose) opts.onClose();
+  };
+  const head = el("div", { class: "modal-head" });
+  if (opts.title) head.append(el("h2", { class: "modal-title", text: opts.title }));
+  for (const d of opts.desc || []) head.append(el("p", { class: "modal-desc", text: d }));
+  head.append(el("button", { class: "modal-x", type: "button", text: "✕", onclick: close }));
+  modal.append(head);
+  const body = el("div", { class: "modal-body" });
+  modal.append(body);
+  scrim.append(modal);
+  scrim.addEventListener("click", (e) => { if (e.target === scrim) close(); });
+  if (mount) mount.replaceChildren(scrim);
+  focusModal(scrim);
+  // The PANEL comes back alongside the body because a footer must not live
+  // inside a scrolling body: a wide row's state table is taller than the
+  // viewport, and an action rendered after it scrolls out of reach. Callers
+  // append their own .modal-foot-ish row as a sibling, which is also how the
+  // dialogs this did not absorb are built.
+  return { body, panel: modal, close };
+}
 
 // focusModal moves keyboard focus into a freshly-opened dialog (#968): the
 // first form field when there is one, else the first button (usually the ✕

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1498,6 +1498,14 @@ button { font-family: inherit; }
 .state-actions { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; margin-top: 14px; }
 .state-actions-note { color: var(--ink-3); font-size: 12.5px; }
 
+/* Time-travel results render in a dialog (#1405). The body scrolls because a
+   wide row's state table and a busy row's timeline are both unbounded; the
+   action row sits OUTSIDE that scroll, so "Restore to this state" stays
+   reachable however long the content is. */
+.state-modal { max-width: 940px; }
+.state-modal .modal-body { max-height: 58vh; overflow-y: auto; }
+.state-modal .state-actions { margin-top: 0; padding: 14px 28px 20px; border-top: 1px solid var(--line); }
+
 /* responsive-ish */
 @media (max-width: 880px) {
   #app { grid-template-columns: 1fr; }

--- a/internal/console/assets/style.css
+++ b/internal/console/assets/style.css
@@ -1499,9 +1499,15 @@ button { font-family: inherit; }
 .state-actions-note { color: var(--ink-3); font-size: 12.5px; }
 
 /* Time-travel results render in a dialog (#1405). The body scrolls because a
-   wide row's state table and a busy row's timeline are both unbounded; the
-   action row sits OUTSIDE that scroll, so "Restore to this state" stays
-   reachable however long the content is. */
+   wide row's state table and a busy row's timeline are both unbounded.
+
+   The pinned footer applies to SHOW STATE only, and saying otherwise was a
+   local truth written as a global one. Show state has one action for the whole
+   result, so leaving it after a 40-column table would put it below the fold
+   exactly when the table is long — it belongs outside the scroll. Show history
+   has no single action: every node carries its own restore button, which
+   travels with the node it names and is meaningless detached from it. Those
+   scroll with their nodes by design. */
 .state-modal { max-width: 940px; }
 .state-modal .modal-body { max-height: 58vh; overflow-y: auto; }
 .state-modal .state-actions { margin-top: 0; padding: 14px 28px 20px; border-top: 1px solid var(--line); }

--- a/internal/console/assets_state_modal_test.go
+++ b/internal/console/assets_state_modal_test.go
@@ -119,9 +119,7 @@ func TestStateResultsRenderInDialog(t *testing.T) {
 	// weakened by the next person to hit it, so the literals are blanked (not
 	// removed: blanking preserves every offset, so the reported line is still
 	// the real one).
-	code := regexp.MustCompile(`"[^"\n]*"`).ReplaceAllStringFunc(region, func(s string) string {
-		return `"` + strings.Repeat(" ", len(s)-2) + `"`
-	})
+	code := blankStringLiterals(region)
 	inline := regexp.MustCompile(`\b(out|warns)\b`)
 	for _, m := range inline.FindAllStringIndex(code, -1) {
 		// clear(out) / clear(warns) are the permitted mentions.
@@ -140,7 +138,14 @@ func TestStateResultsRenderInDialog(t *testing.T) {
 	// name only inside a string, where the identifier scan can no longer see
 	// it. Narrowing a guard is how false negatives get in.
 	for _, id := range []string{"state-out", "state-warnings"} {
-		if strings.Contains(region, `"`+id+`"`) {
+		// Bare, not quote-wrapped. A CSS selector puts a `#` in front of the id
+		// — `$("#state-out", VIEW())`, which is runState's own first line and
+		// this file's idiom for the lookup — so requiring the quote directly
+		// before the name missed the exact shape this check is named after.
+		// Neither pass saw it: the identifier scan had already blanked the
+		// literal. Hyphenated names cannot appear as JS identifiers, so
+		// dropping the anchor costs no precision.
+		if strings.Contains(region, id) {
 			t.Errorf("runState: %q is looked up again after the validation return. Those "+
 				"containers hold the form-validation refusal only; a result sent back to one "+
 				"lands under the filter form (#1405).", id)
@@ -193,6 +198,47 @@ func cssRule(t *testing.T, css, selector string) string {
 		t.Fatalf("style.css: no rule for %q", selector)
 	}
 	return m[1]
+}
+
+// blankStringLiterals replaces the CONTENTS of every quoted run with spaces,
+// preserving length so reported offsets stay real.
+//
+// A regex was tried first and was not enough. `"[^"\n]*"` mis-pairs across an
+// escaped quote and across a single-quoted string that contains double quotes,
+// letting prose back into the identifier scan — and the second shape already
+// exists in this function (`$('[name="state_at"]', VIEW())`). Both were shown
+// producing the fabricated alarm the blanking exists to stop.
+//
+// One property to preserve if this is touched: the scanned region begins
+// MID-LITERAL, because runStateAfterValidation splits on a fragment of the
+// validation message, so the opening quote of that literal is outside the
+// region. Closing an unterminated run at the newline instead of swallowing the
+// rest of the function is what makes that safe.
+func blankStringLiterals(s string) string {
+	out := []byte(s)
+	for i := 0; i < len(out); i++ {
+		q := out[i]
+		if q != '"' && q != '\'' && q != '`' {
+			continue
+		}
+		for j := i + 1; j < len(out); j++ {
+			if out[j] == '\\' && q != '`' && j+1 < len(out) && out[j+1] != '\n' {
+				out[j], out[j+1] = ' ', ' '
+				j++
+				continue
+			}
+			if out[j] == q {
+				i = j
+				break
+			}
+			if out[j] == '\n' && q != '`' {
+				i = j
+				break
+			}
+			out[j] = ' '
+		}
+	}
+	return string(out)
 }
 
 func lineAround(s string, pos int) string {

--- a/internal/console/assets_state_modal_test.go
+++ b/internal/console/assets_state_modal_test.go
@@ -1,0 +1,156 @@
+package console
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Time-travel's "Show state" / "Show history" results render in a dialog
+// (#1405), not in the strip between the filter form and the reversal panel.
+//
+// The e2e proves this against a real browser, and that is the primary guard.
+// These are the parts of the claim a browserless run can still hold, and they
+// are the parts most likely to be undone by accident: the inline containers
+// still EXIST for form validation, so re-pointing a result back at them is a
+// one-word edit that nothing else notices.
+//
+// The division of labour was measured, not assumed. Renaming only the
+// DECLARATION of the dialog's warnings container — leaving its two references
+// dangling — keeps every check here green: JS has no compile-time reference
+// check, `node --check` is syntax only, and reading text cannot see it. That
+// mutation run against the browser suite fails, but at a waitForSelector
+// timeout that aborts the remaining ~110 scenarios (144/145 instead of
+// 255/255), so neither half of the pair is redundant and neither is enough.
+
+// jsFunctionBody returns the brace-balanced body of a top-level function, with
+// whole-line comments blanked. Every needle below is also a word in the prose
+// above the code it describes, so a whole-file scan would pass over a gutted
+// function; scoping to the body is what makes the checks mean anything.
+func jsFunctionBody(t *testing.T, js, name string) string {
+	t.Helper()
+	i := strings.Index(js, "function "+name+"(")
+	if i < 0 {
+		t.Fatalf("app.js: no function %s( — it was renamed or removed. Everything below "+
+			"asserts about its body, so a guard that cannot find it checks nothing.", name)
+	}
+	open := strings.IndexByte(js[i:], '{')
+	if open < 0 {
+		t.Fatalf("app.js:%d: %s has no body", lineOf(js, i), name)
+	}
+	depth, end := 0, -1
+	for k := i + open; k < len(js) && end < 0; k++ {
+		switch js[k] {
+		case '{':
+			depth++
+		case '}':
+			if depth--; depth == 0 {
+				end = k
+			}
+		}
+	}
+	if end < 0 {
+		t.Fatalf("app.js:%d: unbalanced braces in %s", lineOf(js, i), name)
+	}
+	body := stripJSCommentLines(js[i+open : end+1])
+	var out []string
+	for _, ln := range strings.Split(body, "\n") {
+		if c := strings.Index(ln, "//"); c >= 0 {
+			ln = ln[:c]
+		}
+		out = append(out, ln)
+	}
+	return strings.Join(out, "\n")
+}
+
+// The validation refusal is deliberately NOT in the dialog: "schema, table and
+// pk are all required" is a complaint about the form, and it belongs beside
+// the form. Everything after that early return is a RESULT — including a 422
+// gap refusal, which answers the request rather than correcting the fields.
+const stateValidationReturn = `required — fill them in above.`
+
+func runStateAfterValidation(t *testing.T) string {
+	t.Helper()
+	body := jsFunctionBody(t, readAsset(t, "app.js"), "runState")
+	i := strings.Index(body, stateValidationReturn)
+	if i < 0 {
+		t.Fatalf("runState: the inline validation refusal (%q) is gone. This guard splits the "+
+			"function there to separate 'the form is wrong' from 'here is your answer'; "+
+			"without the split it would forbid the one inline render that is correct.",
+			stateValidationReturn)
+	}
+	return body[i:]
+}
+
+func TestStateResultsRenderInDialog(t *testing.T) {
+	region := runStateAfterValidation(t)
+
+	if !strings.Contains(region, "openModal(") {
+		t.Error("runState: no openModal( after the validation return — the reconstructed state " +
+			"is not going into a dialog. #1405: the output is unbounded and is read on the way " +
+			"to the reversal script, so rendering it inline pushes that script off screen.")
+	}
+
+	// #state-out / #state-warnings survive for the validation refusal above.
+	// Past that point the only thing runState may do with them is empty them:
+	// any other use means a result is being painted back into the strip the
+	// dialog exists to keep clear. This is the single-word regression.
+	inline := regexp.MustCompile(`\b(out|warns)\b`)
+	for _, m := range inline.FindAllStringIndex(region, -1) {
+		// clear(out) / clear(warns) are the permitted mentions.
+		pre := region[:m[0]]
+		if strings.HasSuffix(pre, "clear(") {
+			continue
+		}
+		line := strings.TrimSpace(lineAround(region, m[0]))
+		t.Errorf("runState: %q is used after the validation return, in %q. The inline "+
+			"containers are for the form-validation refusal only; a result rendered there "+
+			"lands back under the filter form (#1405).", region[m[0]:m[1]], line)
+	}
+}
+
+func TestStateDialogKeepsRestoreReachable(t *testing.T) {
+	region := runStateAfterValidation(t)
+
+	// Two halves of one claim, and neither is worth anything alone. Appending
+	// the action outside the scrolling body only helps if the BODY is what
+	// scrolls; capping the body only helps if the action is not inside it.
+	// A wide row's state table and a busy row's timeline both exceed the
+	// viewport, and "Restore to this state" is why the dialog was opened.
+	if !strings.Contains(region, ".panel.append(") {
+		t.Error("runState: the restore action is not appended to the dialog PANEL. Inside " +
+			".modal-body it scrolls away with the state table it belongs to (#1405).")
+	}
+
+	css := readAsset(t, "style.css")
+	rule := cssRule(t, css, ".state-modal .modal-body")
+	for _, want := range []string{"max-height", "overflow-y: auto"} {
+		if !strings.Contains(rule, want) {
+			t.Errorf(".state-modal .modal-body is missing %q (rule: %q). Without it the panel "+
+				"grows past the viewport instead of scrolling, and the action row pinned "+
+				"outside it goes off screen with everything else.", want, rule)
+		}
+	}
+}
+
+// cssRule returns the declaration block of the first rule whose selector list
+// matches exactly, so a longer selector that merely contains it cannot satisfy
+// the lookup.
+func cssRule(t *testing.T, css, selector string) string {
+	t.Helper()
+	re := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(selector) + `\s*\{([^}]*)\}`)
+	m := re.FindStringSubmatch(css)
+	if m == nil {
+		t.Fatalf("style.css: no rule for %q", selector)
+	}
+	return m[1]
+}
+
+func lineAround(s string, pos int) string {
+	start := strings.LastIndexByte(s[:pos], '\n') + 1
+	end := strings.IndexByte(s[pos:], '\n')
+	if end < 0 {
+		return s[start:]
+	}
+	return s[start : pos+end]
+}

--- a/internal/console/assets_state_modal_test.go
+++ b/internal/console/assets_state_modal_test.go
@@ -29,6 +29,18 @@ import (
 // function; scoping to the body is what makes the checks mean anything.
 func jsFunctionBody(t *testing.T, js, name string) string {
 	t.Helper()
+	// Whole-line comments go BEFORE the brace walk, not after. The walk counts
+	// braces in raw source, so a `{` inside a comment in the body unbalances it
+	// and the extracted region ends in the wrong place — and this change added
+	// two dozen lines of comment to the very function being walked. Stripping
+	// first costs nothing and removes the hazard for the shape that actually
+	// grows here.
+	//
+	// Residual, stated rather than papered over: a TRAILING comment carrying an
+	// unbalanced brace still confuses the count. Handling that needs a real
+	// tokenizer, and the failure is loud (a Fatalf about unbalanced braces or a
+	// missing needle), not silent.
+	js = stripJSCommentLines(js)
 	i := strings.Index(js, "function "+name+"(")
 	if i < 0 {
 		t.Fatalf("app.js: no function %s( — it was renamed or removed. Everything below "+
@@ -52,7 +64,7 @@ func jsFunctionBody(t *testing.T, js, name string) string {
 	if end < 0 {
 		t.Fatalf("app.js:%d: unbalanced braces in %s", lineOf(js, i), name)
 	}
-	body := stripJSCommentLines(js[i+open : end+1])
+	body := js[i+open : end+1]
 	var out []string
 	for _, ln := range strings.Split(body, "\n") {
 		if c := strings.Index(ln, "//"); c >= 0 {
@@ -95,30 +107,67 @@ func TestStateResultsRenderInDialog(t *testing.T) {
 	// Past that point the only thing runState may do with them is empty them:
 	// any other use means a result is being painted back into the strip the
 	// dialog exists to keep clear. This is the single-word regression.
+	//
+	// Two separate scans, because the identifiers and the ids fail differently.
+	//
+	// The identifier scan runs over CODE ONLY. Run over the raw region it
+	// reports ordinary English: this dialog's own descriptions are in here, and
+	// so is a catch branch where "timed out" is a live thing to write. Review
+	// demonstrated it with one plausible added sentence — "Older changes have
+	// aged out of the index" — which produced a confident, wholly fabricated
+	// alarm about inline rendering. A guard that cries wolf over prose gets
+	// weakened by the next person to hit it, so the literals are blanked (not
+	// removed: blanking preserves every offset, so the reported line is still
+	// the real one).
+	code := regexp.MustCompile(`"[^"\n]*"`).ReplaceAllStringFunc(region, func(s string) string {
+		return `"` + strings.Repeat(" ", len(s)-2) + `"`
+	})
 	inline := regexp.MustCompile(`\b(out|warns)\b`)
-	for _, m := range inline.FindAllStringIndex(region, -1) {
+	for _, m := range inline.FindAllStringIndex(code, -1) {
 		// clear(out) / clear(warns) are the permitted mentions.
-		pre := region[:m[0]]
-		if strings.HasSuffix(pre, "clear(") {
+		if strings.HasSuffix(code[:m[0]], "clear(") {
 			continue
 		}
 		line := strings.TrimSpace(lineAround(region, m[0]))
 		t.Errorf("runState: %q is used after the validation return, in %q. The inline "+
 			"containers are for the form-validation refusal only; a result rendered there "+
-			"lands back under the filter form (#1405).", region[m[0]:m[1]], line)
+			"lands back under the filter form (#1405).", code[m[0]:m[1]], line)
+	}
+
+	// …and the ids scan the literals the first one just blanked. Blanking alone
+	// would open the shape it closed: re-looking-up the container by id
+	// (`renderStateAt(document.getElementById("state-out"), data)`) puts the
+	// name only inside a string, where the identifier scan can no longer see
+	// it. Narrowing a guard is how false negatives get in.
+	for _, id := range []string{"state-out", "state-warnings"} {
+		if strings.Contains(region, `"`+id+`"`) {
+			t.Errorf("runState: %q is looked up again after the validation return. Those "+
+				"containers hold the form-validation refusal only; a result sent back to one "+
+				"lands under the filter form (#1405).", id)
+		}
 	}
 }
 
 func TestStateDialogKeepsRestoreReachable(t *testing.T) {
 	region := runStateAfterValidation(t)
 
-	// Two halves of one claim, and neither is worth anything alone. Appending
-	// the action outside the scrolling body only helps if the BODY is what
-	// scrolls; capping the body only helps if the action is not inside it.
-	// A wide row's state table and a busy row's timeline both exceed the
-	// viewport, and "Restore to this state" is why the dialog was opened.
-	if !strings.Contains(region, ".panel.append(") {
-		t.Error("runState: the restore action is not appended to the dialog PANEL. Inside " +
+	// Two halves of one claim about SHOW STATE, and neither is worth anything
+	// alone. Appending the action outside the scrolling body only helps if the
+	// BODY is what scrolls; capping the body only helps if the action is not
+	// inside it. A wide row's state table exceeds the viewport, and
+	// "Restore to this state" is why the dialog was opened.
+	//
+	// Scoped to the branch, not the function. The claim does NOT hold for Show
+	// history and must not be written as if it did: there every node carries
+	// its own restore button, which belongs beside the node it names and
+	// scrolls with it. Asserting over the whole region would state a property
+	// of one mode as a property of both — and the CSS comment beside this rule
+	// said exactly that until review caught it.
+	if i := strings.Index(region, "renderStateAt("); i < 0 {
+		t.Error("runState no longer calls renderStateAt — this check is scoped to the Show state " +
+			"branch and can no longer find it.")
+	} else if !strings.Contains(region[i:], ".panel.append(") {
+		t.Error("runState: the Show state action is not appended to the dialog PANEL. Inside " +
 			".modal-body it scrolls away with the state table it belongs to (#1405).")
 	}
 

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1185,13 +1185,13 @@ try {
     if (TT_AT && at) at.value = TT_AT;
     await runState(f, false);
   }, { FIX, TT_AT });
-  await page.waitForSelector("#state-out .statetable", { timeout: 10000 });
+  await page.waitForSelector("#modal .state-modal .statetable", { timeout: 10000 });
   const tt1 = await page.evaluate(() => {
     const cells = {};
-    document.querySelectorAll("#state-out .statetable tr").forEach((tr) => {
+    document.querySelectorAll("#modal .state-modal .statetable tr").forEach((tr) => {
       cells[tr.querySelector("th").textContent] = tr.querySelector("td").textContent;
     });
-    return { cells, meta: (document.querySelector("#state-out .meta-line") || {}).textContent || "" };
+    return { cells, meta: (document.querySelector("#modal .state-modal .meta-line") || {}).textContent || "" };
   });
   (tt1.cells.status === "shipped" && tt1.cells.email === "a@example.com")
     ? ok("restore: reconstructed row folds the event over the baseline")
@@ -1201,10 +1201,10 @@ try {
   // pk=4: exists ONLY in the baseline (no events) — a binlog-only reconstruct
   // cannot resolve it, so this pins the baseline half of baseline+deltas.
   await page.evaluate(async () => { const f = document.getElementById("recover-form"); f.elements.pk.value = "4"; await runState(f, false); });
-  await page.waitForFunction(() => /d@example\.com/.test((document.getElementById("state-out") || {}).textContent || ""), { timeout: 10000 });
+  await page.waitForFunction(() => /d@example\.com/.test((document.querySelector("#modal .state-modal") || {}).textContent || ""), { timeout: 10000 });
   const tt4 = await page.evaluate(() => {
     const cells = {};
-    document.querySelectorAll("#state-out .statetable tr").forEach((tr) => {
+    document.querySelectorAll("#modal .state-modal .statetable tr").forEach((tr) => {
       cells[tr.querySelector("th").textContent] = tr.querySelector("td").textContent;
     });
     return cells;
@@ -1216,8 +1216,8 @@ try {
   // pk=2: in the baseline, then DELETEd — must render the deleted note, not an
   // empty table and not the stale baseline value.
   await page.evaluate(async () => { const f = document.getElementById("recover-form"); f.elements.pk.value = "2"; await runState(f, false); });
-  await page.waitForFunction(() => !!document.querySelector("#state-out .deleted-note"), { timeout: 10000 });
-  const tt2 = await page.evaluate(() => (document.querySelector("#state-out .deleted-note") || {}).textContent || "");
+  await page.waitForFunction(() => !!document.querySelector("#modal .state-modal .deleted-note"), { timeout: 10000 });
+  const tt2 = await page.evaluate(() => (document.querySelector("#modal .state-modal .deleted-note") || {}).textContent || "");
   /Row was deleted/.test(tt2)
     ? ok("restore: a deleted row renders the deleted note")
     : bad("restore: a deleted row renders the deleted note", tt2);
@@ -1233,9 +1233,14 @@ try {
     await runState(f, false);
     const btn = document.querySelector(".state-actions .btn-primary");
     if (!btn) return { err: "no Restore-to-this-state button on a found row" };
-    const at = (document.querySelector("#state-out .meta-line") || {}).textContent || "";
+    const at = (document.querySelector("#modal .state-modal .meta-line") || {}).textContent || "";
+    // Also the #1405 claim: the button hands the page back before retargeting
+    // the form, because aimUndoAtInstant scrolls that form into view and
+    // previews rows — both invisible behind a scrim.
+    const inline = !!document.querySelector("#state-out .statetable");
     btn.click();
-    return { since: f.elements.since.value, until: f.elements.until.value, at };
+    return { since: f.elements.since.value, until: f.elements.until.value, at, inline,
+             stillOpen: !!document.querySelector("#modal .state-modal") };
   });
   {
     const m = /as of (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/.exec(bridge.at || "");
@@ -1243,6 +1248,14 @@ try {
     (want && bridge.since === want && bridge.until === "")
       ? ok("restore: 'Restore to this state' sets the undo window to at+1s")
       : bad("restore: 'Restore to this state' sets the undo window to at+1s", JSON.stringify({ ...bridge, want }));
+    // #1405. Retargeting the selectors above would pass just as well if the
+    // result rendered in BOTH places, so state the negative separately.
+    (bridge.inline === false)
+      ? ok("restore: the reconstructed state renders in the dialog, not inline under the form")
+      : bad("restore: the reconstructed state renders in the dialog, not inline under the form", JSON.stringify(bridge));
+    (bridge.stillOpen === false)
+      ? ok("restore: 'Restore to this state' closes the dialog before retargeting the form")
+      : bad("restore: 'Restore to this state' closes the dialog before retargeting the form", JSON.stringify(bridge));
   }
 
   // The timeline is how an operator picks an instant without leaving to read
@@ -1354,6 +1367,13 @@ try {
   (npTl.total >= 2 && npTl.arrived === npTl.total && npTl.firstSeen[1] > npTl.firstSeen[0])
     ? ok("reduced motion: under no-preference the timeline arrives one node at a time")
     : bad("reduced motion: under no-preference the timeline arrives one node at a time", JSON.stringify(npTl));
+
+  // Time-travel results now live in a dialog (#1405), and the scenarios above
+  // leave the last one open. Dismiss it before moving on: a scrim spanning the
+  // viewport is invisible to page.evaluate but intercepts every real click,
+  // and leaving shared state behind for later scenarios is the failure this
+  // suite has already been bitten by once.
+  await page.evaluate(() => { const m = document.getElementById("modal"); if (m) m.replaceChildren(); });
 
   // Scenario 14c — the Overview against the LIVE daemon (#1300). The fixture
   // scenario below drives buildOverview directly, so it cannot catch a route

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1365,8 +1365,19 @@ try {
     use.click();
     const at = (document.querySelector('[name="state_at"]') || {}).value || "";
     if (!restore) return { time, at, skippedRestore: true };
+    // Stubbed for the click, for the same reason the state panel's bridge is:
+    // aimUndoAtInstant calls previewRecover synchronously, previewRecover opens
+    // the busy dialog, and openBusyModal clears the shared #modal mount — so
+    // the timeline dialog vanishes whether or not renderTimeline passed the
+    // caller's close down to this button. Without the stub the assertion below
+    // is satisfied by that side effect and proves nothing, which is exactly how
+    // the state panel's version got shipped vacuous.
+    const realPreview = previewRecover;
+    previewRecover = () => {};
     restore.click();
-    return { time, at, since: f.elements.since.value, until: f.elements.until.value };
+    const stillOpen = !!document.querySelector("#modal .state-modal");
+    previewRecover = realPreview;
+    return { time, at, since: f.elements.since.value, until: f.elements.until.value, stillOpen };
   });
   if (tl.err) {
     bad("restore: timeline offers per-node actions", tl.err);
@@ -1381,6 +1392,13 @@ try {
       (tl.since === want && tl.until === "")
         ? ok("restore: timeline 'Restore to this state' aims AFTER the instant, not before it")
         : bad("restore: timeline 'Restore to this state' aims AFTER the instant, not before it", JSON.stringify({ ...tl, want }));
+      // The history half of the dismissal. Show state's action is a footer on
+      // the panel and closes; each timeline node carries its OWN button, and
+      // those were left retargeting the form under a scrim that stayed up on
+      // either of previewRecover's two early returns.
+      (tl.stillOpen === false)
+        ? ok("restore: a timeline node's 'Restore to this state' closes the dialog too")
+        : bad("restore: a timeline node's 'Restore to this state' closes the dialog too", JSON.stringify(tl));
     }
   }
 

--- a/test/console-e2e/console_e2e.mjs
+++ b/test/console-e2e/console_e2e.mjs
@@ -1238,9 +1238,19 @@ try {
     // the form, because aimUndoAtInstant scrolls that form into view and
     // previews rows — both invisible behind a scrim.
     const inline = !!document.querySelector("#state-out .statetable");
+    // previewRecover is stubbed for the duration of the click, and that is the
+    // whole assertion rather than a convenience. aimUndoAtInstant calls it
+    // synchronously, previewRecover opens the busy dialog, and openBusyModal
+    // clears the shared #modal mount — so the state dialog disappears whether
+    // or not restoreToStateAction ever calls onDone. Review showed the check
+    // below passing on that side effect alone. With the side effect removed,
+    // only the real dismissal can empty the mount.
+    const realPreview = previewRecover;
+    previewRecover = () => {};
     btn.click();
-    return { since: f.elements.since.value, until: f.elements.until.value, at, inline,
-             stillOpen: !!document.querySelector("#modal .state-modal") };
+    const stillOpen = !!document.querySelector("#modal .state-modal");
+    previewRecover = realPreview;
+    return { since: f.elements.since.value, until: f.elements.until.value, at, inline, stillOpen };
   });
   {
     const m = /as of (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/.exec(bridge.at || "");
@@ -1257,6 +1267,82 @@ try {
       ? ok("restore: 'Restore to this state' closes the dialog before retargeting the form")
       : bad("restore: 'Restore to this state' closes the dialog before retargeting the form", JSON.stringify(bridge));
   }
+
+  // #1405's hard constraint, and the one the change is most likely to lose:
+  // the warnings travel INSIDE the dialog. They used to fill a sibling of
+  // #state-out that would now sit behind the scrim, and a reconstruct can
+  // return stale_baseline or a capture-gap caveat — a state read with its
+  // caveat hidden is worse than the old layout, not better.
+  //
+  // Driven by stubbing `api` rather than by finding a fixture that warns: the
+  // claim is about WHERE renderWarnings puts its output, and a canned response
+  // exercises the real runState → openModal → renderWarnings path while making
+  // the warning unconditional. Review showed deleting the whole warnings block
+  // left both suites green, so nothing was holding this.
+  const warnPlacement = await page.evaluate(async () => {
+    const real = api;
+    api = async (path, opts) => {
+      if (path.startsWith("/api/reconstruct")) {
+        return { schema: "e2eshop", table: "orders", pk: "1", at: "2026-01-01 00:00:00",
+                 found: true, state: { id: 1, status: "shipped" },
+                 warnings: ["stale_baseline: newest snapshot has no orders, fell back to an older one"] };
+      }
+      return real(path, opts);
+    };
+    try {
+      const f = document.getElementById("recover-form");
+      f.elements.pk.value = "1";
+      await runState(f, false);
+    } finally {
+      api = real;
+    }
+    return {
+      inDialog: !!document.querySelector("#modal .state-modal .warn-item"),
+      onPage: !!document.querySelector("#state-warnings .warn-item"),
+      text: (document.querySelector("#modal .state-modal .warn-item") || {}).textContent || "",
+    };
+  });
+  (warnPlacement.inDialog && !warnPlacement.onPage && /stale_baseline/.test(warnPlacement.text))
+    ? ok("restore: a reconstruct warning renders inside the dialog, not on the page behind it")
+    : bad("restore: a reconstruct warning renders inside the dialog, not on the page behind it",
+          JSON.stringify(warnPlacement));
+
+  // The dialog's own dismissal controls. openModal wires the ✕ and the scrim
+  // click and relies on globalKeydown for Escape; none of the three had a line
+  // of executed coverage, and the one assertion that named dismissal was
+  // satisfied by a side effect (see the stub above).
+  const dismiss = await page.evaluate(async () => {
+    const f = document.getElementById("recover-form");
+    const out = {};
+    await runState(f, false);
+    out.openedForX = !!document.querySelector("#modal .state-modal");
+    const x = document.querySelector("#modal .state-modal .modal-x");
+    if (x) x.click();
+    out.afterX = !!document.getElementById("modal").firstChild;
+
+    await runState(f, false);
+    const scrim = document.querySelector("#modal .modal-scrim");
+    // On the scrim itself, not on the panel: openModal only dismisses when the
+    // event target IS the scrim, so a click inside the dialog must not close it.
+    if (scrim) scrim.querySelector(".modal").dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    out.afterInsideClick = !!document.getElementById("modal").firstChild;
+    if (scrim) scrim.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    out.afterScrimClick = !!document.getElementById("modal").firstChild;
+
+    await runState(f, false);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    out.afterEscape = !!document.getElementById("modal").firstChild;
+    return out;
+  });
+  (dismiss.openedForX && dismiss.afterX === false)
+    ? ok("restore: the dialog's ✕ closes it")
+    : bad("restore: the dialog's ✕ closes it", JSON.stringify(dismiss));
+  (dismiss.afterInsideClick === true && dismiss.afterScrimClick === false)
+    ? ok("restore: clicking the scrim closes the dialog, clicking inside it does not")
+    : bad("restore: clicking the scrim closes the dialog, clicking inside it does not", JSON.stringify(dismiss));
+  (dismiss.afterEscape === false)
+    ? ok("restore: Escape closes the dialog")
+    : bad("restore: Escape closes the dialog", JSON.stringify(dismiss));
 
   // The timeline is how an operator picks an instant without leaving to read
   // one off Events. Its own restore button used to route through undoEvent,
@@ -1333,7 +1419,9 @@ try {
       // that margin was the whole assertion. It also gets STRONGER as the
       // fixture grows rather than weaker.
       const firstSeen = [];
+      const gapAround = [];
       let arrived = 0, total = 0;
+      let prev = performance.now();
       for (let tick = 0; tick < 90; tick++) {
         const nodes = document.querySelectorAll(".tl-node");
         total = nodes.length;
@@ -1343,14 +1431,36 @@ try {
           arrived++;
           if (firstSeen[i] === undefined) firstSeen[i] = tick;
         });
+        // How long this observation was blind for. The ordering claim is only
+        // readable if consecutive polls are closer together than the stagger
+        // step; a stall longer than that hides the order from the OBSERVER
+        // without saying anything about the code.
+        const nowT = performance.now();
+        gapAround.push(Math.round(nowT - prev));
+        prev = nowT;
         if (total > 0 && arrived === total) break;
         await new Promise((r) => setTimeout(r, 10));
       }
-      return { total, arrived, firstSeen };
+      return { total, arrived, firstSeen, maxGap: Math.max(0, ...gapAround) };
     });
   };
   const rmTl = await staggerProbe("reduce");
-  const npTl = await staggerProbe("no-preference");
+  // The no-preference arm reads an ORDER out of a 55ms step by polling every
+  // 10ms, so a loaded runner can hide it: if the loop stalls longer than one
+  // step, both nodes are first seen on the same poll and the arm reports a
+  // missing stagger that is really a blind observer. Seen twice on a machine
+  // running builds alongside the suite, with the trace showing exactly that —
+  // and it took a bisect against main to find out it was the runner and not
+  // the code, which is a false alarm expensive enough to be worth preventing.
+  //
+  // Retried rather than loosened: a real regression fails every attempt, so
+  // the assertion keeps its teeth. maxGap travels into the failure message so
+  // the next person can classify it in one look instead of a bisect.
+  let npTl = await staggerProbe("no-preference");
+  const staggerRead = (r) => r.total >= 2 && r.arrived === r.total && r.firstSeen[1] > r.firstSeen[0];
+  for (let attempt = 0; attempt < 2 && !staggerRead(npTl); attempt++) {
+    npTl = await staggerProbe("no-preference");
+  }
   await page.emulateMedia({ reducedMotion: null });
 
   (rmTl.total > 0 && rmTl.arrived === rmTl.total
@@ -1364,9 +1474,11 @@ try {
   // there is no fixture size at which this quietly stops asserting — and a
   // fixture that drops below two is reported as a failure rather than waved
   // through, because at that point the scenario has proved nothing.
-  (npTl.total >= 2 && npTl.arrived === npTl.total && npTl.firstSeen[1] > npTl.firstSeen[0])
+  staggerRead(npTl)
     ? ok("reduced motion: under no-preference the timeline arrives one node at a time")
-    : bad("reduced motion: under no-preference the timeline arrives one node at a time", JSON.stringify(npTl));
+    : bad("reduced motion: under no-preference the timeline arrives one node at a time — "
+        + (npTl.maxGap > 55 ? `NOTE: the poll stalled ${npTl.maxGap}ms, longer than the 55ms stagger step, on all 3 attempts` : "the poll kept up, so this is the code"),
+        JSON.stringify(npTl));
 
   // Time-travel results now live in a dialog (#1405), and the scenarios above
   // leave the last one open. Dismiss it before moving on: a scrim spanning the


### PR DESCRIPTION
console: show a row's state and history in a dialog (#1405)

Show state / Show history rendered into #state-out, a strip between the
filter form and the reversal panel. The output is unbounded — a churny
row's history is a long table — and it is consulted on the way to the
script rather than being the script, so checking one pushed the artifact
the page exists to produce down and off screen.

Both are one code path (runState), so both move together.

Three things the move had to not break, and did not:

- The warnings travel INSIDE the dialog. They used to fill a sibling
  container that would now sit behind the scrim, and a reconstruct can
  return stale_baseline or a capture-gap caveat. A state read with its
  caveat hidden behind the dialog is worse than the old layout.
- Restore to this state closes the dialog before retargeting the form.
  It calls aimUndoAtInstant, which scrolls that form into view and
  previews the rows — both invisible behind a scrim.
- That action is appended to the PANEL, not the body. The body scrolls
  (a wide row's state table exceeds the viewport), and an action after
  the table inside a scrolling body is unreachable exactly when the
  table is long.

The inline containers stay, for the one thing that still belongs beside
the form: "schema, table and pk are all required". That is a complaint
about the form. A 422 gap refusal is not — it answers the request — so
it renders in the dialog with the rest of the results.

On the prerequisite the issue asked to decide: openModal is extracted,
and it has ONE caller. The other six dialogs are NOT migrated, and the
reason is structural rather than caution — they append body, footer and
extras as SIBLINGS of the panel, while the helper nests a body inside
it. Adopting it would move their content a level deeper and put their
.modal-foot and body rules on different ancestors: a DOM change to
working recovery-adjacent UI, for tidiness, with no browser coverage of
most of them to catch a layout break. That was found by reading them,
not assumed.

Guards. The browser suite is the real one: eight Time-travel scenarios
now run against the dialog, plus two new ones stating the negative —
the result is NOT also inline, and the dialog is gone after the restore
click. Retargeting selectors alone would have passed with the output
rendered in both places.

The Go guard holds the half a browserless run can: after the validation
return, runState may only CLEAR the inline containers, and the scroll
cap and the out-of-body action row are asserted together because
neither is worth anything alone. Seven mutations, including reverting
each render to its inline original, turn it red; three controls stay
green.

Its limit is measured rather than claimed: renaming only the
declaration of the dialog's warnings container, orphaning its two
references, keeps every Go check green — JS has no compile-time
reference check and text cannot see one. That mutation fails the
browser suite, but at a waitForSelector timeout that aborts the
remaining scenarios (144/145, not 255/255). Neither half is redundant;
neither is enough.

Closes #1405
